### PR TITLE
superseded: feat: add desktop audit screen

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -1252,6 +1252,125 @@
   font-weight: 500;
 }
 
+/* ───────────────────────────────────────────────────────────
+   Audit
+   ─────────────────────────────────────────────────────────── */
+.audit-panel {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.audit-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: 16px 26px;
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 16px;
+  align-content: start;
+}
+.audit-summary {
+  display: grid;
+  gap: 10px;
+}
+.audit-summary div {
+  min-height: 74px;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  background: var(--bg-card);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.audit-summary span,
+.audit-finding__severity,
+.audit-finding__meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.audit-summary span {
+  color: var(--text-3);
+}
+.audit-summary b {
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: 28px;
+  line-height: 1;
+}
+.audit-list {
+  min-width: 0;
+  display: grid;
+  gap: 8px;
+  align-content: start;
+}
+.audit-finding {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  padding: 10px 12px;
+  text-align: left;
+  transition: background .12s, border-color .12s;
+}
+.audit-finding:hover {
+  background: var(--bg-card);
+  border-color: var(--rule-strong);
+}
+.audit-finding__severity {
+  color: var(--text-3);
+}
+.audit-finding__severity--high { color: var(--accent); }
+.audit-finding__severity--medium { color: var(--vault); }
+.audit-finding__main {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+.audit-finding__main b {
+  overflow: hidden;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.audit-finding__main span {
+  overflow: hidden;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.audit-finding__meta {
+  color: var(--text-3);
+  text-transform: lowercase;
+  white-space: nowrap;
+}
+.audit-empty {
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+.audit-empty span {
+  color: var(--accent);
+}
+
 .error {
   animation: arca-shake 200ms linear;
 }
@@ -1595,6 +1714,20 @@
   padding: 12px 20px 16px;
   grid-template-columns: 1fr;
   gap: 10px;
+}
+.arca--mobile .audit-body {
+  padding: 12px 20px 16px;
+  grid-template-columns: 1fr;
+}
+.arca--mobile .audit-summary {
+  grid-template-columns: repeat(3, 1fr);
+}
+.arca--mobile .audit-finding {
+  grid-template-columns: 1fr auto;
+}
+.arca--mobile .audit-finding__severity,
+.arca--mobile .audit-finding__meta {
+  display: none;
 }
 .arca--mobile .note-panel { grid-row: span 1; padding: 14px 16px; font-size: 12.5px; }
 .arca--mobile .field { padding: 11px 14px; grid-template-columns: 76px 1fr auto; }

--- a/apps/desktop/src/lib/components/VaultShell.svelte
+++ b/apps/desktop/src/lib/components/VaultShell.svelte
@@ -2,6 +2,7 @@
   import { lockVault } from '../ipc';
   import { vaultState } from '../stores/vault.svelte';
   import { uiState } from '../stores/ui.svelte';
+  import { AuditPanel } from './audit';
   import { EntryDetail } from './detail';
   import { SettingsPanel } from './settings';
   import { EntryList } from './vault';
@@ -51,6 +52,8 @@
   <EntryList />
 {:else if uiState.view === 'settings'}
   <SettingsPanel />
+{:else if uiState.view === 'audit'}
+  <AuditPanel />
 {:else}
   <section class="vault-placeholder" aria-labelledby="vault-placeholder-title">
     <p class="vault-placeholder__eyebrow">placeholder</p>

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+  import type { EntryDto } from '../../ipc';
+  import { uiState } from '../../stores/ui.svelte';
+  import { vaultState } from '../../stores/vault.svelte';
+  import { Icon } from '../icons';
+  import { Button, Tag } from '../primitives';
+
+  type AuditSeverity = 'high' | 'medium' | 'low';
+
+  interface AuditFinding {
+    key: string;
+    severity: AuditSeverity;
+    title: string;
+    entry: EntryDto;
+    meta: string;
+  }
+
+  const findings = $derived(buildFindings(vaultState.entries));
+  const highCount = $derived(findings.filter((finding) => finding.severity === 'high').length);
+  const mediumCount = $derived(findings.filter((finding) => finding.severity === 'medium').length);
+  const lowCount = $derived(findings.filter((finding) => finding.severity === 'low').length);
+  const auditScore = $derived(scoreFor(vaultState.entries.length, findings.length, highCount));
+
+  function openEntry(entry: EntryDto) {
+    vaultState.selectedEntry = entry;
+    uiState.view = 'detail';
+  }
+
+  function buildFindings(entries: EntryDto[]): AuditFinding[] {
+    const results: AuditFinding[] = [];
+    const usernames = groupBy(entries, (entry) => normalize(entry.username));
+    const loadedPasswords = groupBy(
+      entries.filter((entry) => entry.password),
+      (entry) => entry.password ?? '',
+    );
+
+    for (const entry of entries) {
+      if (!entry.url) {
+        results.push(finding('missing-url', 'low', 'missing_url', entry, 'metadata'));
+      }
+
+      if (entry.tags.length === 0) {
+        results.push(finding('untagged', 'low', 'untagged', entry, 'metadata'));
+      }
+
+      if (isStale(entry.updatedAt)) {
+        results.push(finding('stale', 'medium', 'stale_entry', entry, modified(entry)));
+      }
+
+      if (entry.username && (usernames.get(normalize(entry.username))?.length ?? 0) > 1) {
+        results.push(finding('duplicate-username', 'medium', 'duplicate_username', entry, entry.username));
+      }
+
+      if (entry.password && entry.password.length < 12) {
+        results.push(finding('weak-password', 'high', 'weak_password', entry, 'loaded_secret'));
+      }
+
+      if (entry.password && (loadedPasswords.get(entry.password)?.length ?? 0) > 1) {
+        results.push(finding('reused-password', 'high', 'reused_password', entry, 'loaded_secret'));
+      }
+    }
+
+    return results.sort((a, b) => severityRank(a.severity) - severityRank(b.severity) || a.title.localeCompare(b.title));
+  }
+
+  function finding(
+    type: string,
+    severity: AuditSeverity,
+    title: string,
+    entry: EntryDto,
+    meta: string,
+  ): AuditFinding {
+    return {
+      key: `${type}:${entry.id}`,
+      severity,
+      title,
+      entry,
+      meta,
+    };
+  }
+
+  function groupBy(entries: EntryDto[], keyFor: (entry: EntryDto) => string): Map<string, EntryDto[]> {
+    const groups = new Map<string, EntryDto[]>();
+
+    for (const entry of entries) {
+      const key = keyFor(entry);
+
+      if (!key) {
+        continue;
+      }
+
+      groups.set(key, [...(groups.get(key) ?? []), entry]);
+    }
+
+    return groups;
+  }
+
+  function scoreFor(entryCount: number, findingCount: number, high: number): string {
+    if (entryCount === 0) {
+      return '0';
+    }
+
+    return Math.max(0, 100 - high * 18 - findingCount * 4).toString();
+  }
+
+  function isStale(updatedAt: string): boolean {
+    const time = Date.parse(updatedAt);
+
+    if (Number.isNaN(time)) {
+      return false;
+    }
+
+    return Date.now() - time > 1000 * 60 * 60 * 24 * 180;
+  }
+
+  function modified(entry: EntryDto): string {
+    const time = Date.parse(entry.updatedAt);
+
+    if (Number.isNaN(time)) {
+      return 'unknown';
+    }
+
+    return new Date(time).toISOString().slice(0, 10);
+  }
+
+  function normalize(value: string): string {
+    return value.trim().toLowerCase();
+  }
+
+  function severityRank(severity: AuditSeverity): number {
+    return severity === 'high' ? 0 : severity === 'medium' ? 1 : 2;
+  }
+</script>
+
+<section class="audit-panel" aria-labelledby="audit-title">
+  <div class="detail-head">
+    <div class="detail__title-wrap">
+      <div class="detail__crumbs mono">vault &nbsp;/&nbsp; <b>audit</b></div>
+      <h1 id="audit-title" class="detail__title">audit<em>.</em></h1>
+      <div class="detail__meta mono">
+        <Tag value={`${auditScore}/100`} />
+        <span>entries · <b>{vaultState.entries.length}</b></span>
+        <span>findings · <b>{findings.length}</b></span>
+      </div>
+    </div>
+    <div class="detail__actions">
+      <Button variant="ghost" size="sm" onclick={() => (uiState.view = 'list')}>back_to_vault</Button>
+    </div>
+  </div>
+
+  <div class="audit-body">
+    <section class="audit-summary" aria-label="Audit summary">
+      <div>
+        <span>high</span>
+        <b>{highCount}</b>
+      </div>
+      <div>
+        <span>medium</span>
+        <b>{mediumCount}</b>
+      </div>
+      <div>
+        <span>low</span>
+        <b>{lowCount}</b>
+      </div>
+    </section>
+
+    <div class="audit-list" role="list">
+      {#if findings.length > 0}
+        {#each findings as finding (finding.key)}
+          <button type="button" class="audit-finding" onclick={() => openEntry(finding.entry)}>
+            <span class={`audit-finding__severity audit-finding__severity--${finding.severity}`}>
+              {finding.severity}
+            </span>
+            <span class="audit-finding__main">
+              <b>{finding.title}</b>
+              <span>{finding.entry.title}</span>
+            </span>
+            <span class="audit-finding__meta mono">{finding.meta}</span>
+            <Icon name="external" size={12} />
+          </button>
+        {/each}
+      {:else}
+        <div class="audit-empty">
+          <span>&gt;</span>
+          no_findings
+        </div>
+      {/if}
+    </div>
+  </div>
+</section>

--- a/apps/desktop/src/lib/components/audit/index.ts
+++ b/apps/desktop/src/lib/components/audit/index.ts
@@ -1,0 +1,1 @@
+export { default as AuditPanel } from './AuditPanel.svelte';


### PR DESCRIPTION
Superseded during branch naming cleanup. Replacement PR: #68 (`feat/audit-screen-ui`). Please review and merge the replacement PR instead.