### PR TITLE
Add Paper ink theme switch

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import UnlockScreen from './lib/components/UnlockScreen.svelte';
   import VaultShell from './lib/components/VaultShell.svelte';
   import { StatusBar, Tabs, WindowChrome, type TabItem } from './lib/components/chrome';
   import { vaultState } from './lib/stores/vault.svelte';
-  import { uiState, type ViewName } from './lib/stores/ui.svelte';
+  import { loadThemePreference, uiState, type ViewName } from './lib/stores/ui.svelte';
 
   const tabItems = $derived<TabItem[]>([
     { key: 'vault', label: 'vault', count: vaultState.entries.length },
@@ -62,6 +63,10 @@
 
     uiState.view = viewByTab[key] ?? 'list';
   }
+
+  onMount(() => {
+    loadThemePreference();
+  });
 </script>
 
 <main class="arca arca--desktop" data-theme={uiState.theme}>

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -1094,6 +1094,131 @@
 }
 
 /* ───────────────────────────────────────────────────────────
+   Settings
+   ─────────────────────────────────────────────────────────── */
+.settings-panel {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.settings-head {
+  padding: 18px 26px 14px;
+  border-bottom: 1px dashed var(--rule-dashed);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.settings-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 20px 26px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(240px, 0.8fr);
+  gap: 14px;
+  align-content: start;
+}
+.settings-group {
+  min-width: 0;
+  padding: 0;
+}
+.settings-group__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+.settings-group__eyebrow {
+  margin: 0 0 4px;
+  color: var(--text-3);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.settings-group h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 22px;
+  line-height: 1;
+  letter-spacing: 0;
+  color: var(--text);
+}
+.theme-switch {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+.theme-option {
+  min-width: 0;
+  min-height: 146px;
+  padding: 14px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 8px;
+  background: var(--bg-card);
+  color: var(--text);
+  cursor: pointer;
+  display: grid;
+  grid-template-rows: 1fr auto auto;
+  gap: 10px;
+  text-align: left;
+  transition: background .12s, border-color .12s, color .12s;
+}
+.theme-option:hover {
+  background: var(--bg-card-2);
+  border-color: var(--text-3);
+}
+.theme-option--active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.theme-option__swatches {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+.theme-option__swatch {
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 4px;
+}
+.theme-option__label {
+  font-family: var(--font-display);
+  font-size: 24px;
+  line-height: 1;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+.theme-option__meta {
+  color: var(--text-3);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.settings-row {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-top: 1px dashed var(--rule-dashed);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--text-3);
+}
+.settings-row b {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-2);
+  font-weight: 500;
+}
+
+/* ───────────────────────────────────────────────────────────
    Entry detail
    ─────────────────────────────────────────────────────────── */
 .detail-head {

--- a/apps/desktop/src/lib/components/VaultShell.svelte
+++ b/apps/desktop/src/lib/components/VaultShell.svelte
@@ -3,6 +3,7 @@
   import { vaultState } from '../stores/vault.svelte';
   import { uiState } from '../stores/ui.svelte';
   import { EntryDetail } from './detail';
+  import { SettingsPanel } from './settings';
   import { EntryList } from './vault';
 
   let busy = $state(false);
@@ -48,6 +49,8 @@
   <EntryDetail />
 {:else if uiState.view === 'list'}
   <EntryList />
+{:else if uiState.view === 'settings'}
+  <SettingsPanel />
 {:else}
   <section class="vault-placeholder" aria-labelledby="vault-placeholder-title">
     <p class="vault-placeholder__eyebrow">placeholder</p>

--- a/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import { setThemePreference, uiState, type ThemeName } from '../../stores/ui.svelte';
+  import { Button, Kbd, Tag } from '../primitives';
+
+  type ThemeOption = {
+    key: ThemeName;
+    label: string;
+    surface: string;
+    accent: string;
+    meta: string;
+  };
+
+  const themeOptions: ThemeOption[] = [
+    {
+      key: 'paper',
+      label: 'paper',
+      surface: '#EBE5D6',
+      accent: '#C8553D',
+      meta: 'default',
+    },
+    {
+      key: 'ink',
+      label: 'ink',
+      surface: '#14110D',
+      accent: '#D86A52',
+      meta: 'alternate',
+    },
+  ];
+
+  function selectTheme(theme: ThemeName) {
+    setThemePreference(theme);
+  }
+</script>
+
+<section class="settings-panel" aria-labelledby="settings-title">
+  <div class="settings-head">
+    <div>
+      <div class="detail__crumbs mono">vault &nbsp;/&nbsp; <b>settings</b></div>
+      <h1 id="settings-title" class="detail__title">settings<em>.</em></h1>
+      <div class="detail__meta mono">
+        <Tag value="appearance" />
+        <span>theme · <b>{uiState.theme}</b></span>
+        <span>surface · <b>{uiState.theme === 'paper' ? 'warm' : 'dark'}</b></span>
+      </div>
+    </div>
+    <Button variant="ghost" size="sm" onclick={() => (uiState.view = 'list')}>back_to_vault</Button>
+  </div>
+
+  <div class="settings-body">
+    <section class="settings-group" aria-labelledby="settings-theme-title">
+      <div class="settings-group__head">
+        <div>
+          <p class="settings-group__eyebrow mono">appearance</p>
+          <h2 id="settings-theme-title">theme</h2>
+        </div>
+        <Tag variant={uiState.theme === 'ink' ? 'ink' : 'paper'} value={uiState.theme} />
+      </div>
+
+      <div class="theme-switch" role="group" aria-label="Theme">
+        {#each themeOptions as option}
+          <button
+            type="button"
+            class={uiState.theme === option.key ? 'theme-option theme-option--active' : 'theme-option'}
+            aria-pressed={uiState.theme === option.key}
+            onclick={() => selectTheme(option.key)}
+          >
+            <span class="theme-option__swatches" aria-hidden="true">
+              <span class="theme-option__swatch" style:background={option.surface}></span>
+              <span class="theme-option__swatch" style:background={option.accent}></span>
+            </span>
+            <span class="theme-option__label">{option.label}</span>
+            <span class="theme-option__meta mono">{option.meta}</span>
+          </button>
+        {/each}
+      </div>
+    </section>
+
+    <section class="settings-group settings-group--compact" aria-labelledby="settings-session-title">
+      <div class="settings-group__head">
+        <div>
+          <p class="settings-group__eyebrow mono">session</p>
+          <h2 id="settings-session-title">lock</h2>
+        </div>
+        <Tag variant="vault" value="15m" />
+      </div>
+
+      <div class="settings-row">
+        <span>auto_lock</span>
+        <b>15 minutes</b>
+      </div>
+      <div class="settings-row">
+        <span>clipboard_clear</span>
+        <b>30 seconds</b>
+      </div>
+      <div class="settings-row">
+        <span>shortcut</span>
+        <b><Kbd value="⌘" /> + <Kbd value="," /></b>
+      </div>
+    </section>
+  </div>
+</section>

--- a/apps/desktop/src/lib/components/settings/index.ts
+++ b/apps/desktop/src/lib/components/settings/index.ts
@@ -1,0 +1,1 @@
+export { default as SettingsPanel } from './SettingsPanel.svelte';

--- a/apps/desktop/src/lib/stores/ui.svelte.ts
+++ b/apps/desktop/src/lib/stores/ui.svelte.ts
@@ -9,6 +9,7 @@ export type ViewName =
   | 'shared';
 export type ThemeName = 'paper' | 'ink';
 export type UnlockSurface = 'two-pane' | 'sealed';
+const THEME_STORAGE_KEY = 'arca.theme';
 
 export interface Notification {
   kind: 'info' | 'success' | 'warning' | 'error';
@@ -23,3 +24,33 @@ export const uiState = $state({
   clipboardTimer: null as ReturnType<typeof setTimeout> | null,
   notification: null as Notification | null,
 });
+
+export function coerceThemeName(value: string | null | undefined): ThemeName {
+  return value === 'ink' ? 'ink' : 'paper';
+}
+
+export function loadThemePreference() {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    uiState.theme = coerceThemeName(localStorage.getItem(THEME_STORAGE_KEY));
+  } catch {
+    uiState.theme = 'paper';
+  }
+}
+
+export function setThemePreference(theme: ThemeName) {
+  uiState.theme = theme;
+
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // Theme persistence is best-effort; the active in-memory theme still applies.
+  }
+}


### PR DESCRIPTION
## Summary
- Add a Paper-style settings screen with a Paper/Ink appearance switch.
- Wire the switch to the root `data-theme` attribute and persist the preference in frontend storage.
- Map any legacy/non-ink theme value back to Paper, keeping Paper as the default.
- Keep this UI-only: no Tauri command, IPC, vault-core, or backend changes.

## Validation
- Browser verification at `http://127.0.0.1:5173/preview-settings.html`: Paper and Ink both render, Ink changes CSS tokens, and the selection persists through reload.
- `pnpm --filter @arca/desktop build`
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`