### PR TITLE
Add Paper identity tokens

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -3,32 +3,9 @@
   import VaultShell from './lib/components/VaultShell.svelte';
   import { vaultState } from './lib/stores/vault.svelte';
   import { uiState } from './lib/stores/ui.svelte';
-
-  function setTheme(theme: 'terminal' | 'amber') {
-    uiState.theme = theme;
-  }
 </script>
 
-<main class="app-shell" data-theme={uiState.theme}>
-  <div class="theme-switch" aria-label="Theme selector">
-    <button
-      type="button"
-      class:active={uiState.theme === 'terminal'}
-      aria-pressed={uiState.theme === 'terminal'}
-      onclick={() => setTheme('terminal')}
-    >
-      TERMINAL
-    </button>
-    <button
-      type="button"
-      class:active={uiState.theme === 'amber'}
-      aria-pressed={uiState.theme === 'amber'}
-      onclick={() => setTheme('amber')}
-    >
-      AMBER
-    </button>
-  </div>
-
+<main class="arca arca--desktop" data-theme={uiState.theme}>
   {#if vaultState.locked}
     <UnlockScreen />
   {:else}

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -1,289 +1,1242 @@
+/* ───────────────────────────────────────────────────────────
+   Arca · Paper theme — v0.2 identity system
+   Brand: Bricolage Grotesque · Funnel Sans · JetBrains Mono
+   Palette: Ink / Paper / Cream + Terra (accent·trust) + Moss (accent·vault) + Slate
+   Terminal vibe: tabs · framed panels · status bar · prompt fields
+   ─────────────────────────────────────────────────────────── */
+
+@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,300;12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Funnel+Sans:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
+
 :root {
-  font-family: "JetBrains Mono", "Geist Mono", "Fira Code", monospace;
-  color: #e8e8e8;
-  background: #0a0a0a;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
+  /* ── Type stack ─────────────────────────────────────────── */
+  --font-display: 'Bricolage Grotesque', 'Bricolage', ui-sans-serif, system-ui, sans-serif;
+  --font-body:    'Funnel Sans', ui-sans-serif, system-ui, sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, 'SF Mono', monospace;
+
+  /* ── Brand palette ──────────────────────────────────────── */
+  --ink:    #14110D;
+  --paper:  #EBE5D6;
+  --cream:  #F4EFE2;
+  --terra:  #C8553D;
+  --moss:   #4A5D3E;
+  --slate:  #8A857A;
+
+  /* Workhorses derived from the palette */
+  --paper-2: #E1DBCB;   /* darker paper for dividers & insets */
+  --paper-3: #D6CFBE;   /* hover wells */
+  --cream-2: #ECE5D2;   /* card hover */
+  --ink-2:   #2A2722;   /* secondary ink */
+  --ink-3:   #4A4640;   /* tertiary ink */
+  --slate-2: #B5B0A3;   /* light slate, on paper */
+  --slate-3: #5B564E;   /* dark slate, for body on paper */
+
+  /* Tinted fills (terminal "filled panel" pattern) */
+  --terra-soft:  rgba(200, 85, 61, 0.10);
+  --terra-mid:   rgba(200, 85, 61, 0.16);
+  --moss-soft:   rgba(74, 93, 62, 0.10);
+  --moss-mid:    rgba(74, 93, 62, 0.18);
+  --slate-soft:  rgba(138, 133, 122, 0.14);
 }
 
-* {
-  box-sizing: border-box;
+/* ───────────────────────────────────────────────────────────
+   Theme container — defaults to paper
+   ─────────────────────────────────────────────────────────── */
+.arca {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+  -webkit-font-smoothing: antialiased;
+  /* tokens — paper theme defaults */
+  --bg:           var(--paper);
+  --bg-card:      var(--cream);
+  --bg-card-2:    var(--cream-2);
+  --bg-inset:     var(--paper-2);
+  --bg-hover:     var(--paper-3);
+  --text:         var(--ink);
+  --text-2:       var(--slate-3);
+  --text-3:       var(--slate);
+  --text-4:       var(--slate-2);
+  --rule:         rgba(20, 17, 13, 0.10);
+  --rule-strong:  rgba(20, 17, 13, 0.22);
+  --rule-dashed:  rgba(20, 17, 13, 0.18);
+  --accent:       var(--terra);
+  --accent-on:    #FAF4E5;
+  --accent-soft:  var(--terra-soft);
+  --accent-mid:   var(--terra-mid);
+  --vault:        var(--moss);
+  --vault-on:     #EBE5D6;
+  --vault-soft:   var(--moss-soft);
+  --vault-mid:    var(--moss-mid);
 }
 
-html,
-body,
-#app {
-  width: 100%;
-  height: 100%;
+.arca[data-theme="ink"] {
+  --bg:           var(--ink);
+  --bg-card:      #1D1A14;
+  --bg-card-2:    #25221B;
+  --bg-inset:     #0C0A07;
+  --bg-hover:     #28241E;
+  --text:         var(--paper);
+  --text-2:       #C3BDA9;
+  --text-3:       var(--slate);
+  --text-4:       #5B564E;
+  --rule:         rgba(235, 229, 214, 0.10);
+  --rule-strong:  rgba(235, 229, 214, 0.20);
+  --rule-dashed:  rgba(235, 229, 214, 0.18);
+  --accent:       #D86A52;   /* terra, +6% L for dark surfaces */
+  --accent-on:    var(--ink);
+  --accent-soft:  rgba(216, 106, 82, 0.16);
+  --accent-mid:   rgba(216, 106, 82, 0.26);
+  --vault:        #7C9870;   /* moss, +30% L for dark surfaces */
+  --vault-on:     var(--ink);
+  --vault-soft:   rgba(124, 152, 112, 0.16);
+  --vault-mid:    rgba(124, 152, 112, 0.26);
+  background: var(--bg);
+  color: var(--text);
+}
+
+.arca *, .arca *::before, .arca *::after { box-sizing: border-box; }
+.arca button { font-family: inherit; }
+.arca a { color: inherit; }
+.mono { font-family: var(--font-mono); }
+
+/* Variants of the frame */
+.arca--desktop {
+  width: 1000px;
+  height: 700px;
+  border-radius: 10px;
+  border: 1px solid var(--rule-strong);
+  overflow: hidden;
+}
+.arca--mobile {
+  width: 360px;
+  height: 720px;
+  border-radius: 28px;
+  border: 1px solid var(--rule-strong);
+  overflow: hidden;
+}
+
+/* ───────────────────────────────────────────────────────────
+   Window chrome (desktop)
+   ─────────────────────────────────────────────────────────── */
+.chrome {
+  height: 40px; flex: 0 0 40px;
+  display: flex; align-items: center;
+  padding: 0 16px; gap: 14px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--bg-card);
+  position: relative;
+}
+.chrome__lockup {
+  display: inline-flex;
+  align-items: center;
+}
+.chrome__divider {
+  width: 1px; height: 14px;
+  background: var(--rule-strong);
+  margin: 0 4px;
+}
+.chrome__path {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-3);
+  letter-spacing: 0.02em;
+}
+.chrome__path b { color: var(--text-2); font-weight: 500; }
+.chrome__right {
+  margin-left: auto;
+  display: flex; align-items: center; gap: 12px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-3);
+  letter-spacing: 0.06em;
+}
+
+/* ───────────────────────────────────────────────────────────
+   Tab strip (terminal vibe — active underlined in Terra)
+   ─────────────────────────────────────────────────────────── */
+.tabs {
+  display: flex; align-items: stretch;
+  padding: 0 18px;
+  gap: 0;
+  border-bottom: 1px solid var(--rule);
+  background: var(--bg);
+  flex: 0 0 38px;
+  height: 38px;
+}
+.tab {
+  display: inline-flex; align-items: center;
+  padding: 0 14px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--text-3);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  position: relative;
+  text-transform: lowercase;
+  transition: color .12s;
+}
+.tab:hover { color: var(--text-2); }
+.tab--active {
+  color: var(--text);
+  background: var(--bg-card);
+  border-left: 1px solid var(--rule);
+  border-right: 1px solid var(--rule);
+}
+.tab--active::after {
+  content: ''; position: absolute;
+  left: 0; right: 0; bottom: -1px;
+  height: 2px;
+  background: var(--accent);
+}
+.tab__count {
+  font-size: 9px;
+  color: var(--text-4);
+  margin-left: 6px;
+  letter-spacing: 0.06em;
+}
+
+/* ───────────────────────────────────────────────────────────
+   Hero / brand line
+   ─────────────────────────────────────────────────────────── */
+.hero {
+  padding: 22px 26px 4px;
+  display: flex; align-items: baseline;
+  gap: 18px;
+}
+.hero__hash {
+  font-family: var(--font-mono);
+  color: var(--accent);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+.hero__title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 22px;
+  line-height: 1;
+  letter-spacing: -0.018em;
+  color: var(--text);
   margin: 0;
 }
-
-body {
-  min-width: 900px;
-  min-height: 600px;
+.hero__title em {
+  font-style: normal;
+  color: var(--accent);
 }
-
-button,
-input {
-  font: inherit;
+.hero__meta {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+  display: flex; gap: 16px;
 }
+.hero__meta b { color: var(--text-2); font-weight: 500; }
 
-button {
-  border: 1px solid var(--border);
+/* ───────────────────────────────────────────────────────────
+   Sealed (idle) — full-bleed brand screen, panel slides in
+   from the right on click / Enter. State persists per
+   instance so multiple artboards can hold different states.
+   ─────────────────────────────────────────────────────────── */
+.sealed {
+  flex: 1;
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 0fr;
+  overflow: hidden;
+  transition: grid-template-columns 380ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.sealed--open { grid-template-columns: 1.05fr 1fr; }
+
+.sealed__brand {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 48px 56px;
+  min-width: 0;
+  border-right: 1px dashed transparent;
+  transition: padding 380ms cubic-bezier(0.22, 1, 0.36, 1),
+              border-color 380ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.sealed--open .sealed__brand {
+  padding: 38px 36px;
+  border-right-color: var(--rule-dashed);
+}
+.sealed__brand-meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  display: flex; justify-content: space-between;
+}
+.sealed__brand-meta b { color: var(--text-2); font-weight: 500; }
+.sealed__brand-center {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  align-items: flex-start;
+  max-width: 540px;
+  transition: max-width 380ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.sealed--open .sealed__brand-center { max-width: 360px; }
+
+.sealed__tagline {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 28px;
+  line-height: 1.18;
+  letter-spacing: -0.022em;
+  color: var(--text);
+  transition: font-size 380ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.sealed--open .sealed__tagline { font-size: 22px; }
+.sealed__tagline em { font-style: normal; color: var(--accent); }
+
+.sealed__cta {
+  display: inline-flex; align-items: center; gap: 12px;
   background: transparent;
-  color: var(--text-secondary);
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: lowercase;
+  color: var(--accent);
+  margin-top: 6px;
+  transition: opacity 240ms ease;
+}
+.sealed__cta:hover .sealed__cta-pill { background: var(--accent); color: var(--accent-on); }
+.sealed--open .sealed__cta { opacity: 0; pointer-events: none; }
+.sealed__cta-pill {
+  display: inline-flex; align-items: center; gap: 8px;
+  height: 36px; padding: 0 16px;
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  color: var(--accent);
+  transition: background .15s, color .15s;
+}
+.sealed__cta-hint {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.10em;
+  color: var(--text-3);
+  text-transform: lowercase;
+}
+
+.sealed__panel {
+  position: relative;
+  overflow: hidden;
+}
+.sealed__panel-inner {
+  position: absolute;
+  inset: 0;
+  display: flex; flex-direction: column;
+  justify-content: center;
+  gap: 20px;
+  padding: 48px 44px;
+  background: var(--bg);
+  transform: translateX(100%);
+  opacity: 0;
+  transition: transform 380ms cubic-bezier(0.22, 1, 0.36, 1),
+              opacity 240ms ease 80ms;
+}
+.sealed--open .sealed__panel-inner {
+  transform: translateX(0);
+  opacity: 1;
+}
+.sealed__panel-back {
+  position: absolute;
+  top: 22px; left: 22px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--text-3);
+  text-transform: lowercase;
+  background: transparent;
+  border: 1px solid var(--rule-strong);
+  border-radius: 4px;
+  padding: 4px 10px;
   cursor: pointer;
 }
+.sealed__panel-back:hover { color: var(--text); border-color: var(--text-3); }
 
-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.45;
+/* ─── End sealed ─────────────────────────────────────────── */
+
+/* ───────────────────────────────────────────────────────────
+   Wordmark + lockup (matches identity book exactly)
+   ─────────────────────────────────────────────────────────── */
+.wm {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-variation-settings: "wdth" 100, "opsz" 96;
+  font-feature-settings: "ss01", "ss02";
+  letter-spacing: -0.055em;
+  line-height: 0.85;
+  color: var(--text);
+  display: inline-block;
 }
+.wm--accent { color: var(--accent); }
+.wm--paper  { color: var(--paper); }
+.wm--ink    { color: var(--ink); }
 
-button:focus-visible,
-input:focus-visible {
-  outline: 1px solid var(--border-focus);
-  outline-offset: 2px;
-}
-
-.app-shell {
-  --bg-base: #0a0a0a;
-  --bg-surface: #111111;
-  --bg-hover: #1e1e1e;
-  --text-primary: #e8e8e8;
-  --text-secondary: #888888;
-  --text-disabled: #444444;
-  --accent: #00ff41;
-  --accent-dim: #00cc33;
-  --accent-bg: #00ff4115;
-  --danger: #ff4444;
-  --border: #2a2a2a;
-  --border-focus: #00ff41;
-  display: grid;
-  min-height: 100%;
-  place-items: center;
-  padding: 32px;
-  background: var(--bg-base);
-  color: var(--text-primary);
-}
-
-.app-shell[data-theme="amber"] {
-  --bg-base: #0a0900;
-  --bg-surface: #111008;
-  --bg-hover: #1e1c00;
-  --text-primary: #ffe8b0;
-  --text-secondary: #997744;
-  --text-disabled: #443322;
-  --accent: #ffaa00;
-  --accent-dim: #dd8800;
-  --accent-bg: #ffaa0015;
-  --border: #2a2500;
-  --border-focus: #ffaa00;
-}
-
-.theme-switch {
-  position: fixed;
-  top: 16px;
-  right: 16px;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(96px, 1fr));
-  height: 32px;
-  border: 1px solid var(--border);
-}
-
-.theme-switch button {
-  height: 30px;
-  padding: 0 12px;
-  border: 0;
-  border-right: 1px solid var(--border);
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.theme-switch button:last-child {
-  border-right: 0;
-}
-
-.theme-switch button.active,
-.mode-tabs button.active {
-  background: var(--accent-bg);
-  color: var(--accent);
-}
-
-.unlock-screen {
-  display: grid;
-  width: min(440px, 100%);
-  gap: 24px;
-}
-
-.unlock-header {
-  display: grid;
-  justify-items: center;
-  gap: 10px;
-  text-align: center;
-}
-
-.unlock-header h1 {
-  margin: 0;
-  color: var(--accent);
-  font-size: 32px;
-  font-weight: 700;
-  letter-spacing: 0;
-  line-height: 1.2;
-}
-
-.unlock-header p {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 12px;
-}
-
-.divider {
-  width: 160px;
-  height: 1px;
-  background: var(--border);
-}
-
-.mode-tabs {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  height: 40px;
-  border: 1px solid var(--border);
-}
-
-.mode-tabs button {
-  border: 0;
-  border-right: 1px solid var(--border);
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.mode-tabs button:last-child {
-  border-right: 0;
-}
-
-.unlock-form {
-  display: grid;
-  gap: 16px;
-}
-
-.unlock-form label {
-  display: grid;
-  gap: 8px;
-}
-
-.unlock-form span {
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.unlock-form input {
-  width: 100%;
-  height: 42px;
-  padding: 0 12px;
-  border: 1px solid var(--border);
-  background: var(--bg-surface);
-  color: var(--text-primary);
-}
-
-.unlock-form input::placeholder {
-  color: var(--text-disabled);
-}
-
-.primary-action {
-  height: 40px;
-  border: 0;
-  background: var(--accent);
-  color: #000000;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.primary-action:not(:disabled):hover {
-  background: var(--accent-dim);
-}
-
-.error {
-  border-left: 3px solid var(--danger);
-  padding: 8px 12px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  color: var(--text-primary);
-  font-size: 12px;
-}
-
-.vault-shell {
-  display: grid;
-  width: min(920px, 100%);
-  min-height: 520px;
-  grid-template-rows: auto auto 1fr;
-  border: 1px solid var(--border);
-  background: var(--bg-base);
-}
-
-.top-bar {
-  display: flex;
-  min-height: 56px;
+/* Lockup = lettermark + wordmark, horizontally aligned on x-height */
+.lockup {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  padding: 0 16px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-surface);
+  gap: 0.30em;
+  line-height: 1;
+  color: var(--text);
 }
-
-.top-bar h1,
-.top-bar p {
-  margin: 0;
-}
-
-.top-bar h1 {
-  color: var(--accent);
-  font-size: 16px;
-  font-weight: 700;
-}
-
-.top-bar p {
-  margin-top: 2px;
-  color: var(--text-secondary);
-  font-size: 12px;
-}
-
-.top-bar-actions {
-  display: flex;
+.lockup__mark {
+  display: inline-flex;
   align-items: center;
-  gap: 16px;
-  color: var(--text-secondary);
-  font-size: 12px;
+}
+.lockup__word {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-variation-settings: "wdth" 100, "opsz" 96;
+  font-feature-settings: "ss01", "ss02";
+  letter-spacing: -0.055em;
+  line-height: 0.85;
+  display: inline-block;
 }
 
-.top-bar-actions button {
-  height: 32px;
+/* Sizes — `--lm` controls the lettermark height, the word follows the parent font-size */
+.lockup--xs { font-size: 16px; }
+.lockup--sm { font-size: 22px; }
+.lockup--md { font-size: 32px; }
+.lockup--lg { font-size: 64px; }
+.lockup--xl { font-size: 112px; gap: 0.18em; }
+
+/* Stacked wordmark — the "lip gloss" cascade (kept for marketing) */
+.wordstack {
+  position: relative;
+  font-family: var(--font-display);
+  font-weight: 800;
+  line-height: 0.92;
+  letter-spacing: -0.045em;
+  user-select: none;
+}
+.wordstack__row {
+  display: block;
+  background: var(--accent-mid);
+  color: var(--accent);
+  padding: 0 8px;
+  width: max-content;
+  border-radius: 2px;
+}
+.wordstack__row + .wordstack__row { margin-top: 2px; margin-left: 16px; }
+.wordstack__row + .wordstack__row + .wordstack__row { margin-left: 32px; }
+.wordstack__row + .wordstack__row + .wordstack__row + .wordstack__row { margin-left: 48px; }
+.wordstack__row + .wordstack__row + .wordstack__row + .wordstack__row + .wordstack__row { margin-left: 64px; }
+
+/* ───────────────────────────────────────────────────────────
+   Search bar (terminal prompt)
+   ─────────────────────────────────────────────────────────── */
+.toolbar {
+  display: flex; gap: 10px;
+  padding: 14px 26px 10px;
+  align-items: stretch;
+}
+.search {
+  flex: 1;
+  display: flex; align-items: center; gap: 12px;
+  height: 38px;
   padding: 0 14px;
-  color: var(--accent);
+  background: var(--bg-card);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  transition: border-color .12s, background .12s;
+}
+.search:hover { border-color: var(--rule-strong); }
+.search--focus {
+  border-color: var(--accent);
+  background: var(--bg-card-2);
+  color: var(--text);
+}
+.search__prompt {
+  font-weight: 600;
   font-size: 12px;
-  font-weight: 700;
+  color: var(--text-3);
+}
+.search--focus .search__prompt { color: var(--accent); }
+.search__text {
+  flex: 1;
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  display: flex; align-items: center;
+}
+.search__text--ph { color: var(--text-3); opacity: 0.85; }
+.search__caret {
+  display: inline-block;
+  width: 7px; height: 13px;
+  background: var(--accent);
+  opacity: 0.7;
+  margin-left: 3px;
+  animation: arca-blink 1.2s steps(2,end) infinite;
+}
+@keyframes arca-blink { 50% { opacity: 0.15; } }
+.search__hint {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.10em;
+  color: var(--text-3);
+  padding: 2px 7px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 3px;
+  text-transform: uppercase;
 }
 
-.top-bar-actions button:not(:disabled):hover {
-  background: var(--bg-hover);
+/* ───────────────────────────────────────────────────────────
+   Buttons — primary (Terra fill), secondary, ghost, danger
+   ─────────────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+  height: 38px;
+  padding: 0 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text);
+  transition: background .12s, border-color .12s, color .12s;
+  white-space: nowrap;
+}
+.btn--sm { height: 30px; padding: 0 12px; font-size: 10px; }
+.btn--xs { height: 24px; padding: 0 8px;  font-size: 10px; border-radius: 4px; }
+
+.btn--primary {
+  background: var(--accent);
+  color: var(--accent-on);
+  border-color: var(--accent);
+}
+.btn--primary:hover { background: #B14933; border-color: #B14933; }
+
+.btn--vault {
+  background: var(--vault);
+  color: var(--vault-on);
+  border-color: var(--vault);
+}
+.btn--vault:hover { background: #3D4F33; border-color: #3D4F33; }
+
+.btn--ghost {
+  background: var(--bg-card);
+  color: var(--text);
+  border-color: var(--rule-strong);
+}
+.btn--ghost:hover { background: var(--bg-card-2); border-color: var(--text-3); }
+
+.btn--bare {
+  background: transparent;
+  color: var(--text-2);
+  border-color: transparent;
+}
+.btn--bare:hover { background: var(--bg-card); color: var(--text); }
+
+.btn--danger { color: var(--accent); }
+.btn--danger:hover { background: var(--accent-soft); }
+
+.btn kbd {
+  font-family: inherit;
+  font-size: 9px;
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid currentColor;
+  opacity: 0.55;
+  background: transparent;
+  letter-spacing: 0.04em;
 }
 
-.empty-state {
-  display: grid;
-  place-items: center;
-  align-content: center;
-  gap: 12px;
-  color: var(--text-secondary);
-  font-size: 13px;
+/* Icon button (24/28px squares) */
+.iconbtn {
+  width: 30px; height: 30px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid var(--rule);
+  border-radius: 5px;
+  background: var(--bg-card);
+  color: var(--text-2);
+  cursor: pointer;
+  transition: border-color .12s, color .12s, background .12s;
 }
+.iconbtn:hover {
+  color: var(--text);
+  border-color: var(--rule-strong);
+  background: var(--bg-card-2);
+}
+.iconbtn--accent { color: var(--accent); border-color: var(--accent); background: var(--accent-soft); }
+.iconbtn--vault  { color: var(--vault);  border-color: var(--vault);  background: var(--vault-soft); }
+.iconbtn--ghost  { border-color: transparent; background: transparent; }
+.iconbtn--ghost:hover { background: var(--bg-card); border-color: var(--rule); }
 
-.empty-state span {
+/* ───────────────────────────────────────────────────────────
+   Bracket tags & kbd
+   ─────────────────────────────────────────────────────────── */
+.tag {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 3px;
+  white-space: nowrap;
+  border: 1px solid transparent;
+  background: var(--accent-soft);
   color: var(--accent);
-  font-size: 20px;
-  font-weight: 700;
+}
+.tag--vault  { background: var(--vault-soft); color: var(--vault); }
+.tag--slate  { background: var(--slate-soft); color: var(--text-2); }
+.tag--out    { background: transparent; border-color: var(--accent); color: var(--accent); }
+.tag--ink    { background: var(--ink); color: var(--paper); }
+.tag--paper  { background: var(--paper); color: var(--ink); }
+
+.kbd {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--bg-card);
+  border: 1px solid var(--rule-strong);
+  border-bottom-width: 2px;
+  color: var(--text);
+  min-width: 20px;
+  text-align: center;
+  display: inline-block;
 }
 
-.empty-state p {
+/* ───────────────────────────────────────────────────────────
+   Two-column layout — filters + entries
+   ─────────────────────────────────────────────────────────── */
+.body {
+  flex: 1 1 0;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 0;
+  padding: 6px 26px 14px;
+}
+.body--single { grid-template-columns: 1fr; }
+
+.sidepanel {
+  border-right: 1px dashed var(--rule-dashed);
+  padding: 8px 18px 0 0;
+  display: flex; flex-direction: column; gap: 2px;
+  overflow: auto;
+}
+.sidepanel__title {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  margin: 14px 0 8px;
+  display: flex; align-items: center; gap: 8px;
+}
+.sidepanel__title:first-child { margin-top: 0; }
+.sidepanel__title-rule { flex: 1; height: 1px; background: var(--rule); }
+
+.filter {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  padding: 6px 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-2);
+  border-radius: 4px;
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  transition: background .12s, color .12s;
+}
+.filter:hover { background: var(--bg-card); color: var(--text); }
+.filter--active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.filter--active::before { content: '▸ '; }
+.filter:not(.filter--active)::before { content: '  '; }
+.filter__count {
+  font-size: 9px;
+  color: var(--text-3);
+  letter-spacing: 0.04em;
+}
+.filter--active .filter__count { color: var(--accent); opacity: 0.7; }
+
+/* ───────────────────────────────────────────────────────────
+   Entries list
+   ─────────────────────────────────────────────────────────── */
+.entries {
+  display: flex; flex-direction: column;
+  overflow: auto;
+  padding-left: 18px;
+}
+.entries__section {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  padding: 12px 4px 8px;
+  display: flex; align-items: center; gap: 12px;
+}
+.entries__section:first-child { padding-top: 4px; }
+.entries__rule { flex: 1; height: 0; border-top: 1px dashed var(--rule-dashed); }
+.entries__count { color: var(--text-4); }
+
+.row {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 12px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  transition: background .12s, border-color .12s;
+}
+.row:hover { background: var(--bg-card); border-color: var(--rule); }
+.row--selected {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+.row__bullet {
+  width: 18px; height: 18px;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--text-3);
+}
+.row--selected .row__bullet { color: var(--accent); }
+.row__title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text);
+  white-space: nowrap;
+}
+.row__sub {
+  font-size: 10px;
+  color: var(--text-3);
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+.row__actions { display: flex; gap: 4px; }
+.row__action {
+  width: 26px; height: 26px;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--text-3);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+}
+.row:hover .row__action { color: var(--text-2); }
+.row__action:hover { color: var(--text); background: var(--bg-card-2); }
+.row__action--ok { color: var(--vault); border-color: var(--vault); background: var(--vault-soft); }
+
+/* ───────────────────────────────────────────────────────────
+   Status bar (always at the bottom)
+   ─────────────────────────────────────────────────────────── */
+.status {
+  flex: 0 0 30px;
+  height: 30px;
+  display: flex; align-items: center;
+  padding: 0 14px;
+  gap: 10px;
+  background: var(--bg-card);
+  border-top: 1px solid var(--rule);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+  text-transform: lowercase;
+}
+.status__pill {
+  display: inline-flex; align-items: center;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  background: var(--accent);
+  color: var(--accent-on);
+  font-weight: 600;
+}
+.status__pill--vault { background: var(--vault); color: var(--vault-on); }
+.status__pill--ink   { background: var(--ink);   color: var(--paper); }
+.status__pill--slate { background: var(--slate); color: var(--paper); }
+.status__pill--ghost {
+  background: transparent;
+  color: var(--text-3);
+  border: 1px solid var(--rule-strong);
+}
+.status__spacer { flex: 1; }
+.status__dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--vault);
+  display: inline-block;
+  margin-right: 6px;
+}
+.status__dot--warn { background: var(--accent); }
+
+/* ───────────────────────────────────────────────────────────
+   Unlock screen
+   ─────────────────────────────────────────────────────────── */
+.unlock {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  gap: 0;
+  overflow: hidden;
+}
+.unlock__left {
+  padding: 38px 36px;
+  display: flex; flex-direction: column;
+  justify-content: space-between;
+  border-right: 1px dashed var(--rule-dashed);
+  background: var(--bg);
+}
+.unlock__wordmark {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 112px;
+  line-height: 0.86;
+  letter-spacing: -0.06em;
+  color: var(--text);
+}
+.unlock__lede {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 21px;
+  line-height: 1.18;
+  letter-spacing: -0.018em;
+  color: var(--text);
+  max-width: 320px;
+}
+.unlock__lede em {
+  font-style: normal;
+  color: var(--accent);
+}
+.unlock__caption {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  display: flex; gap: 16px;
+}
+.unlock__caption b { color: var(--text-2); font-weight: 500; }
+
+.unlock__right {
+  padding: 38px 36px;
+  display: flex; flex-direction: column;
+  justify-content: center;
+  gap: 20px;
+}
+.unlock__field-label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  display: flex; justify-content: space-between;
+  align-items: center;
+}
+.unlock__field {
+  display: flex; align-items: center;
+  height: 48px;
+  padding: 0 16px; gap: 10px;
+  background: var(--bg-card);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+}
+.unlock__field::before {
+  content: '>';
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 14px;
+}
+.unlock__input {
+  flex: 1;
+  background: transparent;
+  border: none; outline: none;
+  font-family: var(--font-mono);
+  font-size: 16px;
+  letter-spacing: 0.30em;
+  color: var(--text);
+}
+.unlock__cta { width: 100%; height: 48px; font-size: 12px; }
+.unlock__hints {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+  display: flex; flex-wrap: wrap;
+  gap: 14px 22px;
+  margin-top: 4px;
+}
+.unlock__hints b { color: var(--text-2); font-weight: 500; }
+
+/* ───────────────────────────────────────────────────────────
+   Entry detail
+   ─────────────────────────────────────────────────────────── */
+.detail-head {
+  padding: 18px 26px 14px;
+  border-bottom: 1px dashed var(--rule-dashed);
+  display: flex; align-items: flex-start; gap: 16px;
+}
+.detail__crumbs {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--text-3);
+  margin-bottom: 10px;
+}
+.detail__crumbs b { color: var(--text); font-weight: 500; }
+.detail__title-wrap { flex: 1; min-width: 0; }
+.detail__title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 1;
+  letter-spacing: -0.022em;
+  color: var(--text);
   margin: 0;
 }
+.detail__title em { font-style: normal; color: var(--accent); }
+.detail__meta {
+  display: flex; gap: 14px; align-items: center;
+  margin-top: 10px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  color: var(--text-3);
+}
+.detail__meta b { color: var(--text-2); font-weight: 500; }
+.detail__actions { display: flex; gap: 8px; }
+
+.detail-body {
+  flex: 1; overflow: auto;
+  padding: 16px 26px;
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 14px;
+  align-content: start;
+}
+
+/* Filled "moss" panel — note/content (the lipgloss-purple equivalent) */
+.note-panel {
+  background: var(--vault);
+  color: var(--vault-on);
+  border-radius: 8px;
+  padding: 18px 20px;
+  display: flex; flex-direction: column; gap: 10px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.5;
+  grid-row: span 2;
+}
+.note-panel__head {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  opacity: 0.66;
+  display: flex; align-items: center; gap: 8px;
+}
+.note-panel__head::before {
+  content: '/* '; opacity: 0.7;
+}
+.note-panel__head::after {
+  content: ' */'; opacity: 0.7;
+}
+.note-panel__body { white-space: pre-wrap; }
+
+/* Field stack */
+.fields {
+  display: flex; flex-direction: column;
+  background: var(--bg-card);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.field {
+  display: grid;
+  grid-template-columns: 92px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px dashed var(--rule-dashed);
+}
+.field:last-child { border-bottom: none; }
+.field--focus { background: var(--accent-soft); }
+.field__k {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+.field__v {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  color: var(--text);
+  min-width: 0;
+  word-break: break-all;
+}
+.field__v--mask { letter-spacing: 0.20em; color: var(--text-2); }
+.field__v--url { color: var(--accent); text-decoration: underline; text-decoration-color: var(--accent-soft); text-underline-offset: 3px; cursor: pointer; }
+.field__v--ok  { color: var(--vault); }
+.field__actions { display: flex; gap: 6px; }
+
+/* Compact stat strip */
+.strip {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  background: var(--bg-card);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.strip__cell {
+  padding: 12px 14px;
+  border-right: 1px dashed var(--rule-dashed);
+}
+.strip__cell:last-child { border-right: none; }
+.strip__k {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  margin-bottom: 5px;
+}
+.strip__v {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+}
+.strip__v--accent { color: var(--accent); }
+
+/* Entropy bar (paper-friendly) */
+.entropy {
+  display: flex; align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+.entropy__bar { display: flex; gap: 2px; }
+.entropy__seg {
+  width: 9px; height: 6px;
+  background: var(--bg-inset);
+  border-radius: 1px;
+}
+.entropy__seg--w { background: var(--accent); opacity: 0.65; }
+.entropy__seg--m { background: var(--accent); }
+.entropy__seg--s { background: var(--vault);  }
+.entropy__bits { color: var(--text-2); }
+.entropy__cls  { color: var(--vault); font-weight: 600; }
+
+/* TOTP */
+.totp {
+  display: flex; align-items: center; gap: 12px;
+}
+.totp__digits {
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+}
+.totp__digits span { color: var(--text-4); margin: 0 3px; font-weight: 400; }
+.totp__bar {
+  flex: 1; max-width: 100px; height: 3px;
+  background: var(--bg-inset);
+  border-radius: 999px; overflow: hidden;
+}
+.totp__bar > div {
+  height: 100%; background: var(--accent);
+}
+.totp__cd {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-3);
+}
+
+/* ───────────────────────────────────────────────────────────
+   Mobile-specific
+   ─────────────────────────────────────────────────────────── */
+.arca--mobile .chrome { display: none; }
+.arca--mobile .status-bar-os {
+  height: 36px; flex: 0 0 36px;
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 8px 22px 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  background: var(--bg);
+}
+.arca--mobile .status-bar-os__right {
+  display: flex; gap: 6px; align-items: center;
+  font-size: 11px;
+}
+
+.mhead {
+  padding: 10px 20px 4px;
+  display: flex; align-items: center; gap: 10px;
+}
+.mhead__brand {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 26px;
+  letter-spacing: -0.04em;
+  color: var(--text);
+  line-height: 1;
+}
+.mhead__brand em { color: var(--accent); font-style: normal; }
+.mhead__spacer { flex: 1; }
+
+.mhero {
+  padding: 12px 20px 8px;
+}
+.mhero__line {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 19px;
+  line-height: 1.15;
+  letter-spacing: -0.018em;
+  color: var(--text);
+}
+.mhero__line em { color: var(--accent); font-style: normal; }
+.mhero__sub {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+  margin-top: 6px;
+}
+
+.arca--mobile .toolbar { padding: 12px 18px 6px; }
+.arca--mobile .search { height: 42px; }
+
+.arca--mobile .body {
+  padding: 4px 18px 8px;
+  grid-template-columns: 1fr;
+}
+.arca--mobile .entries { padding-left: 0; }
+
+.arca--mobile .row {
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  padding: 11px 12px;
+}
+.arca--mobile .row__title { font-size: 13px; }
+.arca--mobile .row__actions { gap: 2px; }
+
+/* Mobile bottom nav */
+.mnav {
+  flex: 0 0 64px;
+  height: 64px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  background: var(--bg-card);
+  border-top: 1px solid var(--rule);
+  padding-bottom: 8px;
+}
+.mnav__item {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 3px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  color: var(--text-3);
+  text-transform: lowercase;
+  position: relative;
+}
+.mnav__item--active { color: var(--accent); }
+.mnav__item--active::before {
+  content: ''; position: absolute;
+  top: -1px; left: 30%; right: 30%;
+  height: 2px;
+  background: var(--accent);
+}
+
+/* Mobile detail screen */
+.arca--mobile .detail-head {
+  padding: 14px 20px 14px;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+}
+.arca--mobile .detail__title { font-size: 26px; }
+.arca--mobile .detail-body {
+  padding: 12px 20px 16px;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+.arca--mobile .note-panel { grid-row: span 1; padding: 14px 16px; font-size: 12.5px; }
+.arca--mobile .field { padding: 11px 14px; grid-template-columns: 76px 1fr auto; }
+.arca--mobile .field__v { font-size: 12px; }
+
+/* ───────────────────────────────────────────────────────────
+   Modal — the "are you sure" pattern from lipgloss
+   ─────────────────────────────────────────────────────────── */
+.modal {
+  background: var(--bg-card);
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  padding: 16px 18px;
+}
+.modal__q {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text);
+  margin-bottom: 14px;
+}
+.modal__row { display: flex; gap: 8px; }
+
+/* ───────────────────────────────────────────────────────────
+   Misc utilities
+   ─────────────────────────────────────────────────────────── */
+.ds-hr {
+  height: 0;
+  border-top: 1px dashed var(--rule-dashed);
+  margin: 14px 0;
+}
+.ds-hr--solid { border-top-style: solid; border-color: var(--rule); }

--- a/apps/desktop/src/lib/stores/ui.svelte.ts
+++ b/apps/desktop/src/lib/stores/ui.svelte.ts
@@ -1,5 +1,5 @@
 export type ViewName = 'unlock' | 'list' | 'detail' | 'edit' | 'settings' | 'generator';
-export type ThemeName = 'terminal' | 'amber';
+export type ThemeName = 'paper' | 'ink';
 
 export interface Notification {
   kind: 'info' | 'success' | 'warning' | 'error';
@@ -7,7 +7,7 @@ export interface Notification {
 }
 
 export const uiState = $state({
-  theme: 'terminal' as ThemeName,
+  theme: 'paper' as ThemeName,
   view: 'unlock' as ViewName,
   clipboardTimer: null as ReturnType<typeof setTimeout> | null,
   notification: null as Notification | null,


### PR DESCRIPTION
## Summary
- Replace the v0.1 terminal-green stylesheet with the Paper + Ink v0.2 token/component CSS from the mockup package
- Move the app root to the new `.arca arca--desktop` container with `data-theme="paper"`
- Update the internal UI theme store from terminal/amber to paper/ink without changing the Tauri command surface or IPC wrappers

## Product decisions confirmed
- TOTP stays out of production UI for now
- Tabs/sidebar stay in the v0.2 port, with non-vault tabs treated as placeholders until their screens land
- Sealed is idle-lock only; cold start uses the two-pane unlock flow

## Validation
- `pnpm --filter @arca/desktop build`
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- Browser-verified `http://127.0.0.1:5173/`: root mounts as `.arca arca--desktop`, theme is `paper`, Paper background resolves, and no console errors