### PR TITLE
feat: add desktop entry delete flow

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -1327,6 +1327,26 @@
   display: flex;
   flex-direction: column;
 }
+.detail-confirm {
+  margin: 14px 26px 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+.detail-confirm__copy {
+  margin: -6px 0 0;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.03em;
+}
+.detail-confirm__error {
+  margin-top: 10px;
+  color: var(--accent);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+}
 
 /* Filled "moss" panel — note/content (the lipgloss-purple equivalent) */
 .note-panel {
@@ -1595,6 +1615,16 @@
   padding: 12px 20px 16px;
   grid-template-columns: 1fr;
   gap: 10px;
+}
+.arca--mobile .detail-confirm {
+  margin: 12px 20px 0;
+  flex-direction: column;
+}
+.arca--mobile .detail-confirm .modal__row {
+  width: 100%;
+}
+.arca--mobile .detail-confirm .btn {
+  flex: 1;
 }
 .arca--mobile .note-panel { grid-row: span 1; padding: 14px 16px; font-size: 12.5px; }
 .arca--mobile .field { padding: 11px 14px; grid-template-columns: 76px 1fr auto; }

--- a/apps/desktop/src/lib/components/detail/EntryDetail.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryDetail.svelte
@@ -106,7 +106,7 @@
       <div
         class="detail-confirm modal"
         role="alertdialog"
-        aria-modal="false"
+        aria-modal="true"
         aria-labelledby="delete-entry-title"
         aria-describedby="delete-entry-message"
       >

--- a/apps/desktop/src/lib/components/detail/EntryDetail.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { EntryDto } from '../../ipc';
+  import { deleteEntry, type EntryDto } from '../../ipc';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
@@ -9,6 +9,9 @@
   import NotePanel from './NotePanel.svelte';
 
   const entry = $derived(vaultState.selectedEntry ?? vaultState.entries[0] ?? null);
+  let confirmDeleteOpen = $state(false);
+  let deleteBusy = $state(false);
+  let deleteError = $state('');
 
   function backToList() {
     uiState.view = 'list';
@@ -16,6 +19,37 @@
 
   function editEntry() {
     uiState.view = 'edit';
+  }
+
+  function requestDelete() {
+    confirmDeleteOpen = true;
+    deleteError = '';
+  }
+
+  function cancelDelete() {
+    confirmDeleteOpen = false;
+    deleteError = '';
+  }
+
+  async function confirmDelete(entry: EntryDto) {
+    deleteBusy = true;
+    deleteError = '';
+
+    try {
+      await deleteEntry(entry.id);
+      vaultState.entries = vaultState.entries.filter((item) => item.id !== entry.id);
+
+      if (vaultState.selectedEntry?.id === entry.id) {
+        vaultState.selectedEntry = null;
+      }
+
+      vaultState.lastSaved = new Date();
+      uiState.view = 'list';
+    } catch (error) {
+      deleteError = messageFromError(error);
+    } finally {
+      deleteBusy = false;
+    }
   }
 
   function modified(entry: EntryDto): string {
@@ -26,6 +60,14 @@
     }
 
     return new Date(time).toISOString().slice(0, 16).replace('T', ' ');
+  }
+
+  function messageFromError(error: unknown): string {
+    if (typeof error === 'object' && error !== null && 'message' in error) {
+      return String(error.message);
+    }
+
+    return 'Unable to delete entry';
   }
 </script>
 
@@ -54,11 +96,38 @@
           <Icon name="share" size={12} />
           share
         </Button>
-        <IconButton label={`Delete ${entry.title}`}>
+        <IconButton label={`Delete ${entry.title}`} onclick={requestDelete} disabled={deleteBusy}>
           <Icon name="trash" size={13} />
         </IconButton>
       </div>
     </div>
+
+    {#if confirmDeleteOpen}
+      <div
+        class="detail-confirm modal"
+        role="alertdialog"
+        aria-modal="false"
+        aria-labelledby="delete-entry-title"
+        aria-describedby="delete-entry-message"
+      >
+        <div>
+          <div id="delete-entry-title" class="modal__q">delete_entry</div>
+          <p id="delete-entry-message" class="detail-confirm__copy">
+            {entry.title} will be removed from this vault.
+          </p>
+          {#if deleteError}
+            <div class="detail-confirm__error mono error" role="alert">{deleteError}</div>
+          {/if}
+        </div>
+        <div class="modal__row">
+          <Button variant="ghost" size="sm" onclick={cancelDelete} disabled={deleteBusy}>cancel</Button>
+          <Button variant="danger" size="sm" onclick={() => confirmDelete(entry)} disabled={deleteBusy}>
+            <Icon name="trash" size={12} />
+            {deleteBusy ? 'deleting' : 'delete'}
+          </Button>
+        </div>
+      </div>
+    {/if}
 
     <div class="detail-body">
       <NotePanel notes={entry.notes} tags={entry.tags} />


### PR DESCRIPTION
## Summary

- Adds a confirmation flow for deleting entries from the desktop detail screen.
- Calls the existing delete-entry Tauri command.
- Removes the deleted entry from local state and returns to the vault list after success.

## Validation

- pnpm typecheck
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an entry deletion confirmation dialog with clear “cancel” and “delete” actions.
  * Deletion now shows a busy state while processing and prevents repeated submissions.
  * Displays error messaging if deletion fails.
* **Style / UX Improvements**
  * Refined the confirmation-area layout, spacing, typography, and error styling.
  * Improved mobile responsiveness by switching the confirmation layout to a vertical arrangement and ensuring buttons/rows fit correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->