### PR TITLE
Add Paper sealed screen

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -29,10 +29,26 @@
         : 'vault.local',
   );
 
-  const statusPill = $derived(vaultState.locked ? 'SEALED' : activeTab === 'vault' ? 'VIEWING' : 'AUTH');
-  const statusKind = $derived(vaultState.locked ? 'vault' : activeTab === 'vault' ? 'slate' : 'ink');
+  const unlockSurface = $derived(
+    uiState.unlockSurface === 'sealed' && vaultState.vaultPath ? 'sealed' : 'two-pane',
+  );
+  const unlockedStatusPill = $derived(activeTab === 'vault' ? 'VIEWING' : 'AUTH');
+  const lockedStatusPill = $derived(unlockSurface === 'sealed' && uiState.sealedPromptOpen ? 'AUTH' : 'SEALED');
+  const statusKind = $derived(
+    vaultState.locked
+      ? unlockSurface === 'sealed' && uiState.sealedPromptOpen
+        ? 'slate'
+        : 'vault'
+      : activeTab === 'vault'
+        ? 'slate'
+        : 'ink',
+  );
   const statusText = $derived(
-    vaultState.locked ? 'awaiting_credentials · argon2id' : `vault.local · ${vaultState.entries.length} entries`,
+    vaultState.locked
+      ? unlockSurface === 'sealed' && !uiState.sealedPromptOpen
+        ? 'tap, click, or press ↵ to unlock · argon2id'
+        : 'awaiting_credentials · argon2id'
+      : `vault.local · ${vaultState.entries.length} entries`,
   );
 
   function selectTab(key: string) {
@@ -57,11 +73,15 @@
 
   <div class="app-content app-content--full">
     {#if vaultState.locked}
-      <UnlockScreen />
+      <UnlockScreen variant={unlockSurface} />
     {:else}
       <VaultShell />
     {/if}
   </div>
 
-  <StatusBar pill={statusPill} pillKind={statusKind} leftText={statusText} />
+  <StatusBar
+    pill={vaultState.locked ? lockedStatusPill : unlockedStatusPill}
+    pillKind={statusKind}
+    leftText={statusText}
+  />
 </main>

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -267,11 +267,13 @@
   flex: 1;
   position: relative;
   display: grid;
-  grid-template-columns: 1fr 0fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0fr);
   overflow: hidden;
+  width: 100%;
+  min-height: 0;
   transition: grid-template-columns 380ms cubic-bezier(0.22, 1, 0.36, 1);
 }
-.sealed--open { grid-template-columns: 1.05fr 1fr; }
+.sealed.sealed--open { grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr); }
 
 .sealed__brand {
   display: flex;
@@ -283,7 +285,7 @@
   transition: padding 380ms cubic-bezier(0.22, 1, 0.36, 1),
               border-color 380ms cubic-bezier(0.22, 1, 0.36, 1);
 }
-.sealed--open .sealed__brand {
+.sealed.sealed--open .sealed__brand {
   padding: 38px 36px;
   border-right-color: var(--rule-dashed);
 }
@@ -304,7 +306,7 @@
   max-width: 540px;
   transition: max-width 380ms cubic-bezier(0.22, 1, 0.36, 1);
 }
-.sealed--open .sealed__brand-center { max-width: 360px; }
+.sealed.sealed--open .sealed__brand-center { max-width: 360px; }
 
 .sealed__tagline {
   font-family: var(--font-display);
@@ -315,7 +317,7 @@
   color: var(--text);
   transition: font-size 380ms cubic-bezier(0.22, 1, 0.36, 1);
 }
-.sealed--open .sealed__tagline { font-size: 22px; }
+.sealed.sealed--open .sealed__tagline { font-size: 22px; }
 .sealed__tagline em { font-style: normal; color: var(--accent); }
 
 .sealed__cta {
@@ -334,7 +336,7 @@
   transition: opacity 240ms ease;
 }
 .sealed__cta:hover .sealed__cta-pill { background: var(--accent); color: var(--accent-on); }
-.sealed--open .sealed__cta { opacity: 0; pointer-events: none; }
+.sealed.sealed--open .sealed__cta { opacity: 0; pointer-events: none; }
 .sealed__cta-pill {
   display: inline-flex; align-items: center; gap: 8px;
   height: 36px; padding: 0 16px;
@@ -354,6 +356,7 @@
 .sealed__panel {
   position: relative;
   overflow: hidden;
+  min-width: 0;
 }
 .sealed__panel-inner {
   position: absolute;
@@ -368,7 +371,7 @@
   transition: transform 380ms cubic-bezier(0.22, 1, 0.36, 1),
               opacity 240ms ease 80ms;
 }
-.sealed--open .sealed__panel-inner {
+.sealed.sealed--open .sealed__panel-inner {
   transform: translateX(0);
   opacity: 1;
 }
@@ -387,6 +390,20 @@
   cursor: pointer;
 }
 .sealed__panel-back:hover { color: var(--text); border-color: var(--text-3); }
+.sealed__panel-meta { margin-top: auto; }
+
+@media (prefers-reduced-motion: reduce) {
+  .sealed,
+  .sealed__brand,
+  .sealed__brand-center,
+  .sealed__tagline,
+  .sealed__cta,
+  .sealed__cta-pill,
+  .sealed__panel-inner {
+    transition-duration: 0ms;
+    transition-delay: 0ms;
+  }
+}
 
 /* ─── End sealed ─────────────────────────────────────────── */
 

--- a/apps/desktop/src/lib/components/UnlockScreen.svelte
+++ b/apps/desktop/src/lib/components/UnlockScreen.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { createVault, listEntries, unlockVault, type EntryDto } from '../ipc';
   import { vaultState } from '../stores/vault.svelte';
   import { uiState } from '../stores/ui.svelte';
@@ -7,13 +8,23 @@
   import { Button, IconButton, Kbd } from './primitives';
 
   type Mode = 'open' | 'create';
+  type Variant = 'two-pane' | 'sealed';
+
+  let {
+    variant = 'two-pane',
+  } = $props<{
+    variant?: Variant;
+  }>();
 
   let mode: Mode = $state('open');
-  let path = $state('');
+  let path = $state(vaultState.vaultPath);
   let password = $state('');
   let vaultName = $state('personal');
   let busy = $state(false);
   let errorMessage = $state('');
+  let openButton = $state<HTMLButtonElement | null>(null);
+  let passwordInput = $state<HTMLInputElement | null>(null);
+  let focusTimer: ReturnType<typeof setTimeout> | null = null;
 
   const canSubmit = $derived(
     path.trim().length > 0 &&
@@ -21,6 +32,37 @@
       (mode === 'open' || vaultName.trim().length > 0) &&
       !busy,
   );
+  const isSealed = $derived(variant === 'sealed');
+  const sealedOpen = $derived(isSealed && uiState.sealedPromptOpen);
+
+  onMount(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if (!isSealed || !vaultState.locked) {
+        return;
+      }
+
+      if (event.key === 'Escape' && uiState.sealedPromptOpen) {
+        event.preventDefault();
+        closeSealedPrompt();
+        return;
+      }
+
+      if (!uiState.sealedPromptOpen && (event.key === 'Enter' || event.key === ' ')) {
+        event.preventDefault();
+        openSealedPrompt();
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeydown);
+
+      if (focusTimer) {
+        clearTimeout(focusTimer);
+      }
+    };
+  });
 
   async function submit() {
     if (!canSubmit) {
@@ -41,6 +83,8 @@
       }
 
       password = '';
+      uiState.unlockSurface = 'two-pane';
+      uiState.sealedPromptOpen = false;
       uiState.view = 'list';
     } catch (error) {
       errorMessage = messageFromError(error);
@@ -66,130 +110,264 @@
 
     return 'Unable to open vault';
   }
+
+  function openSealedPrompt() {
+    if (!isSealed || busy) {
+      return;
+    }
+
+    errorMessage = '';
+    uiState.sealedPromptOpen = true;
+    schedulePasswordFocus();
+  }
+
+  function closeSealedPrompt() {
+    if (busy) {
+      return;
+    }
+
+    password = '';
+    errorMessage = '';
+    uiState.sealedPromptOpen = false;
+    openButton?.focus();
+
+    if (focusTimer) {
+      clearTimeout(focusTimer);
+      focusTimer = null;
+    }
+  }
+
+  function schedulePasswordFocus() {
+    if (focusTimer) {
+      clearTimeout(focusTimer);
+    }
+
+    const delay =
+      window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 380;
+
+    focusTimer = setTimeout(() => {
+      passwordInput?.focus();
+      focusTimer = null;
+    }, delay);
+  }
 </script>
 
 <section class="unlock-screen" aria-labelledby="unlock-title">
-  <div class="unlock">
-    <div class="unlock__left">
-      <div>
-        <div class="unlock__caption mono">
+  {#if isSealed}
+    <div class={sealedOpen ? 'sealed sealed--open' : 'sealed'}>
+      <div class="sealed__brand">
+        <div class="sealed__brand-meta mono">
           <span>v01 · 2026</span>
           <span>identity · <b>arca</b></span>
         </div>
+
+        <div class="sealed__brand-center">
+          <Lockup size={128} />
+          <h1 id="unlock-title" class="sealed__tagline">
+            the vault for what you <em>can't lose.</em><br />
+            kept where only you can reach it.
+          </h1>
+          <button
+            bind:this={openButton}
+            type="button"
+            class="sealed__cta"
+            onclick={openSealedPrompt}
+            aria-label="open vault"
+          >
+            <span class="sealed__cta-pill">
+              <Icon name="key" size={11} sw={2} />
+              press to unlock
+            </span>
+            <span class="sealed__cta-hint"><Kbd value="↵" /> &nbsp;or click</span>
+          </button>
+        </div>
+
+        <div class="sealed__brand-meta mono">
+          <span><span class="status__dot"></span> local_store · <b>ready</b></span>
+          <span>zero_knowledge · <b>enabled</b></span>
+        </div>
       </div>
 
-      <div>
-        <Lockup size={112} />
-        <div class="unlock__brand-gap"></div>
-        <h1 id="unlock-title" class="unlock__lede">
-          the vault for what you <em>can't lose.</em><br />
-          kept where only you can reach it.
-        </h1>
-      </div>
+      <div class="sealed__panel">
+        <form
+          class="sealed__panel-inner"
+          onsubmit={(event) => {
+            event.preventDefault();
+            submit();
+          }}
+        >
+          <button type="button" class="sealed__panel-back" onclick={closeSealedPrompt} aria-label="cancel">
+            ← cancel
+          </button>
 
-      <div class="unlock__caption mono">
-        <span>identity system · <b>p. 01</b></span>
-        <span class="unlock__caption-trail">bricolage grotesque · 800</span>
+          <label>
+            <div class="unlock__field-label">
+              <span>master_password</span>
+              <span>argon2id · aes-512</span>
+            </div>
+            <div class="unlock__field">
+              <input
+                bind:this={passwordInput}
+                bind:value={password}
+                autocomplete="current-password"
+                class="unlock__input"
+                type="password"
+                aria-label="master password"
+              />
+              <IconButton label="Password remains hidden" variant="ghost" disabled>
+                <Icon name="eye" size={14} />
+              </IconButton>
+            </div>
+          </label>
+
+          {#if errorMessage}
+            <div class="unlock__error mono" role="alert">{errorMessage}</div>
+          {/if}
+
+          <Button class="unlock__cta" variant="primary" type="submit" disabled={!canSubmit}>
+            <Icon name="key" size={12} sw={2} />
+            {busy ? 'working' : 'unlock_vault'}
+            <Kbd value="↵" />
+          </Button>
+
+          <div class="unlock__hints mono">
+            <span><Kbd value="↵" /> <b>unlock</b></span>
+            <span><Kbd value="⌘" />+<Kbd value="," /> settings</span>
+            <span><Kbd value="⌘" />+<Kbd value="O" /> other vault</span>
+          </div>
+
+          <div class="ds-hr"></div>
+
+          <div class="sealed__brand-meta mono sealed__panel-meta">
+            <span>argon2id · m=128 · t=3 · p=4</span>
+            <span>local_only · <b>ready</b></span>
+          </div>
+        </form>
       </div>
     </div>
+  {:else}
+    <div class="unlock">
+      <div class="unlock__left">
+        <div>
+          <div class="unlock__caption mono">
+            <span>v01 · 2026</span>
+            <span>identity · <b>arca</b></span>
+          </div>
+        </div>
 
-    <form
-      class="unlock__right"
-      onsubmit={(event) => {
-        event.preventDefault();
-        submit();
-      }}
-    >
-      <div class="unlock__mode-tabs" role="tablist" aria-label="Vault mode">
-        <button
-          type="button"
-          role="tab"
-          aria-selected={mode === 'open'}
-          class={mode === 'open' ? 'unlock__mode-tab unlock__mode-tab--active' : 'unlock__mode-tab'}
-          onclick={() => (mode = 'open')}
-        >
-          open
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={mode === 'create'}
-          class={mode === 'create' ? 'unlock__mode-tab unlock__mode-tab--active' : 'unlock__mode-tab'}
-          onclick={() => (mode = 'create')}
-        >
-          create
-        </button>
+        <div>
+          <Lockup size={112} />
+          <div class="unlock__brand-gap"></div>
+          <h1 id="unlock-title" class="unlock__lede">
+            the vault for what you <em>can't lose.</em><br />
+            kept where only you can reach it.
+          </h1>
+        </div>
+
+        <div class="unlock__caption mono">
+          <span>identity system · <b>p. 01</b></span>
+          <span class="unlock__caption-trail">bricolage grotesque · 800</span>
+        </div>
       </div>
 
-      {#if mode === 'create'}
+      <form
+        class="unlock__right"
+        onsubmit={(event) => {
+          event.preventDefault();
+          submit();
+        }}
+      >
+        <div class="unlock__mode-tabs" role="tablist" aria-label="Vault mode">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'open'}
+            class={mode === 'open' ? 'unlock__mode-tab unlock__mode-tab--active' : 'unlock__mode-tab'}
+            onclick={() => (mode = 'open')}
+          >
+            open
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'create'}
+            class={mode === 'create' ? 'unlock__mode-tab unlock__mode-tab--active' : 'unlock__mode-tab'}
+            onclick={() => (mode = 'create')}
+          >
+            create
+          </button>
+        </div>
+
+        {#if mode === 'create'}
+          <label>
+            <div class="unlock__field-label">
+              <span>vault_name</span>
+              <span>local_first · encrypted</span>
+            </div>
+            <div class="unlock__field unlock__field--compact">
+              <input bind:value={vaultName} autocomplete="off" class="unlock__input" spellcheck="false" />
+            </div>
+          </label>
+        {/if}
+
         <label>
           <div class="unlock__field-label">
-            <span>vault_name</span>
-            <span>local_first · encrypted</span>
+            <span>vault_path</span>
+            <span>{mode === 'open' ? 'existing vault' : 'new vault'}</span>
           </div>
           <div class="unlock__field unlock__field--compact">
-            <input bind:value={vaultName} autocomplete="off" class="unlock__input" spellcheck="false" />
+            <input
+              bind:value={path}
+              autocomplete="off"
+              class="unlock__input"
+              placeholder="/Users/you/.arca/vaults/primary.arca"
+              spellcheck="false"
+            />
           </div>
         </label>
-      {/if}
 
-      <label>
-        <div class="unlock__field-label">
-          <span>vault_path</span>
-          <span>{mode === 'open' ? 'existing vault' : 'new vault'}</span>
+        <label>
+          <div class="unlock__field-label">
+            <span>master_password</span>
+            <span>argon2id · aes-512</span>
+          </div>
+          <div class="unlock__field">
+            <input
+              bind:value={password}
+              autocomplete="current-password"
+              class="unlock__input"
+              type="password"
+              aria-label="master password"
+            />
+            <IconButton label="Password remains hidden" variant="ghost" disabled>
+              <Icon name="eye" size={14} />
+            </IconButton>
+          </div>
+        </label>
+
+        {#if errorMessage}
+          <div class="unlock__error mono" role="alert">{errorMessage}</div>
+        {/if}
+
+        <Button class="unlock__cta" variant="primary" type="submit" disabled={!canSubmit}>
+          <Icon name="key" size={12} sw={2} />
+          {busy ? 'working' : mode === 'open' ? 'unlock_vault' : 'create_vault'}
+          <Kbd value="↵" />
+        </Button>
+
+        <div class="unlock__hints mono">
+          <span><Kbd value="↵" /> <b>{mode === 'open' ? 'unlock' : 'create'}</b></span>
+          <span><Kbd value="⌘" />+<Kbd value="," /> settings</span>
+          <span><Kbd value="⌘" />+<Kbd value="O" /> other vault</span>
         </div>
-        <div class="unlock__field unlock__field--compact">
-          <input
-            bind:value={path}
-            autocomplete="off"
-            class="unlock__input"
-            placeholder="/Users/you/.arca/vaults/primary.arca"
-            spellcheck="false"
-          />
+
+        <div class="ds-hr"></div>
+
+        <div class="unlock__caption mono unlock__connection">
+          <span><span class="status__dot"></span> local_store · <b>ready</b></span>
+          <span>zero_knowledge · <b>enabled</b></span>
         </div>
-      </label>
-
-      <label>
-        <div class="unlock__field-label">
-          <span>master_password</span>
-          <span>argon2id · aes-512</span>
-        </div>
-        <div class="unlock__field">
-          <input
-            bind:value={password}
-            autocomplete="current-password"
-            class="unlock__input"
-            type="password"
-            aria-label="master password"
-          />
-          <IconButton label="Password remains hidden" variant="ghost" disabled>
-            <Icon name="eye" size={14} />
-          </IconButton>
-        </div>
-      </label>
-
-      {#if errorMessage}
-        <div class="unlock__error mono" role="alert">{errorMessage}</div>
-      {/if}
-
-      <Button class="unlock__cta" variant="primary" type="submit" disabled={!canSubmit}>
-        <Icon name="key" size={12} sw={2} />
-        {busy ? 'working' : mode === 'open' ? 'unlock_vault' : 'create_vault'}
-        <Kbd value="↵" />
-      </Button>
-
-      <div class="unlock__hints mono">
-        <span><Kbd value="↵" /> <b>{mode === 'open' ? 'unlock' : 'create'}</b></span>
-        <span><Kbd value="⌘" />+<Kbd value="," /> settings</span>
-        <span><Kbd value="⌘" />+<Kbd value="O" /> other vault</span>
-      </div>
-
-      <div class="ds-hr"></div>
-
-      <div class="unlock__caption mono unlock__connection">
-        <span><span class="status__dot"></span> local_store · <b>ready</b></span>
-        <span>zero_knowledge · <b>enabled</b></span>
-      </div>
-    </form>
-  </div>
+      </form>
+    </div>
+  {/if}
 </section>

--- a/apps/desktop/src/lib/components/VaultShell.svelte
+++ b/apps/desktop/src/lib/components/VaultShell.svelte
@@ -18,9 +18,8 @@
       vaultState.entries = [];
       vaultState.selectedEntry = null;
       vaultState.searchQuery = '';
-      vaultState.vaultName = '';
-      vaultState.vaultPath = '';
-      vaultState.lastSaved = null;
+      uiState.unlockSurface = vaultState.vaultPath ? 'sealed' : 'two-pane';
+      uiState.sealedPromptOpen = false;
       uiState.view = 'unlock';
     } catch (error) {
       errorMessage = messageFromError(error);

--- a/apps/desktop/src/lib/stores/ui.svelte.ts
+++ b/apps/desktop/src/lib/stores/ui.svelte.ts
@@ -8,6 +8,7 @@ export type ViewName =
   | 'audit'
   | 'shared';
 export type ThemeName = 'paper' | 'ink';
+export type UnlockSurface = 'two-pane' | 'sealed';
 
 export interface Notification {
   kind: 'info' | 'success' | 'warning' | 'error';
@@ -17,6 +18,8 @@ export interface Notification {
 export const uiState = $state({
   theme: 'paper' as ThemeName,
   view: 'unlock' as ViewName,
+  unlockSurface: 'two-pane' as UnlockSurface,
+  sealedPromptOpen: false,
   clipboardTimer: null as ReturnType<typeof setTimeout> | null,
   notification: null as Notification | null,
 });


### PR DESCRIPTION
## Summary
- Add the v0.2 sealed idle-lock surface as a second UnlockScreen variant.
- Keep cold start on the two-pane unlock screen, while post-lock state now preserves the non-secret vault path and enters sealed mode.
- Wire sealed click/Enter/Space opening, Escape/cancel collapse, delayed password focus, status-bar AUTH/SEALED transitions, and reduced-motion CSS.
- Suppress hardware-key/Face ID/TOTP UI; this remains UI-only with no Tauri command or vault-core changes.

## Validation
- Temporary browser preview confirmed the closed sealed screen, no TOTP/hardware-key text, status transition state, click-to-open, focus handoff, and Escape close before the in-app browser pane became unavailable.
- `pnpm --filter @arca/desktop build`
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`