### PR TITLE
Add Paper unlock screen

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -55,7 +55,7 @@
     <Tabs items={tabItems} active={activeTab} onselect={selectTab} />
   {/if}
 
-  <div class="app-content" class:app-content--full={!vaultState.locked}>
+  <div class="app-content app-content--full">
     {#if vaultState.locked}
       <UnlockScreen />
     {:else}

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -587,6 +587,16 @@
 
 .btn--danger { color: var(--accent); }
 .btn--danger:hover { background: var(--accent-soft); }
+.btn:disabled,
+.iconbtn:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+.iconbtn:disabled:hover {
+  background: var(--bg-card);
+  border-color: var(--rule);
+  color: var(--text-2);
+}
 
 .btn kbd {
   font-family: inherit;
@@ -906,6 +916,15 @@
   grid-template-columns: 1.05fr 1fr;
   gap: 0;
   overflow: hidden;
+  width: 100%;
+  min-height: 0;
+}
+.unlock-screen {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  display: flex;
 }
 .unlock__left {
   padding: 38px 36px;
@@ -914,6 +933,7 @@
   border-right: 1px dashed var(--rule-dashed);
   background: var(--bg);
 }
+.unlock__brand-gap { height: 18px; }
 .unlock__wordmark {
   font-family: var(--font-display);
   font-weight: 800;
@@ -944,12 +964,45 @@
   display: flex; gap: 16px;
 }
 .unlock__caption b { color: var(--text-2); font-weight: 500; }
+.unlock__caption-trail { margin-left: auto; }
 
 .unlock__right {
   padding: 38px 36px;
   display: flex; flex-direction: column;
   justify-content: center;
-  gap: 20px;
+  gap: 16px;
+}
+.unlock__mode-tabs {
+  display: inline-flex;
+  align-self: flex-start;
+  gap: 4px;
+  padding: 3px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 6px;
+  background: var(--bg-card);
+}
+.unlock__mode-tab {
+  height: 26px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-3);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+.unlock__mode-tab:hover {
+  color: var(--text-2);
+  border-color: var(--rule);
+}
+.unlock__mode-tab--active {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
 }
 .unlock__field-label {
   font-family: var(--font-mono);
@@ -968,6 +1021,11 @@
   border: 1px solid var(--accent);
   border-radius: 6px;
   font-family: var(--font-mono);
+  margin-top: 8px;
+}
+.unlock__field--compact {
+  height: 42px;
+  border-color: var(--rule-strong);
 }
 .unlock__field::before {
   content: '>';
@@ -977,6 +1035,7 @@
 }
 .unlock__input {
   flex: 1;
+  min-width: 0;
   background: transparent;
   border: none; outline: none;
   font-family: var(--font-mono);
@@ -984,7 +1043,24 @@
   letter-spacing: 0.30em;
   color: var(--text);
 }
+.unlock__field--compact .unlock__input {
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+.unlock__input::placeholder {
+  color: var(--text-3);
+  opacity: 0.75;
+}
 .unlock__cta { width: 100%; height: 48px; font-size: 12px; }
+.unlock__error {
+  padding: 9px 12px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
 .unlock__hints {
   font-family: var(--font-mono);
   font-size: 10px;
@@ -995,6 +1071,10 @@
   margin-top: 4px;
 }
 .unlock__hints b { color: var(--text-2); font-weight: 500; }
+.unlock__connection {
+  justify-content: space-between;
+  gap: 12px;
+}
 
 /* ───────────────────────────────────────────────────────────
    Entry detail

--- a/apps/desktop/src/lib/components/UnlockScreen.svelte
+++ b/apps/desktop/src/lib/components/UnlockScreen.svelte
@@ -2,13 +2,16 @@
   import { createVault, listEntries, unlockVault, type EntryDto } from '../ipc';
   import { vaultState } from '../stores/vault.svelte';
   import { uiState } from '../stores/ui.svelte';
+  import { Lockup } from './brand';
+  import { Icon } from './icons';
+  import { Button, IconButton, Kbd } from './primitives';
 
   type Mode = 'open' | 'create';
 
   let mode: Mode = $state('open');
   let path = $state('');
   let password = $state('');
-  let vaultName = $state('SOVEREIGN_CONSOLE');
+  let vaultName = $state('personal');
   let busy = $state(false);
   let errorMessage = $state('');
 
@@ -66,68 +69,127 @@
 </script>
 
 <section class="unlock-screen" aria-labelledby="unlock-title">
-  <div class="unlock-header">
-    <h1 id="unlock-title">ARCA</h1>
-    <div class="divider"></div>
-    <p>{mode === 'open' ? 'OPEN_VAULT' : 'CREATE_VAULT'}</p>
-  </div>
+  <div class="unlock">
+    <div class="unlock__left">
+      <div>
+        <div class="unlock__caption mono">
+          <span>v01 · 2026</span>
+          <span>identity · <b>arca</b></span>
+        </div>
+      </div>
 
-  <div class="mode-tabs" role="tablist" aria-label="Vault mode">
-    <button
-      type="button"
-      role="tab"
-      aria-selected={mode === 'open'}
-      class:active={mode === 'open'}
-      onclick={() => (mode = 'open')}
-    >
-      OPEN
-    </button>
-    <button
-      type="button"
-      role="tab"
-      aria-selected={mode === 'create'}
-      class:active={mode === 'create'}
-      onclick={() => (mode = 'create')}
-    >
-      CREATE
-    </button>
-  </div>
+      <div>
+        <Lockup size={112} />
+        <div class="unlock__brand-gap"></div>
+        <h1 id="unlock-title" class="unlock__lede">
+          the vault for what you <em>can't lose.</em><br />
+          kept where only you can reach it.
+        </h1>
+      </div>
 
-  <form
-    class="unlock-form"
-    onsubmit={(event) => {
-      event.preventDefault();
-      submit();
-    }}
-  >
-    {#if mode === 'create'}
+      <div class="unlock__caption mono">
+        <span>identity system · <b>p. 01</b></span>
+        <span class="unlock__caption-trail">bricolage grotesque · 800</span>
+      </div>
+    </div>
+
+    <form
+      class="unlock__right"
+      onsubmit={(event) => {
+        event.preventDefault();
+        submit();
+      }}
+    >
+      <div class="unlock__mode-tabs" role="tablist" aria-label="Vault mode">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === 'open'}
+          class={mode === 'open' ? 'unlock__mode-tab unlock__mode-tab--active' : 'unlock__mode-tab'}
+          onclick={() => (mode = 'open')}
+        >
+          open
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === 'create'}
+          class={mode === 'create' ? 'unlock__mode-tab unlock__mode-tab--active' : 'unlock__mode-tab'}
+          onclick={() => (mode = 'create')}
+        >
+          create
+        </button>
+      </div>
+
+      {#if mode === 'create'}
+        <label>
+          <div class="unlock__field-label">
+            <span>vault_name</span>
+            <span>local_first · encrypted</span>
+          </div>
+          <div class="unlock__field unlock__field--compact">
+            <input bind:value={vaultName} autocomplete="off" class="unlock__input" spellcheck="false" />
+          </div>
+        </label>
+      {/if}
+
       <label>
-        <span>VAULT_NAME</span>
-        <input bind:value={vaultName} autocomplete="off" spellcheck="false" />
+        <div class="unlock__field-label">
+          <span>vault_path</span>
+          <span>{mode === 'open' ? 'existing vault' : 'new vault'}</span>
+        </div>
+        <div class="unlock__field unlock__field--compact">
+          <input
+            bind:value={path}
+            autocomplete="off"
+            class="unlock__input"
+            placeholder="/Users/you/.arca/vaults/primary.arca"
+            spellcheck="false"
+          />
+        </div>
       </label>
-    {/if}
 
-    <label>
-      <span>VAULT_PATH</span>
-      <input
-        bind:value={path}
-        autocomplete="off"
-        placeholder="/Users/you/.arca/vaults/primary.kdbx"
-        spellcheck="false"
-      />
-    </label>
+      <label>
+        <div class="unlock__field-label">
+          <span>master_password</span>
+          <span>argon2id · aes-512</span>
+        </div>
+        <div class="unlock__field">
+          <input
+            bind:value={password}
+            autocomplete="current-password"
+            class="unlock__input"
+            type="password"
+            aria-label="master password"
+          />
+          <IconButton label="Password remains hidden" variant="ghost" disabled>
+            <Icon name="eye" size={14} />
+          </IconButton>
+        </div>
+      </label>
 
-    <label>
-      <span>MASTER_PASSWORD</span>
-      <input bind:value={password} autocomplete="current-password" type="password" />
-    </label>
+      {#if errorMessage}
+        <div class="unlock__error mono" role="alert">{errorMessage}</div>
+      {/if}
 
-    {#if errorMessage}
-      <div class="error" role="alert">{errorMessage}</div>
-    {/if}
+      <Button class="unlock__cta" variant="primary" type="submit" disabled={!canSubmit}>
+        <Icon name="key" size={12} sw={2} />
+        {busy ? 'working' : mode === 'open' ? 'unlock_vault' : 'create_vault'}
+        <Kbd value="↵" />
+      </Button>
 
-    <button class="primary-action" type="submit" disabled={!canSubmit}>
-      {busy ? 'WORKING' : mode === 'open' ? 'UNLOCK' : 'CREATE'}
-    </button>
-  </form>
+      <div class="unlock__hints mono">
+        <span><Kbd value="↵" /> <b>{mode === 'open' ? 'unlock' : 'create'}</b></span>
+        <span><Kbd value="⌘" />+<Kbd value="," /> settings</span>
+        <span><Kbd value="⌘" />+<Kbd value="O" /> other vault</span>
+      </div>
+
+      <div class="ds-hr"></div>
+
+      <div class="unlock__caption mono unlock__connection">
+        <span><span class="status__dot"></span> local_store · <b>ready</b></span>
+        <span>zero_knowledge · <b>enabled</b></span>
+      </div>
+    </form>
+  </div>
 </section>


### PR DESCRIPTION
## Summary
- Restyle the locked cold-start surface into the v0.2 Paper two-pane unlock screen.
- Preserve the existing open/create vault flow while adding Paper mode tabs, prompt fields, keyboard hints, and local security metadata.
- Make locked app content full-bleed so the unlock surface matches the artboard frame; sealed idle-lock behavior remains for the next PR.

## Validation
- Browser verification at `http://127.0.0.1:5173/`: default open mode, create mode toggle, submit enablement, and no TOTP/hardware-key text.
- `pnpm --filter @arca/desktop build`
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

## Notes
- UI-only change: no Tauri command, IPC, vault-core, or backend behavior changes.