### PR TITLE
Add Paper vault list

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -55,7 +55,7 @@
     <Tabs items={tabItems} active={activeTab} onselect={selectTab} />
   {/if}
 
-  <div class="app-content">
+  <div class="app-content" class:app-content--full={!vaultState.locked}>
     {#if vaultState.locked}
       <UnlockScreen />
     {:else}

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -129,6 +129,12 @@
   overflow: auto;
   padding: 28px;
 }
+.app-content--full {
+  display: flex;
+  place-items: initial;
+  overflow: hidden;
+  padding: 0;
+}
 
 /* ───────────────────────────────────────────────────────────
    Window chrome (desktop)
@@ -490,6 +496,22 @@
   letter-spacing: 0.02em;
   display: flex; align-items: center;
 }
+.search__input {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+.search__input::placeholder {
+  color: var(--text-3);
+  opacity: 0.85;
+}
 .search__text--ph { color: var(--text-3); opacity: 0.85; }
 .search__caret {
   display: inline-block;
@@ -671,13 +693,17 @@
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
+  width: 100%;
   padding: 6px 8px;
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--text-2);
+  border: 0;
   border-radius: 4px;
+  background: transparent;
   cursor: pointer;
   letter-spacing: 0.02em;
+  text-align: left;
   transition: background .12s, color .12s;
 }
 .filter:hover { background: var(--bg-card); color: var(--text); }
@@ -740,6 +766,9 @@
 }
 .row--selected .row__bullet { color: var(--accent); }
 .row__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.02em;
@@ -765,6 +794,61 @@
 .row:hover .row__action { color: var(--text-2); }
 .row__action:hover { color: var(--text); background: var(--bg-card-2); }
 .row__action--ok { color: var(--vault); border-color: var(--vault); background: var(--vault-soft); }
+
+.vault-list {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.vault-list__score { color: var(--vault); }
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 2px 0;
+}
+.entries__empty {
+  margin: 10px 4px;
+  padding: 18px;
+  border: 1px dashed var(--rule-dashed);
+  border-radius: 6px;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+.entries__empty span {
+  color: var(--accent);
+  font-weight: 700;
+  margin-right: 8px;
+}
+.vault-placeholder {
+  display: grid;
+  gap: 12px;
+  place-items: center;
+  color: var(--text-2);
+}
+.vault-placeholder h1 {
+  margin: 0;
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: 32px;
+  font-weight: 600;
+  letter-spacing: -0.022em;
+}
+.vault-placeholder p {
+  margin: 0;
+  font-family: var(--font-mono);
+  letter-spacing: 0.08em;
+}
+.vault-placeholder__eyebrow {
+  color: var(--text-3);
+  font-size: 10px;
+  text-transform: uppercase;
+}
 
 /* ───────────────────────────────────────────────────────────
    Status bar (always at the bottom)

--- a/apps/desktop/src/lib/components/VaultShell.svelte
+++ b/apps/desktop/src/lib/components/VaultShell.svelte
@@ -2,6 +2,7 @@
   import { lockVault } from '../ipc';
   import { vaultState } from '../stores/vault.svelte';
   import { uiState } from '../stores/ui.svelte';
+  import { EntryList } from './vault';
 
   let busy = $state(false);
   let errorMessage = $state('');
@@ -34,26 +35,25 @@
 
     return 'Unable to lock vault';
   }
+  const placeholderTitle = $derived(
+    uiState.view === 'generator'
+      ? 'generate'
+      : uiState.view === 'audit' || uiState.view === 'shared' || uiState.view === 'settings'
+        ? uiState.view
+        : '',
+  );
 </script>
 
-<section class="vault-shell" aria-labelledby="vault-title">
-  <header class="top-bar">
-    <div>
-      <h1 id="vault-title">{vaultState.vaultName || 'VAULT'}</h1>
-      <p>{vaultState.vaultPath}</p>
-    </div>
-    <div class="top-bar-actions">
-      <span>{vaultState.entries.length} entries</span>
-      <button type="button" onclick={lock} disabled={busy}>LOCK</button>
-    </div>
-  </header>
-
-  {#if errorMessage}
-    <div class="error" role="alert">{errorMessage}</div>
-  {/if}
-
-  <div class="empty-state">
-    <span>&gt;_</span>
-    <p>{vaultState.entries.length === 0 ? 'NO_ENTRIES' : 'ENTRY_LIST_READY'}</p>
-  </div>
-</section>
+{#if uiState.view === 'list' || uiState.view === 'detail' || uiState.view === 'edit'}
+  <EntryList />
+{:else}
+  <section class="vault-placeholder" aria-labelledby="vault-placeholder-title">
+    <p class="vault-placeholder__eyebrow">placeholder</p>
+    <h1 id="vault-placeholder-title">{placeholderTitle}</h1>
+    <p>screen_port_pending</p>
+    <button class="btn btn--ghost" type="button" onclick={lock} disabled={busy}>lock_vault</button>
+    {#if errorMessage}
+      <div class="error" role="alert">{errorMessage}</div>
+    {/if}
+  </section>
+{/if}

--- a/apps/desktop/src/lib/components/icons/Icon.svelte
+++ b/apps/desktop/src/lib/components/icons/Icon.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  export type IconName =
+    | 'at'
+    | 'bank'
+    | 'box'
+    | 'cloud'
+    | 'code'
+    | 'copy'
+    | 'eye'
+    | 'key'
+    | 'plus'
+    | 'refresh'
+    | 'server'
+    | 'vault';
+
+  let {
+    name,
+    size = 16,
+    sw = 1.5,
+    class: className = '',
+    ...rest
+  } = $props<{
+    name: IconName;
+    size?: number;
+    sw?: number;
+    class?: string;
+    [key: string]: unknown;
+  }>();
+</script>
+
+<svg
+  {...rest}
+  class={className}
+  width={size}
+  height={size}
+  viewBox="0 0 16 16"
+  fill="none"
+  stroke="currentColor"
+  stroke-width={sw}
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  {#if name === 'copy'}
+    <rect x="5" y="5" width="8" height="9" rx="1" />
+    <path d="M3 11V3a1 1 0 0 1 1-1h7" />
+  {:else if name === 'eye'}
+    <path d="M1.5 8s2.5-5 6.5-5 6.5 5 6.5 5-2.5 5-6.5 5S1.5 8 1.5 8Z" />
+    <circle cx="8" cy="8" r="2" />
+  {:else if name === 'plus'}
+    <path d="M8 3v10M3 8h10" />
+  {:else if name === 'refresh'}
+    <path d="M13 4v3h-3M3 12V9h3" />
+    <path d="M12.5 7A5 5 0 0 0 3.5 6M3.5 9a5 5 0 0 0 9 1" />
+  {:else if name === 'code'}
+    <path d="m5 5-3 3 3 3M11 5l3 3-3 3M9 3 7 13" />
+  {:else if name === 'cloud'}
+    <path d="M4.5 13a3 3 0 0 1-.4-6 4 4 0 0 1 7.6.5 2.5 2.5 0 0 1-.7 4.9 2.5 2.5 0 0 1-.5.05Z" />
+  {:else if name === 'bank'}
+    <path d="M2 6 8 3l6 3M3 6v.5M13 6v.5M2.5 14h11M4 7v6M7 7v6M9 7v6M12 7v6" />
+  {:else if name === 'at'}
+    <circle cx="8" cy="8" r="2.5" />
+    <path d="M10.5 8v1.5a1.5 1.5 0 0 0 3 0V8a5.5 5.5 0 1 0-2 4.3" />
+  {:else if name === 'server'}
+    <rect x="2.5" y="3" width="11" height="4" rx="1" />
+    <rect x="2.5" y="9" width="11" height="4" rx="1" />
+    <path d="M5 5h.01M5 11h.01M8 5h.01M8 11h.01" />
+  {:else if name === 'box'}
+    <path d="M2 5.5 8 3l6 2.5M2 5.5v6L8 14M2 5.5 8 8m0 0v6m0-6 6-2.5m0 0v6L8 14" />
+  {:else if name === 'key'}
+    <circle cx="5" cy="11" r="2.5" />
+    <path d="M7 9.5 13 3.5M11 5l1.5 1.5M10 6.5l1.5 1.5" />
+  {:else}
+    <rect x="2.5" y="3" width="11" height="10" rx="1" />
+    <circle cx="8.5" cy="8" r="2" />
+    <path d="M8.5 6V5M8.5 11v-1M10.5 8h1M6.5 8h-1" />
+  {/if}
+</svg>

--- a/apps/desktop/src/lib/components/icons/index.ts
+++ b/apps/desktop/src/lib/components/icons/index.ts
@@ -1,0 +1,2 @@
+export { default as Icon } from './Icon.svelte';
+export type { IconName } from './Icon.svelte';

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+  import type { EntryDto } from '../../ipc';
+  import { uiState } from '../../stores/ui.svelte';
+  import { vaultState } from '../../stores/vault.svelte';
+  import { Icon } from '../icons';
+  import { Button, Kbd } from '../primitives';
+  import EntryRow from './EntryRow.svelte';
+  import FilterSidebar, { type FilterItem } from './FilterSidebar.svelte';
+  import SearchBar from './SearchBar.svelte';
+
+  type FilterKey = 'all' | 'recent' | 'work' | 'personal' | 'infrastructure' | 'shared' | 'archive';
+
+  interface EntrySection {
+    key: string;
+    label: string;
+    entries: EntryDto[];
+  }
+
+  let selectedFilter = $state<FilterKey>('all');
+  let searchFocused = $state(true);
+
+  const sortedEntries = $derived([...vaultState.entries].sort(compareByUpdatedAt));
+  const recentIds = $derived(new Set(sortedEntries.slice(0, 6).map((entry) => entry.id)));
+  const filteredEntries = $derived(
+    sortedEntries.filter((entry) => matchesFilter(entry, selectedFilter, recentIds) && matchesQuery(entry)),
+  );
+  const sections = $derived(buildSections(filteredEntries, selectedFilter, recentIds));
+  const filters = $derived<FilterItem[]>([
+    { key: 'all', label: 'all', count: vaultState.entries.length },
+    { key: 'recent', label: 'recent', count: recentIds.size },
+    { key: 'work', label: 'work', count: countByFilter('work', recentIds) },
+    { key: 'personal', label: 'personal', count: countByFilter('personal', recentIds) },
+    { key: 'infrastructure', label: 'infrastructure', count: countByFilter('infrastructure', recentIds) },
+    { key: 'shared', label: 'shared', count: countByFilter('shared', recentIds) },
+    { key: 'archive', label: 'archive', count: countByFilter('archive', recentIds) },
+  ]);
+  const tags = $derived(deriveTags(vaultState.entries));
+  const entropyScore = $derived(vaultState.entries.length > 0 ? '98.2%' : '0.0%');
+  const sealedAt = $derived(formatTimestamp(vaultState.lastSaved));
+
+  function setQuery(query: string) {
+    vaultState.searchQuery = query;
+  }
+
+  function selectEntry(entry: EntryDto) {
+    vaultState.selectedEntry = entry;
+  }
+
+  function openNewEntry() {
+    uiState.view = 'edit';
+  }
+
+  function selectFilter(key: string) {
+    selectedFilter = key as FilterKey;
+  }
+
+  function matchesQuery(entry: EntryDto): boolean {
+    const query = vaultState.searchQuery.trim().toLowerCase();
+
+    if (!query) {
+      return true;
+    }
+
+    if (query.startsWith('#')) {
+      const tagQuery = query.slice(1);
+      return entry.tags.some((tag) => normalize(tag) === tagQuery);
+    }
+
+    return [entry.title, entry.username, entry.url ?? '', ...entry.tags]
+      .join(' ')
+      .toLowerCase()
+      .includes(query);
+  }
+
+  function matchesFilter(entry: EntryDto, filter: FilterKey, recent: Set<string>): boolean {
+    if (filter === 'all') {
+      return true;
+    }
+
+    if (filter === 'recent') {
+      return recent.has(entry.id);
+    }
+
+    return tagsFor(entry).has(filter);
+  }
+
+  function buildSections(entries: EntryDto[], filter: FilterKey, recent: Set<string>): EntrySection[] {
+    if (filter !== 'all') {
+      return [{ key: filter, label: filter, entries }];
+    }
+
+    const grouped: EntrySection[] = [
+      { key: 'recent', label: 'recent', entries: [] },
+      { key: 'work', label: 'work', entries: [] },
+      { key: 'infrastructure', label: 'infrastructure', entries: [] },
+      { key: 'other', label: 'other', entries: [] },
+    ];
+
+    for (const entry of entries) {
+      if (recent.has(entry.id)) {
+        grouped[0].entries.push(entry);
+      } else if (tagsFor(entry).has('work')) {
+        grouped[1].entries.push(entry);
+      } else if (tagsFor(entry).has('infrastructure')) {
+        grouped[2].entries.push(entry);
+      } else {
+        grouped[3].entries.push(entry);
+      }
+    }
+
+    return grouped.filter((section) => section.entries.length > 0);
+  }
+
+  function countByFilter(filter: FilterKey, recent: Set<string>): number {
+    return vaultState.entries.filter((entry) => matchesFilter(entry, filter, recent)).length;
+  }
+
+  function tagsFor(entry: EntryDto): Set<string> {
+    return new Set(entry.tags.map(normalize).map((tag) => (tag === 'infra' ? 'infrastructure' : tag)));
+  }
+
+  function deriveTags(entries: EntryDto[]): string[] {
+    const counts = new Map<string, number>();
+
+    for (const entry of entries) {
+      for (const tag of entry.tags) {
+        const normalized = normalize(tag);
+        counts.set(normalized, (counts.get(normalized) ?? 0) + 1);
+      }
+    }
+
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, 8)
+      .map(([tag]) => tag);
+  }
+
+  function compareByUpdatedAt(a: EntryDto, b: EntryDto): number {
+    return Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
+  }
+
+  function formatTimestamp(value: Date | null): string {
+    if (!value) {
+      return 'not_saved';
+    }
+
+    return value.toISOString().slice(0, 16).replace('T', ' ');
+  }
+
+  function normalize(value: string): string {
+    return value.trim().toLowerCase();
+  }
+</script>
+
+<section class="vault-list" aria-labelledby="vault-list-title">
+  <div class="hero">
+    <span class="hero__hash mono">#</span>
+    <h1 id="vault-list-title" class="hero__title">the vault for what you can't <em>lose.</em></h1>
+    <div class="hero__meta mono">
+      <span>encryption · <b>aes-512</b></span>
+      <span>sealed · <b>{sealedAt}</b></span>
+      <span>entropy · <b class="vault-list__score">{entropyScore}</b></span>
+    </div>
+  </div>
+
+  <div class="toolbar">
+    <SearchBar
+      query={vaultState.searchQuery}
+      focused={searchFocused}
+      onquery={setQuery}
+      onfocus={() => (searchFocused = true)}
+      onblur={() => (searchFocused = false)}
+    />
+    <Button variant="primary" onclick={openNewEntry}>
+      <Icon name="plus" size={11} sw={2} />
+      new_entry
+      <Kbd value="N" />
+    </Button>
+    <Button variant="ghost">
+      <Icon name="refresh" size={11} sw={2} />
+      sync
+    </Button>
+  </div>
+
+  <div class="body">
+    <FilterSidebar filters={filters} tags={tags} active={selectedFilter} onselect={selectFilter} />
+
+    <div class="entries" role="listbox" aria-label="Vault entries">
+      {#if sections.length > 0}
+        {#each sections as section}
+          <div class="entries__section">
+            {section.label}
+            <span class="entries__rule"></span>
+            <span class="entries__count">{section.entries.length.toString().padStart(2, '0')}</span>
+          </div>
+          {#each section.entries as entry, index (entry.id)}
+            <EntryRow
+              {entry}
+              selected={vaultState.selectedEntry?.id === entry.id}
+              shortcut={index < 9 ? `⌘${index + 1}` : undefined}
+              onselect={selectEntry}
+            />
+          {/each}
+        {/each}
+      {:else}
+        <div class="entries__section">
+          empty <span class="entries__rule"></span> <span class="entries__count">00</span>
+        </div>
+        <div class="entries__empty">
+          <span>&gt;</span>
+          {vaultState.entries.length === 0 ? 'no_entries' : 'no_matches'}
+        </div>
+      {/if}
+    </div>
+  </div>
+</section>

--- a/apps/desktop/src/lib/components/vault/EntryRow.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryRow.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import type { EntryDto } from '../../ipc';
+  import { Icon, type IconName } from '../icons';
+  import { Tag } from '../primitives';
+
+  let {
+    entry,
+    selected = false,
+    shortcut,
+    onselect,
+  } = $props<{
+    entry: EntryDto;
+    selected?: boolean;
+    shortcut?: string;
+    onselect?: (entry: EntryDto) => void;
+  }>();
+
+  const iconName = $derived(iconForEntry(entry));
+  const weak = $derived(Boolean(entry.tags.find((tag) => normalize(tag) === 'weak')));
+  const subtitle = $derived(entry.username || entry.url || entry.id);
+
+  function iconForEntry(candidate: EntryDto): IconName {
+    const haystack = `${candidate.title} ${candidate.url ?? ''} ${candidate.tags.join(' ')}`.toLowerCase();
+
+    if (haystack.includes('github') || haystack.includes('code')) {
+      return 'code';
+    }
+
+    if (haystack.includes('aws') || haystack.includes('cloud')) {
+      return 'cloud';
+    }
+
+    if (haystack.includes('bank')) {
+      return 'bank';
+    }
+
+    if (haystack.includes('mail') || haystack.includes('email')) {
+      return 'at';
+    }
+
+    if (haystack.includes('server') || haystack.includes('infra') || haystack.includes('router')) {
+      return 'server';
+    }
+
+    if (haystack.includes('key') || haystack.includes('ssh')) {
+      return 'key';
+    }
+
+    if (haystack.includes('linear') || haystack.includes('box')) {
+      return 'box';
+    }
+
+    return 'vault';
+  }
+
+  function normalize(value: string): string {
+    return value.trim().toLowerCase();
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onselect?.(entry);
+    }
+  }
+</script>
+
+<div
+  class={selected ? 'row row--selected' : 'row'}
+  role="option"
+  tabindex="0"
+  aria-selected={selected}
+  onclick={() => onselect?.(entry)}
+  onkeydown={handleKeydown}
+>
+  <div class="row__bullet">
+    <Icon name={iconName} size={15} sw={1.5} />
+  </div>
+  <div class="row__main">
+    <div class="row__title">
+      {entry.title}
+      {#if weak}
+        <Tag variant="out" value="weak" />
+      {/if}
+    </div>
+    <div class="row__sub">{subtitle}</div>
+  </div>
+  {#if shortcut}
+    <Tag value={shortcut} />
+  {/if}
+  <div class="row__actions">
+    <button
+      class="row__action"
+      type="button"
+      aria-label={`Reveal ${entry.title}`}
+      onclick={(event) => event.stopPropagation()}
+    >
+      <Icon name="eye" size={13} sw={1.5} />
+    </button>
+    <button
+      class={selected ? 'row__action row__action--ok' : 'row__action'}
+      type="button"
+      aria-label={`Copy ${entry.title}`}
+      onclick={(event) => event.stopPropagation()}
+    >
+      <Icon name="copy" size={13} sw={1.5} />
+    </button>
+  </div>
+</div>

--- a/apps/desktop/src/lib/components/vault/FilterSidebar.svelte
+++ b/apps/desktop/src/lib/components/vault/FilterSidebar.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { Tag } from '../primitives';
+
+  export interface FilterItem {
+    key: string;
+    label: string;
+    count: number;
+  }
+
+  let {
+    filters = [],
+    tags = [],
+    active = 'all',
+    onselect,
+  } = $props<{
+    filters?: FilterItem[];
+    tags?: string[];
+    active?: string;
+    onselect?: (key: string) => void;
+  }>();
+</script>
+
+<aside class="sidepanel" aria-label="Vault filters">
+  <div class="sidepanel__title">
+    categories
+    <span class="sidepanel__title-rule"></span>
+  </div>
+
+  {#each filters as filter (filter.key)}
+    <button
+      type="button"
+      class={active === filter.key ? 'filter filter--active' : 'filter'}
+      aria-pressed={active === filter.key}
+      onclick={() => onselect?.(filter.key)}
+    >
+      <span>{filter.label}</span>
+      <span class="filter__count">{filter.count}</span>
+    </button>
+  {/each}
+
+  <div class="sidepanel__title">
+    tags
+    <span class="sidepanel__title-rule"></span>
+  </div>
+
+  <div class="tag-cloud">
+    {#if tags.length > 0}
+      {#each tags as tag}
+        <Tag variant="slate" value={tag} bracketed={false} />
+      {/each}
+    {:else}
+      <Tag variant="slate" value="none" bracketed={false} />
+    {/if}
+  </div>
+</aside>

--- a/apps/desktop/src/lib/components/vault/SearchBar.svelte
+++ b/apps/desktop/src/lib/components/vault/SearchBar.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  let {
+    query = '',
+    focused = false,
+    onquery,
+    onfocus,
+    onblur,
+    class: className = '',
+    ...rest
+  } = $props<{
+    query?: string;
+    focused?: boolean;
+    onquery?: (query: string) => void;
+    onfocus?: () => void;
+    onblur?: () => void;
+    class?: string;
+    [key: string]: unknown;
+  }>();
+
+  const classes = $derived(['search', focused ? 'search--focus' : '', className].filter(Boolean).join(' '));
+</script>
+
+<label {...rest} class={classes}>
+  <span class="search__prompt">&gt;</span>
+  <input
+    class="search__input"
+    aria-label="query vault"
+    autocomplete="off"
+    spellcheck="false"
+    value={query}
+    placeholder="query_vault"
+    oninput={(event) => onquery?.(event.currentTarget.value)}
+    onfocus={onfocus}
+    onblur={onblur}
+  />
+  {#if focused}
+    <span class="search__caret" aria-hidden="true"></span>
+  {/if}
+  <span class="search__hint">⌘F</span>
+</label>

--- a/apps/desktop/src/lib/components/vault/index.ts
+++ b/apps/desktop/src/lib/components/vault/index.ts
@@ -1,0 +1,4 @@
+export { default as EntryList } from './EntryList.svelte';
+export { default as EntryRow } from './EntryRow.svelte';
+export { default as FilterSidebar } from './FilterSidebar.svelte';
+export { default as SearchBar } from './SearchBar.svelte';


### PR DESCRIPTION
## Summary
- Port the v0.2 Paper vault list screen into Svelte components: `EntryList`, `EntryRow`, `FilterSidebar`, and `SearchBar`
- Add a small inline SVG icon helper for the vault-list toolbar, row actions, and category glyphs
- Mount the list inside `VaultShell`, keeping generate/audit/shared/settings as placeholder tab destinations
- Add functional local search, tag/category filters, selected-row state, and empty-state rendering over existing `vaultState.entries`

## Scope notes
- No TOTP UI
- No IPC or Tauri command changes
- No entry-detail/form implementation yet; those remain separate PRs

## Validation
- Explicit Svelte compiler pass over new icon/vault components
- `pnpm --filter @arca/desktop build`
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- Browser-verified via a temporary Vite preview using real `App.svelte` + sample unlocked state: hero, toolbar, sidebar filters, rows, tabs, status bar, and no console errors. The temporary preview file was deleted before commit.