### PR TITLE
Implement initial frontend shell

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -12,6 +12,7 @@ use crate::error::ArcaError;
 use crate::state::{AppState, Settings};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct VaultInfo {
     pub name: String,
     pub path: String,
@@ -20,6 +21,7 @@ pub struct VaultInfo {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct EntryDto {
     pub id: String,
     pub title: String,

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -70,6 +70,7 @@ impl SessionState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct Settings {
     pub auto_lock_timeout_minutes: Option<u64>,
     pub clipboard_clear_seconds: Option<u64>,

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1,13 +1,37 @@
 <script lang="ts">
+  import UnlockScreen from './lib/components/UnlockScreen.svelte';
+  import VaultShell from './lib/components/VaultShell.svelte';
   import { vaultState } from './lib/stores/vault.svelte';
+  import { uiState } from './lib/stores/ui.svelte';
+
+  function setTheme(theme: 'terminal' | 'amber') {
+    uiState.theme = theme;
+  }
 </script>
 
-<main class="shell">
-  <section class="panel" aria-label="Arca desktop shell">
-    <div class="brand">ARCA</div>
-    <div class="status">
-      <span>{vaultState.locked ? 'LOCKED' : 'UNLOCKED'}</span>
-      <span>{vaultState.entries.length} entries</span>
-    </div>
-  </section>
+<main class="app-shell" data-theme={uiState.theme}>
+  <div class="theme-switch" aria-label="Theme selector">
+    <button
+      type="button"
+      class:active={uiState.theme === 'terminal'}
+      aria-pressed={uiState.theme === 'terminal'}
+      onclick={() => setTheme('terminal')}
+    >
+      TERMINAL
+    </button>
+    <button
+      type="button"
+      class:active={uiState.theme === 'amber'}
+      aria-pressed={uiState.theme === 'amber'}
+      onclick={() => setTheme('amber')}
+    >
+      AMBER
+    </button>
+  </div>
+
+  {#if vaultState.locked}
+    <UnlockScreen />
+  {:else}
+    <VaultShell />
+  {/if}
 </main>

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -23,32 +23,267 @@ body {
   min-height: 600px;
 }
 
-.shell {
+button,
+input {
+  font: inherit;
+}
+
+button {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+button:focus-visible,
+input:focus-visible {
+  outline: 1px solid var(--border-focus);
+  outline-offset: 2px;
+}
+
+.app-shell {
+  --bg-base: #0a0a0a;
+  --bg-surface: #111111;
+  --bg-hover: #1e1e1e;
+  --text-primary: #e8e8e8;
+  --text-secondary: #888888;
+  --text-disabled: #444444;
+  --accent: #00ff41;
+  --accent-dim: #00cc33;
+  --accent-bg: #00ff4115;
+  --danger: #ff4444;
+  --border: #2a2a2a;
+  --border-focus: #00ff41;
   display: grid;
   min-height: 100%;
   place-items: center;
-  background: #0a0a0a;
+  padding: 32px;
+  background: var(--bg-base);
+  color: var(--text-primary);
 }
 
-.panel {
+.app-shell[data-theme="amber"] {
+  --bg-base: #0a0900;
+  --bg-surface: #111008;
+  --bg-hover: #1e1c00;
+  --text-primary: #ffe8b0;
+  --text-secondary: #997744;
+  --text-disabled: #443322;
+  --accent: #ffaa00;
+  --accent-dim: #dd8800;
+  --accent-bg: #ffaa0015;
+  --border: #2a2500;
+  --border-focus: #ffaa00;
+}
+
+.theme-switch {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(96px, 1fr));
+  height: 32px;
+  border: 1px solid var(--border);
+}
+
+.theme-switch button {
+  height: 30px;
+  padding: 0 12px;
+  border: 0;
+  border-right: 1px solid var(--border);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.theme-switch button:last-child {
+  border-right: 0;
+}
+
+.theme-switch button.active,
+.mode-tabs button.active {
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+.unlock-screen {
+  display: grid;
+  width: min(440px, 100%);
+  gap: 24px;
+}
+
+.unlock-header {
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  text-align: center;
+}
+
+.unlock-header h1 {
+  margin: 0;
+  color: var(--accent);
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.2;
+}
+
+.unlock-header p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.divider {
+  width: 160px;
+  height: 1px;
+  background: var(--border);
+}
+
+.mode-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  height: 40px;
+  border: 1px solid var(--border);
+}
+
+.mode-tabs button {
+  border: 0;
+  border-right: 1px solid var(--border);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.mode-tabs button:last-child {
+  border-right: 0;
+}
+
+.unlock-form {
   display: grid;
   gap: 16px;
-  min-width: 320px;
-  padding: 24px;
-  border: 1px solid #2a2a2a;
-  background: #111111;
 }
 
-.brand {
-  color: #00ff41;
+.unlock-form label {
+  display: grid;
+  gap: 8px;
+}
+
+.unlock-form span {
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.unlock-form input {
+  width: 100%;
+  height: 42px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+}
+
+.unlock-form input::placeholder {
+  color: var(--text-disabled);
+}
+
+.primary-action {
+  height: 40px;
+  border: 0;
+  background: var(--accent);
+  color: #000000;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.primary-action:not(:disabled):hover {
+  background: var(--accent-dim);
+}
+
+.error {
+  border-left: 3px solid var(--danger);
+  padding: 8px 12px;
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.vault-shell {
+  display: grid;
+  width: min(920px, 100%);
+  min-height: 520px;
+  grid-template-rows: auto auto 1fr;
+  border: 1px solid var(--border);
+  background: var(--bg-base);
+}
+
+.top-bar {
+  display: flex;
+  min-height: 56px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+
+.top-bar h1,
+.top-bar p {
+  margin: 0;
+}
+
+.top-bar h1 {
+  color: var(--accent);
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.top-bar p {
+  margin-top: 2px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.top-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.top-bar-actions button {
+  height: 32px;
+  padding: 0 14px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.top-bar-actions button:not(:disabled):hover {
+  background: var(--bg-hover);
+}
+
+.empty-state {
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 12px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.empty-state span {
+  color: var(--accent);
   font-size: 20px;
   font-weight: 700;
 }
 
-.status {
-  display: flex;
-  justify-content: space-between;
-  gap: 24px;
-  color: #888888;
-  font-size: 12px;
+.empty-state p {
+  margin: 0;
 }

--- a/apps/desktop/src/lib/components/UnlockScreen.svelte
+++ b/apps/desktop/src/lib/components/UnlockScreen.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  import { createVault, listEntries, unlockVault, type EntryDto } from '../ipc';
+  import { vaultState } from '../stores/vault.svelte';
+  import { uiState } from '../stores/ui.svelte';
+
+  type Mode = 'open' | 'create';
+
+  let mode: Mode = $state('open');
+  let path = $state('');
+  let password = $state('');
+  let vaultName = $state('SOVEREIGN_CONSOLE');
+  let busy = $state(false);
+  let errorMessage = $state('');
+
+  const canSubmit = $derived(
+    path.trim().length > 0 &&
+      password.length > 0 &&
+      (mode === 'open' || vaultName.trim().length > 0) &&
+      !busy,
+  );
+
+  async function submit() {
+    if (!canSubmit) {
+      return;
+    }
+
+    busy = true;
+    errorMessage = '';
+
+    try {
+      if (mode === 'open') {
+        const info = await unlockVault(path.trim(), password);
+        const entries = await listEntries();
+        applyUnlockedState(info.name, info.path, entries, info.modifiedAt);
+      } else {
+        await createVault(path.trim(), password, vaultName.trim());
+        applyUnlockedState(vaultName.trim(), path.trim(), [], new Date().toISOString());
+      }
+
+      password = '';
+      uiState.view = 'list';
+    } catch (error) {
+      errorMessage = messageFromError(error);
+    } finally {
+      busy = false;
+    }
+  }
+
+  function applyUnlockedState(name: string, vaultPath: string, entries: EntryDto[], modifiedAt: string) {
+    vaultState.locked = false;
+    vaultState.entries = entries;
+    vaultState.selectedEntry = null;
+    vaultState.searchQuery = '';
+    vaultState.vaultName = name;
+    vaultState.vaultPath = vaultPath;
+    vaultState.lastSaved = new Date(modifiedAt);
+  }
+
+  function messageFromError(error: unknown): string {
+    if (typeof error === 'object' && error !== null && 'message' in error) {
+      return String(error.message);
+    }
+
+    return 'Unable to open vault';
+  }
+</script>
+
+<section class="unlock-screen" aria-labelledby="unlock-title">
+  <div class="unlock-header">
+    <h1 id="unlock-title">ARCA</h1>
+    <div class="divider"></div>
+    <p>{mode === 'open' ? 'OPEN_VAULT' : 'CREATE_VAULT'}</p>
+  </div>
+
+  <div class="mode-tabs" role="tablist" aria-label="Vault mode">
+    <button
+      type="button"
+      role="tab"
+      aria-selected={mode === 'open'}
+      class:active={mode === 'open'}
+      onclick={() => (mode = 'open')}
+    >
+      OPEN
+    </button>
+    <button
+      type="button"
+      role="tab"
+      aria-selected={mode === 'create'}
+      class:active={mode === 'create'}
+      onclick={() => (mode = 'create')}
+    >
+      CREATE
+    </button>
+  </div>
+
+  <form
+    class="unlock-form"
+    onsubmit={(event) => {
+      event.preventDefault();
+      submit();
+    }}
+  >
+    {#if mode === 'create'}
+      <label>
+        <span>VAULT_NAME</span>
+        <input bind:value={vaultName} autocomplete="off" spellcheck="false" />
+      </label>
+    {/if}
+
+    <label>
+      <span>VAULT_PATH</span>
+      <input
+        bind:value={path}
+        autocomplete="off"
+        placeholder="/Users/you/.arca/vaults/primary.kdbx"
+        spellcheck="false"
+      />
+    </label>
+
+    <label>
+      <span>MASTER_PASSWORD</span>
+      <input bind:value={password} autocomplete="current-password" type="password" />
+    </label>
+
+    {#if errorMessage}
+      <div class="error" role="alert">{errorMessage}</div>
+    {/if}
+
+    <button class="primary-action" type="submit" disabled={!canSubmit}>
+      {busy ? 'WORKING' : mode === 'open' ? 'UNLOCK' : 'CREATE'}
+    </button>
+  </form>
+</section>

--- a/apps/desktop/src/lib/components/VaultShell.svelte
+++ b/apps/desktop/src/lib/components/VaultShell.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import { lockVault } from '../ipc';
+  import { vaultState } from '../stores/vault.svelte';
+  import { uiState } from '../stores/ui.svelte';
+
+  let busy = $state(false);
+  let errorMessage = $state('');
+
+  async function lock() {
+    busy = true;
+    errorMessage = '';
+
+    try {
+      await lockVault();
+      vaultState.locked = true;
+      vaultState.entries = [];
+      vaultState.selectedEntry = null;
+      vaultState.searchQuery = '';
+      vaultState.vaultName = '';
+      vaultState.vaultPath = '';
+      vaultState.lastSaved = null;
+      uiState.view = 'unlock';
+    } catch (error) {
+      errorMessage = messageFromError(error);
+    } finally {
+      busy = false;
+    }
+  }
+
+  function messageFromError(error: unknown): string {
+    if (typeof error === 'object' && error !== null && 'message' in error) {
+      return String(error.message);
+    }
+
+    return 'Unable to lock vault';
+  }
+</script>
+
+<section class="vault-shell" aria-labelledby="vault-title">
+  <header class="top-bar">
+    <div>
+      <h1 id="vault-title">{vaultState.vaultName || 'VAULT'}</h1>
+      <p>{vaultState.vaultPath}</p>
+    </div>
+    <div class="top-bar-actions">
+      <span>{vaultState.entries.length} entries</span>
+      <button type="button" onclick={lock} disabled={busy}>LOCK</button>
+    </div>
+  </header>
+
+  {#if errorMessage}
+    <div class="error" role="alert">{errorMessage}</div>
+  {/if}
+
+  <div class="empty-state">
+    <span>&gt;_</span>
+    <p>{vaultState.entries.length === 0 ? 'NO_ENTRIES' : 'ENTRY_LIST_READY'}</p>
+  </div>
+</section>

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -14,9 +14,9 @@ export interface EntryDto {
   id: string;
   title: string;
   username: string;
-  password?: string;
-  url?: string;
-  notes?: string;
+  password: string | null;
+  url: string | null;
+  notes: string | null;
   tags: string[];
   createdAt: string;
   updatedAt: string;

--- a/apps/desktop/src/lib/stores/vault.svelte.ts
+++ b/apps/desktop/src/lib/stores/vault.svelte.ts
@@ -6,5 +6,6 @@ export const vaultState = $state({
   selectedEntry: null as EntryDto | null,
   searchQuery: '',
   vaultName: '',
+  vaultPath: '',
   lastSaved: null as Date | null,
 });


### PR DESCRIPTION
## Summary
- Add the initial Svelte unlock/create vault screen and unlocked vault shell
- Add terminal and amber theme switching with shell-level styling
- Align frontend IPC types with Tauri serde DTO casing and nullable fields

## Validation
- `pnpm --filter @arca/desktop build`
- `cargo test --workspace`
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- Browser-verified `http://127.0.0.1:5173/` for open/create mode and amber theme switching