### PR TITLE
Polish Paper UI interactions

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -135,6 +135,31 @@
   overflow: hidden;
   padding: 0;
 }
+.app-content > section,
+.app-content > .unlock-screen {
+  animation: arca-view-fade 120ms ease-out;
+}
+@keyframes arca-view-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.tab:focus-visible,
+.btn:focus-visible,
+.iconbtn:focus-visible,
+.filter:focus-visible,
+.row:focus-visible,
+.row__action:focus-visible,
+.search:focus-within,
+.unlock__mode-tab:focus-visible,
+.unlock__field:focus-within,
+.sealed__cta:focus-visible,
+.sealed__panel-back:focus-visible,
+.detail__crumb-link:focus-visible,
+.theme-option:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 /* ───────────────────────────────────────────────────────────
    Window chrome (desktop)
@@ -496,6 +521,11 @@
   transition: border-color .12s, background .12s;
 }
 .search:hover { border-color: var(--rule-strong); }
+.search:focus-within {
+  border-color: var(--accent);
+  background: var(--bg-card-2);
+  color: var(--text);
+}
 .search--focus {
   border-color: var(--accent);
   background: var(--bg-card-2);
@@ -538,7 +568,10 @@
   margin-left: 3px;
   animation: arca-blink 1.2s steps(2,end) infinite;
 }
-@keyframes arca-blink { 50% { opacity: 0.15; } }
+@keyframes arca-blink {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 0.15; }
+}
 .search__hint {
   font-family: var(--font-mono);
   font-size: 9px;
@@ -1077,6 +1110,7 @@
   color: var(--accent);
   font-size: 10px;
   letter-spacing: 0.04em;
+  animation: arca-shake 200ms linear;
 }
 .unlock__hints {
   font-family: var(--font-mono);
@@ -1216,6 +1250,18 @@
   gap: 5px;
   color: var(--text-2);
   font-weight: 500;
+}
+
+.error {
+  animation: arca-shake 200ms linear;
+}
+@keyframes arca-shake {
+  0%, 100% { transform: translateX(0); }
+  16% { transform: translateX(-4px); }
+  33% { transform: translateX(4px); }
+  50% { transform: translateX(-4px); }
+  66% { transform: translateX(4px); }
+  83% { transform: translateX(-4px); }
 }
 
 /* ───────────────────────────────────────────────────────────
@@ -1553,6 +1599,15 @@
 .arca--mobile .note-panel { grid-row: span 1; padding: 14px 16px; font-size: 12.5px; }
 .arca--mobile .field { padding: 11px 14px; grid-template-columns: 76px 1fr auto; }
 .arca--mobile .field__v { font-size: 12px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .app-content > section,
+  .app-content > .unlock-screen,
+  .unlock__error,
+  .error {
+    animation-duration: 0ms;
+  }
+}
 
 /* ───────────────────────────────────────────────────────────
    Modal — the "are you sure" pattern from lipgloss

--- a/apps/desktop/src/lib/clipboard.ts
+++ b/apps/desktop/src/lib/clipboard.ts
@@ -1,0 +1,35 @@
+export async function writeClipboardText(value: string): Promise<boolean> {
+  if (!value) {
+    return false;
+  }
+
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+  } catch {
+    // Fall through to the textarea fallback for webviews without clipboard grants.
+  }
+
+  try {
+    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const textarea = document.createElement('textarea');
+
+    textarea.value = value;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    textarea.style.pointerEvents = 'none';
+    document.body.append(textarea);
+    textarea.select();
+
+    const copied = document.execCommand('copy');
+    textarea.remove();
+    activeElement?.focus();
+
+    return copied;
+  } catch {
+    return false;
+  }
+}

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import type { EntryDto } from '../../ipc';
+  import { writeClipboardText } from '../../clipboard';
   import { Icon } from '../icons';
   import { Entropy, IconButton, Kbd } from '../primitives';
 
@@ -10,10 +12,38 @@
   }>();
 
   const passwordMask = '●●●●●●●●●●●●●●●●●●●●●●●●';
+  let copied = $state<'username' | 'password' | null>(null);
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
   const url = $derived(entry.url?.trim() || 'not_set');
   const username = $derived(entry.username.trim() || 'not_set');
+  const password = $derived(entry.password?.trim() || '');
   const entropyBits = $derived(Math.max(72, Math.min(112, entry.title.length * 6 + entry.username.length * 4 + 48)));
   const entropyFilled = $derived(Math.max(10, Math.min(16, Math.round(entropyBits / 7))));
+
+  onDestroy(() => {
+    if (copyTimer) {
+      clearTimeout(copyTimer);
+    }
+  });
+
+  async function copyValue(kind: 'username' | 'password', value: string) {
+    if (!value) {
+      return;
+    }
+
+    await writeClipboardText(value);
+    copied = kind;
+
+    if (copyTimer) {
+      clearTimeout(copyTimer);
+    }
+
+    copyTimer = setTimeout(() => {
+      copied = null;
+      copyTimer = null;
+    }, 1500);
+  }
 </script>
 
 <div class="fields">
@@ -31,8 +61,17 @@
     <div class="field__k">user <Kbd value="U" /></div>
     <div class="field__v">{username}</div>
     <div class="field__actions">
-      <IconButton label={`Copy ${entry.title} username`}>
-        <Icon name="copy" size={13} />
+      <IconButton
+        label={copied === 'username' ? 'Username copied' : `Copy ${entry.title} username`}
+        variant={copied === 'username' ? 'accent' : 'default'}
+        disabled={!entry.username.trim()}
+        onclick={() => copyValue('username', entry.username)}
+      >
+        {#if copied === 'username'}
+          ✓
+        {:else}
+          <Icon name="copy" size={13} />
+        {/if}
       </IconButton>
     </div>
   </div>
@@ -44,7 +83,18 @@
       <IconButton label={`Reveal ${entry.title} password`}>
         <Icon name="eye" size={13} />
       </IconButton>
-      <IconButton variant="accent" label={`Copy ${entry.title} password`}>✓</IconButton>
+      <IconButton
+        variant={copied === 'password' ? 'accent' : 'default'}
+        label={copied === 'password' ? 'Password copied' : `Copy ${entry.title} password`}
+        disabled={!password}
+        onclick={() => copyValue('password', password)}
+      >
+        {#if copied === 'password'}
+          ✓
+        {:else}
+          <Icon name="copy" size={13} />
+        {/if}
+      </IconButton>
     </div>
   </div>
 

--- a/apps/desktop/src/lib/components/vault/EntryRow.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryRow.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import type { EntryDto } from '../../ipc';
+  import { writeClipboardText } from '../../clipboard';
   import { Icon, type IconName } from '../icons';
   import { Tag } from '../primitives';
 
@@ -18,6 +20,15 @@
   const iconName = $derived(iconForEntry(entry));
   const weak = $derived(Boolean(entry.tags.find((tag) => normalize(tag) === 'weak')));
   const subtitle = $derived(entry.username || entry.url || entry.id);
+  const copyValue = $derived(entry.username || entry.url || entry.title);
+  let copied = $state(false);
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  onDestroy(() => {
+    if (copyTimer) {
+      clearTimeout(copyTimer);
+    }
+  });
 
   function iconForEntry(candidate: EntryDto): IconName {
     const haystack = `${candidate.title} ${candidate.url ?? ''} ${candidate.tags.join(' ')}`.toLowerCase();
@@ -63,6 +74,26 @@
       onselect?.(entry);
     }
   }
+
+  async function handleCopy(event: MouseEvent) {
+    event.stopPropagation();
+
+    if (!copyValue) {
+      return;
+    }
+
+    await writeClipboardText(copyValue);
+    copied = true;
+
+    if (copyTimer) {
+      clearTimeout(copyTimer);
+    }
+
+    copyTimer = setTimeout(() => {
+      copied = false;
+      copyTimer = null;
+    }, 1500);
+  }
 </script>
 
 <div
@@ -98,12 +129,16 @@
       <Icon name="eye" size={13} sw={1.5} />
     </button>
     <button
-      class={selected ? 'row__action row__action--ok' : 'row__action'}
+      class={copied || selected ? 'row__action row__action--ok' : 'row__action'}
       type="button"
-      aria-label={`Copy ${entry.title}`}
-      onclick={(event) => event.stopPropagation()}
+      aria-label={copied ? `${entry.title} copied` : `Copy ${entry.title}`}
+      onclick={handleCopy}
     >
-      <Icon name="copy" size={13} sw={1.5} />
+      {#if copied}
+        ✓
+      {:else}
+        <Icon name="copy" size={13} sw={1.5} />
+      {/if}
     </button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Add keyboard focus-visible rings across Paper controls, rows, tabs, fields, and theme options.
- Tighten motion polish with 120ms view fade, explicit caret opacity keyframes, and reduced-motion guarded error shake.
- Add copy confirmation timing for vault rows and entry detail fields: best-effort clipboard write, text swap to `✓`, reset after 1500ms.
- Keep password copy disabled unless a full entry payload actually includes password material.

## Validation
- Browser verification at `http://127.0.0.1:5173/preview-polish.html`: focus/motion rules present, detail copy feedback swaps and resets, row copy feedback swaps.
- `pnpm --filter @arca/desktop build`
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

## Notes
- UI-only change: no Tauri command, IPC, vault-core, or backend changes.