### PR TITLE
Add Paper UI primitives

### DIFF
--- a/apps/desktop/src/lib/components/brand/Lettermark.svelte
+++ b/apps/desktop/src/lib/components/brand/Lettermark.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  let {
+    size = 22,
+    color = 'currentColor',
+    title,
+    class: className = '',
+    ...rest
+  } = $props<{
+    size?: number;
+    color?: string;
+    title?: string;
+    class?: string;
+    [key: string]: unknown;
+  }>();
+
+  const width = $derived(size * (540 / 700));
+  const path =
+    'M 390 140 L 540 140 L 540 380 A 270 320 0 0 1 0 380 L 390 380 Z ' +
+    'M 110 490 L 390 490 A 140 130 0 0 1 110 490 Z';
+</script>
+
+<svg
+  {...rest}
+  class={className}
+  width={width}
+  height={size}
+  viewBox="0 0 540 700"
+  role={title ? 'img' : undefined}
+  aria-hidden={title ? undefined : true}
+  style:display="block"
+  style:flex-shrink="0"
+>
+  {#if title}
+    <title>{title}</title>
+  {/if}
+  <path fill={color} fill-rule="evenodd" d={path} />
+</svg>

--- a/apps/desktop/src/lib/components/brand/Lockup.svelte
+++ b/apps/desktop/src/lib/components/brand/Lockup.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import Lettermark from './Lettermark.svelte';
+
+  let {
+    size = 22,
+    color,
+    accent = false,
+    gap,
+    ariaLabel = 'arca',
+    class: className = '',
+    ...rest
+  } = $props<{
+    size?: number;
+    color?: string;
+    accent?: boolean;
+    gap?: number;
+    ariaLabel?: string;
+    class?: string;
+    [key: string]: unknown;
+  }>();
+
+  const wordColor = $derived(color ?? (accent ? 'var(--accent)' : 'var(--text)'));
+  const lockupGap = $derived(gap ?? Math.max(4, size * 0.22));
+  const classes = $derived(['lockup', className].filter(Boolean).join(' '));
+</script>
+
+<span
+  {...rest}
+  class={classes}
+  aria-label={ariaLabel}
+  style:gap={`${lockupGap}px`}
+  style:color={wordColor}
+>
+  <Lettermark size={size * 0.82} color="currentColor" />
+  <span class="lockup__word" style:font-size={`${size}px`}>arca</span>
+</span>

--- a/apps/desktop/src/lib/components/brand/index.ts
+++ b/apps/desktop/src/lib/components/brand/index.ts
@@ -1,0 +1,2 @@
+export { default as Lettermark } from './Lettermark.svelte';
+export { default as Lockup } from './Lockup.svelte';

--- a/apps/desktop/src/lib/components/primitives/Button.svelte
+++ b/apps/desktop/src/lib/components/primitives/Button.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type ButtonVariant = 'primary' | 'vault' | 'ghost' | 'bare' | 'danger';
+  type ButtonSize = 'default' | 'sm' | 'xs';
+  type ButtonType = 'button' | 'submit' | 'reset';
+
+  let {
+    variant = 'ghost',
+    size = 'default',
+    type = 'button',
+    disabled = false,
+    class: className = '',
+    children,
+    ...rest
+  } = $props<{
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+    type?: ButtonType;
+    disabled?: boolean;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  }>();
+
+  const classes = $derived(
+    ['btn', `btn--${variant}`, size !== 'default' ? `btn--${size}` : '', className]
+      .filter(Boolean)
+      .join(' '),
+  );
+</script>
+
+<button {...rest} class={classes} {type} {disabled}>
+  {#if children}
+    {@render children()}
+  {/if}
+</button>

--- a/apps/desktop/src/lib/components/primitives/Entropy.svelte
+++ b/apps/desktop/src/lib/components/primitives/Entropy.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  let {
+    filled = 13,
+    segments = 16,
+    bits = 94,
+    strength = 'strong',
+    class: className = '',
+    ...rest
+  } = $props<{
+    filled?: number;
+    segments?: number;
+    bits?: number;
+    strength?: string;
+    class?: string;
+    [key: string]: unknown;
+  }>();
+
+  const classes = $derived(['entropy', className].filter(Boolean).join(' '));
+  const segmentCount = $derived(Math.max(0, Math.floor(segments)));
+  const filledCount = $derived(Math.max(0, Math.min(Math.floor(filled), segmentCount)));
+  const segmentClasses = $derived(
+    Array.from({ length: segmentCount }, (_, index) => {
+      if (index >= filledCount) {
+        return '';
+      }
+
+      if (index < 5) {
+        return ' entropy__seg--w';
+      }
+
+      if (index < 10) {
+        return ' entropy__seg--m';
+      }
+
+      return ' entropy__seg--s';
+    }),
+  );
+</script>
+
+<div {...rest} class={classes}>
+  <div class="entropy__bar" aria-hidden="true">
+    {#each segmentClasses as segmentClass}
+      <div class={`entropy__seg${segmentClass}`}></div>
+    {/each}
+  </div>
+  <span class="entropy__bits">{bits} bits</span>
+  <span class="entropy__cls">{strength}</span>
+</div>

--- a/apps/desktop/src/lib/components/primitives/IconButton.svelte
+++ b/apps/desktop/src/lib/components/primitives/IconButton.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type IconButtonVariant = 'default' | 'accent' | 'vault' | 'ghost';
+  type ButtonType = 'button' | 'submit' | 'reset';
+
+  let {
+    variant = 'default',
+    label,
+    title,
+    type = 'button',
+    disabled = false,
+    class: className = '',
+    children,
+    ...rest
+  } = $props<{
+    variant?: IconButtonVariant;
+    label: string;
+    title?: string;
+    type?: ButtonType;
+    disabled?: boolean;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  }>();
+
+  const classes = $derived(
+    ['iconbtn', variant !== 'default' ? `iconbtn--${variant}` : '', className]
+      .filter(Boolean)
+      .join(' '),
+  );
+</script>
+
+<button {...rest} class={classes} aria-label={label} title={title ?? label} {type} {disabled}>
+  {#if children}
+    {@render children()}
+  {/if}
+</button>

--- a/apps/desktop/src/lib/components/primitives/Kbd.svelte
+++ b/apps/desktop/src/lib/components/primitives/Kbd.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let {
+    value,
+    class: className = '',
+    children,
+    ...rest
+  } = $props<{
+    value?: string;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  }>();
+
+  const classes = $derived(['kbd', className].filter(Boolean).join(' '));
+</script>
+
+<kbd {...rest} class={classes}>
+  {#if value}
+    {value}
+  {:else if children}
+    {@render children()}
+  {/if}
+</kbd>

--- a/apps/desktop/src/lib/components/primitives/Tag.svelte
+++ b/apps/desktop/src/lib/components/primitives/Tag.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type TagVariant = 'default' | 'vault' | 'slate' | 'out' | 'ink' | 'paper';
+
+  let {
+    variant = 'default',
+    value,
+    bracketed = true,
+    class: className = '',
+    children,
+    ...rest
+  } = $props<{
+    variant?: TagVariant;
+    value?: string;
+    bracketed?: boolean;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  }>();
+
+  const classes = $derived(
+    ['tag', variant !== 'default' ? `tag--${variant}` : '', className].filter(Boolean).join(' '),
+  );
+</script>
+
+<span {...rest} class={classes}>
+  {#if value}
+    {bracketed ? `[${value}]` : value}
+  {:else if children}
+    {@render children()}
+  {/if}
+</span>

--- a/apps/desktop/src/lib/components/primitives/index.ts
+++ b/apps/desktop/src/lib/components/primitives/index.ts
@@ -1,0 +1,5 @@
+export { default as Button } from './Button.svelte';
+export { default as Entropy } from './Entropy.svelte';
+export { default as IconButton } from './IconButton.svelte';
+export { default as Kbd } from './Kbd.svelte';
+export { default as Tag } from './Tag.svelte';


### PR DESCRIPTION
## Summary
- Add Paper identity brand components: `Lettermark` and `Lockup`
- Add primitive Svelte adapters for the v0.2 CSS vocabulary: `Button`, `IconButton`, `Tag`, `Kbd`, and `Entropy`
- Add index exports for the brand and primitive component groups

## Notes
- No screen wiring or visible UI changes in this PR
- The lettermark uses the final bowl + stem path with no seam line
- Components consume the classes already introduced by the Paper token sheet

## Validation
- Explicit Svelte compiler pass over all new components
- `pnpm --filter @arca/desktop build`
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`

## Follow-up
- `pnpm --filter @arca/desktop exec tsc --noEmit` currently fails on the repo baseline because Node/Vite types are not configured, so it is not used as a PR gate yet.