### PR TITLE
Add Paper desktop chrome

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1,14 +1,67 @@
 <script lang="ts">
   import UnlockScreen from './lib/components/UnlockScreen.svelte';
   import VaultShell from './lib/components/VaultShell.svelte';
+  import { StatusBar, Tabs, WindowChrome, type TabItem } from './lib/components/chrome';
   import { vaultState } from './lib/stores/vault.svelte';
-  import { uiState } from './lib/stores/ui.svelte';
+  import { uiState, type ViewName } from './lib/stores/ui.svelte';
+
+  const tabItems = $derived<TabItem[]>([
+    { key: 'vault', label: 'vault', count: vaultState.entries.length },
+    { key: 'generate', label: 'generate' },
+    { key: 'audit', label: 'audit' },
+    { key: 'shared', label: 'shared' },
+    { key: 'settings', label: 'settings' },
+  ]);
+
+  const activeTab = $derived(
+    uiState.view === 'generator'
+      ? 'generate'
+      : uiState.view === 'settings' || uiState.view === 'audit' || uiState.view === 'shared'
+        ? uiState.view
+        : 'vault',
+  );
+
+  const chromePath = $derived(
+    vaultState.locked
+      ? 'vault.local · sealed'
+      : vaultState.selectedEntry
+        ? `vault.local / ${vaultState.selectedEntry.title}`
+        : 'vault.local',
+  );
+
+  const statusPill = $derived(vaultState.locked ? 'SEALED' : activeTab === 'vault' ? 'VIEWING' : 'AUTH');
+  const statusKind = $derived(vaultState.locked ? 'vault' : activeTab === 'vault' ? 'slate' : 'ink');
+  const statusText = $derived(
+    vaultState.locked ? 'awaiting_credentials · argon2id' : `vault.local · ${vaultState.entries.length} entries`,
+  );
+
+  function selectTab(key: string) {
+    const viewByTab: Record<string, ViewName> = {
+      vault: 'list',
+      generate: 'generator',
+      audit: 'audit',
+      shared: 'shared',
+      settings: 'settings',
+    };
+
+    uiState.view = viewByTab[key] ?? 'list';
+  }
 </script>
 
 <main class="arca arca--desktop" data-theme={uiState.theme}>
-  {#if vaultState.locked}
-    <UnlockScreen />
-  {:else}
-    <VaultShell />
+  <WindowChrome path={chromePath} />
+
+  {#if !vaultState.locked}
+    <Tabs items={tabItems} active={activeTab} onselect={selectTab} />
   {/if}
+
+  <div class="app-content">
+    {#if vaultState.locked}
+      <UnlockScreen />
+    {:else}
+      <VaultShell />
+    {/if}
+  </div>
+
+  <StatusBar pill={statusPill} pillKind={statusKind} leftText={statusText} />
 </main>

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -121,6 +121,15 @@
   overflow: hidden;
 }
 
+.app-content {
+  flex: 1 1 0;
+  min-height: 0;
+  display: grid;
+  place-items: center;
+  overflow: auto;
+  padding: 28px;
+}
+
 /* ───────────────────────────────────────────────────────────
    Window chrome (desktop)
    ─────────────────────────────────────────────────────────── */

--- a/apps/desktop/src/lib/components/chrome/StatusBar.svelte
+++ b/apps/desktop/src/lib/components/chrome/StatusBar.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type PillKind = 'vault' | 'ink' | 'slate' | 'ghost';
+
+  let {
+    pill = 'SEALED',
+    pillKind = 'vault',
+    leftText = '',
+    connected = true,
+    connectionLabel,
+    left,
+    right,
+    class: className = '',
+    ...rest
+  } = $props<{
+    pill?: string;
+    pillKind?: PillKind;
+    leftText?: string;
+    connected?: boolean;
+    connectionLabel?: string;
+    left?: Snippet;
+    right?: Snippet;
+    class?: string;
+    [key: string]: unknown;
+  }>();
+
+  const classes = $derived(['status', className].filter(Boolean).join(' '));
+  const pillClasses = $derived(['status__pill', `status__pill--${pillKind}`].join(' '));
+  const dotClasses = $derived(['status__dot', connected ? '' : 'status__dot--warn'].filter(Boolean).join(' '));
+</script>
+
+<div {...rest} class={classes}>
+  <span class={pillClasses}>{pill}</span>
+  {#if left}
+    {@render left()}
+  {:else if leftText}
+    <span>{leftText}</span>
+  {/if}
+  <span class="status__spacer"></span>
+  {#if right}
+    {@render right()}
+  {:else}
+    <span class="status__pill status__pill--ghost">UTF-8</span>
+    <span class="status__pill status__pill--ghost">aes-512</span>
+    <span><span class={dotClasses}></span>{connectionLabel ?? (connected ? 'online' : 'offline')}</span>
+  {/if}
+</div>

--- a/apps/desktop/src/lib/components/chrome/Tabs.svelte
+++ b/apps/desktop/src/lib/components/chrome/Tabs.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  export interface TabItem {
+    key: string;
+    label: string;
+    count?: number | null;
+    disabled?: boolean;
+  }
+
+  let {
+    items = [],
+    active,
+    onselect,
+    label = 'Workspace sections',
+    class: className = '',
+    ...rest
+  } = $props<{
+    items?: TabItem[];
+    active?: string;
+    onselect?: (key: string) => void;
+    label?: string;
+    class?: string;
+    [key: string]: unknown;
+  }>();
+
+  const classes = $derived(['tabs', className].filter(Boolean).join(' '));
+</script>
+
+<div {...rest} class={classes} role="tablist" aria-label={label}>
+  {#each items as item (item.key)}
+    <button
+      type="button"
+      role="tab"
+      class={active === item.key ? 'tab tab--active' : 'tab'}
+      aria-selected={active === item.key}
+      disabled={item.disabled}
+      onclick={() => onselect?.(item.key)}
+    >
+      {item.label}
+      {#if item.count !== undefined && item.count !== null}
+        <span class="tab__count">[{item.count}]</span>
+      {/if}
+    </button>
+  {/each}
+</div>

--- a/apps/desktop/src/lib/components/chrome/WindowChrome.svelte
+++ b/apps/desktop/src/lib/components/chrome/WindowChrome.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { Lockup } from '../brand';
+
+  let {
+    path = 'vault.local',
+    prefix = './',
+    rightText = 'v0.2 · 2026',
+    right,
+    class: className = '',
+    ...rest
+  } = $props<{
+    path?: string;
+    prefix?: string;
+    rightText?: string;
+    right?: Snippet;
+    class?: string;
+    [key: string]: unknown;
+  }>();
+
+  const classes = $derived(['chrome', className].filter(Boolean).join(' '));
+</script>
+
+<div {...rest} class={classes}>
+  <span class="chrome__lockup">
+    <Lockup size={18} />
+  </span>
+  <span class="chrome__divider"></span>
+  <div class="chrome__path mono">{prefix}<b>{path}</b></div>
+  <div class="chrome__right">
+    {#if right}
+      {@render right()}
+    {:else}
+      {rightText}
+    {/if}
+  </div>
+</div>

--- a/apps/desktop/src/lib/components/chrome/index.ts
+++ b/apps/desktop/src/lib/components/chrome/index.ts
@@ -1,0 +1,4 @@
+export { default as StatusBar } from './StatusBar.svelte';
+export { default as Tabs } from './Tabs.svelte';
+export type { TabItem } from './Tabs.svelte';
+export { default as WindowChrome } from './WindowChrome.svelte';

--- a/apps/desktop/src/lib/stores/ui.svelte.ts
+++ b/apps/desktop/src/lib/stores/ui.svelte.ts
@@ -1,4 +1,12 @@
-export type ViewName = 'unlock' | 'list' | 'detail' | 'edit' | 'settings' | 'generator';
+export type ViewName =
+  | 'unlock'
+  | 'list'
+  | 'detail'
+  | 'edit'
+  | 'settings'
+  | 'generator'
+  | 'audit'
+  | 'shared';
 export type ThemeName = 'paper' | 'ink';
 
 export interface Notification {


### PR DESCRIPTION
## Summary
- Add Svelte ports of the Paper desktop chrome primitives: `WindowChrome`, `Tabs`, and `StatusBar`
- Mount the chrome and status bar around the desktop app shell
- Show the tab strip only after unlock, with generate/audit/shared/settings as local placeholder destinations
- Add a minimal content host so existing screens sit inside the new framed shell until their dedicated v0.2 ports land

## Validation
- Explicit Svelte compiler pass over new chrome components
- `pnpm --filter @arca/desktop build`
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- Browser-verified `http://127.0.0.1:5173/`: Paper root renders chrome lockup/path, status bar, no locked-state tabs, and no console errors

## Notes
- No vault list/detail porting in this PR; that remains PR #4 and PR #5 from the handoff plan.