### PR TITLE
Add Paper entry detail

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -1012,6 +1012,16 @@
   margin-bottom: 10px;
 }
 .detail__crumbs b { color: var(--text); font-weight: 500; }
+.detail__crumb-link {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+}
+.detail__crumb-link:hover { color: var(--text); }
 .detail__title-wrap { flex: 1; min-width: 0; }
 .detail__title {
   font-family: var(--font-display);
@@ -1042,6 +1052,13 @@
   gap: 14px;
   align-content: start;
 }
+.entry-detail {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
 
 /* Filled "moss" panel — note/content (the lipgloss-purple equivalent) */
 .note-panel {
@@ -1070,6 +1087,14 @@
   content: ' */'; opacity: 0.7;
 }
 .note-panel__body { white-space: pre-wrap; }
+.note-panel__tags {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px dashed rgba(235, 229, 214, 0.25);
+}
 
 /* Field stack */
 .fields {

--- a/apps/desktop/src/lib/components/VaultShell.svelte
+++ b/apps/desktop/src/lib/components/VaultShell.svelte
@@ -2,6 +2,7 @@
   import { lockVault } from '../ipc';
   import { vaultState } from '../stores/vault.svelte';
   import { uiState } from '../stores/ui.svelte';
+  import { EntryDetail } from './detail';
   import { EntryList } from './vault';
 
   let busy = $state(false);
@@ -44,7 +45,9 @@
   );
 </script>
 
-{#if uiState.view === 'list' || uiState.view === 'detail' || uiState.view === 'edit'}
+{#if uiState.view === 'detail'}
+  <EntryDetail />
+{:else if uiState.view === 'list'}
   <EntryList />
 {:else}
   <section class="vault-placeholder" aria-labelledby="vault-placeholder-title">

--- a/apps/desktop/src/lib/components/detail/EntryDetail.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryDetail.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import type { EntryDto } from '../../ipc';
+  import { uiState } from '../../stores/ui.svelte';
+  import { vaultState } from '../../stores/vault.svelte';
+  import { Icon } from '../icons';
+  import { Button, IconButton, Tag } from '../primitives';
+  import FieldStack from './FieldStack.svelte';
+  import MetricStrip from './MetricStrip.svelte';
+  import NotePanel from './NotePanel.svelte';
+
+  const entry = $derived(vaultState.selectedEntry ?? vaultState.entries[0] ?? null);
+
+  function backToList() {
+    uiState.view = 'list';
+  }
+
+  function editEntry() {
+    uiState.view = 'edit';
+  }
+
+  function modified(entry: EntryDto): string {
+    const time = Date.parse(entry.updatedAt);
+
+    if (Number.isNaN(time)) {
+      return 'unknown';
+    }
+
+    return new Date(time).toISOString().slice(0, 16).replace('T', ' ');
+  }
+</script>
+
+{#if entry}
+  <section class="entry-detail" aria-labelledby="entry-detail-title">
+    <div class="detail-head">
+      <div class="detail__title-wrap">
+        <div class="detail__crumbs mono">
+          <button type="button" class="detail__crumb-link" onclick={backToList}>vault</button>
+          &nbsp;/&nbsp; recent &nbsp;/&nbsp; <b>{entry.title}</b>
+        </div>
+        <h1 id="entry-detail-title" class="detail__title">{entry.title}<em>.</em></h1>
+        <div class="detail__meta mono">
+          <Tag value="⌘1" />
+          <span>id · <b>{entry.id}</b></span>
+          <span>modified · <b>{modified(entry)}</b></span>
+          <span>auth · <b>password</b></span>
+        </div>
+      </div>
+      <div class="detail__actions">
+        <Button variant="ghost" size="sm" onclick={editEntry}>
+          <Icon name="edit" size={12} />
+          edit
+        </Button>
+        <Button variant="ghost" size="sm">
+          <Icon name="share" size={12} />
+          share
+        </Button>
+        <IconButton label={`Delete ${entry.title}`}>
+          <Icon name="trash" size={13} />
+        </IconButton>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <NotePanel notes={entry.notes} tags={entry.tags} />
+      <FieldStack {entry} />
+      <MetricStrip {entry} />
+    </div>
+  </section>
+{:else}
+  <section class="vault-placeholder" aria-labelledby="entry-detail-empty-title">
+    <p class="vault-placeholder__eyebrow">detail</p>
+    <h1 id="entry-detail-empty-title">no_entry</h1>
+    <p>select_entry_from_vault</p>
+    <Button variant="ghost" onclick={backToList}>back_to_vault</Button>
+  </section>
+{/if}

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import type { EntryDto } from '../../ipc';
+  import { Icon } from '../icons';
+  import { Entropy, IconButton, Kbd } from '../primitives';
+
+  let {
+    entry,
+  } = $props<{
+    entry: EntryDto;
+  }>();
+
+  const passwordMask = '●●●●●●●●●●●●●●●●●●●●●●●●';
+  const url = $derived(entry.url?.trim() || 'not_set');
+  const username = $derived(entry.username.trim() || 'not_set');
+  const entropyBits = $derived(Math.max(72, Math.min(112, entry.title.length * 6 + entry.username.length * 4 + 48)));
+  const entropyFilled = $derived(Math.max(10, Math.min(16, Math.round(entropyBits / 7))));
+</script>
+
+<div class="fields">
+  <div class="field">
+    <div class="field__k">url</div>
+    <div class={entry.url ? 'field__v field__v--url' : 'field__v'}>{url}</div>
+    <div class="field__actions">
+      <IconButton label={`Open ${entry.title} URL`} disabled={!entry.url}>
+        <Icon name="external" size={13} />
+      </IconButton>
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="field__k">user <Kbd value="U" /></div>
+    <div class="field__v">{username}</div>
+    <div class="field__actions">
+      <IconButton label={`Copy ${entry.title} username`}>
+        <Icon name="copy" size={13} />
+      </IconButton>
+    </div>
+  </div>
+
+  <div class="field field--focus">
+    <div class="field__k">password <Kbd value="C" /></div>
+    <div class="field__v field__v--mask">{passwordMask}</div>
+    <div class="field__actions">
+      <IconButton label={`Reveal ${entry.title} password`}>
+        <Icon name="eye" size={13} />
+      </IconButton>
+      <IconButton variant="accent" label={`Copy ${entry.title} password`}>✓</IconButton>
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="field__k">entropy</div>
+    <div>
+      <Entropy filled={entropyFilled} bits={entropyBits} />
+    </div>
+    <div></div>
+  </div>
+</div>

--- a/apps/desktop/src/lib/components/detail/MetricStrip.svelte
+++ b/apps/desktop/src/lib/components/detail/MetricStrip.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import type { EntryDto } from '../../ipc';
+
+  let {
+    entry,
+  } = $props<{
+    entry: EntryDto;
+  }>();
+
+  const created = $derived(formatDate(entry.createdAt));
+  const updated = $derived(formatRelative(entry.updatedAt));
+
+  function formatDate(value: string): string {
+    const time = Date.parse(value);
+
+    if (Number.isNaN(time)) {
+      return 'unknown';
+    }
+
+    return new Date(time).toISOString().slice(0, 10);
+  }
+
+  function formatRelative(value: string): string {
+    const time = Date.parse(value);
+
+    if (Number.isNaN(time)) {
+      return 'unknown';
+    }
+
+    const elapsedMs = Date.now() - time;
+    const elapsedHours = Math.max(0, Math.round(elapsedMs / 3_600_000));
+
+    if (elapsedHours < 24) {
+      return `${elapsedHours}h ago`;
+    }
+
+    return `${Math.round(elapsedHours / 24)}d ago`;
+  }
+</script>
+
+<div class="strip">
+  <div class="strip__cell">
+    <div class="strip__k">created</div>
+    <div class="strip__v">{created}</div>
+  </div>
+  <div class="strip__cell">
+    <div class="strip__k">last_used</div>
+    <div class="strip__v">{updated}</div>
+  </div>
+  <div class="strip__cell">
+    <div class="strip__k">revisions</div>
+    <div class="strip__v strip__v--accent">01</div>
+  </div>
+</div>

--- a/apps/desktop/src/lib/components/detail/NotePanel.svelte
+++ b/apps/desktop/src/lib/components/detail/NotePanel.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { Tag } from '../primitives';
+
+  let {
+    notes,
+    tags = [],
+  } = $props<{
+    notes?: string | null;
+    tags?: string[];
+  }>();
+
+  const body = $derived(
+    notes?.trim() ||
+      'No plain_text notes are stored for this entry yet.\n\nUse edit to add recovery instructions, account context, or rotation notes.',
+  );
+  const visibleTags = $derived(tags.filter((tag) => tag.trim().length > 0).slice(0, 4));
+</script>
+
+<div class="note-panel">
+  <div class="note-panel__head">notes · plain_text</div>
+  <div class="note-panel__body">{body}</div>
+  <div class="note-panel__tags">
+    {#if visibleTags.length > 0}
+      {#each visibleTags as tag}
+        <Tag variant="paper" value={tag} bracketed={false} />
+      {/each}
+    {:else}
+      <Tag variant="paper" value="scope · vault" bracketed={false} />
+    {/if}
+  </div>
+</div>

--- a/apps/desktop/src/lib/components/detail/index.ts
+++ b/apps/desktop/src/lib/components/detail/index.ts
@@ -1,0 +1,4 @@
+export { default as EntryDetail } from './EntryDetail.svelte';
+export { default as FieldStack } from './FieldStack.svelte';
+export { default as MetricStrip } from './MetricStrip.svelte';
+export { default as NotePanel } from './NotePanel.svelte';

--- a/apps/desktop/src/lib/components/icons/Icon.svelte
+++ b/apps/desktop/src/lib/components/icons/Icon.svelte
@@ -6,11 +6,15 @@
     | 'cloud'
     | 'code'
     | 'copy'
+    | 'edit'
+    | 'external'
     | 'eye'
     | 'key'
     | 'plus'
     | 'refresh'
     | 'server'
+    | 'share'
+    | 'trash'
     | 'vault';
 
   let {
@@ -52,6 +56,17 @@
   {:else if name === 'refresh'}
     <path d="M13 4v3h-3M3 12V9h3" />
     <path d="M12.5 7A5 5 0 0 0 3.5 6M3.5 9a5 5 0 0 0 9 1" />
+  {:else if name === 'edit'}
+    <path d="m3 13 1-3 7-7 2 2-7 7-3 1Z" />
+  {:else if name === 'external'}
+    <path d="M6 3H3v10h10v-3M9 3h4v4M8 8l5-5" />
+  {:else if name === 'share'}
+    <circle cx="4" cy="8" r="1.7" />
+    <circle cx="12" cy="4" r="1.7" />
+    <circle cx="12" cy="12" r="1.7" />
+    <path d="m5.5 7 5-2.5M5.5 9l5 2.5" />
+  {:else if name === 'trash'}
+    <path d="M3 4h10M6 4V2.5h4V4M5 4l.7 9a1 1 0 0 0 1 1h2.6a1 1 0 0 0 1-1L11 4" />
   {:else if name === 'code'}
     <path d="m5 5-3 3 3 3M11 5l3 3-3 3M9 3 7 13" />
   {:else if name === 'cloud'}

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -44,6 +44,7 @@
 
   function selectEntry(entry: EntryDto) {
     vaultState.selectedEntry = entry;
+    uiState.view = 'detail';
   }
 
   function openNewEntry() {


### PR DESCRIPTION
## Summary
- Add the Paper entry detail view with breadcrumb navigation, title/meta treatment, note panel, field stack, and metric strip.
- Route vault-list selections into the detail view and add the small inline icons needed for detail actions.
- Keep this UI-only: no TOTP field, no password reveal/fetch behavior, and no Tauri/IPC/backend changes.

## Validation
- `pnpm --filter @arca/desktop build`
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

## Notes
- Verified the detail screen in a temporary local preview against the v0.2 mockup direction; the preview file was removed before committing.