### PR TITLE
feat: add desktop entry create edit form

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -1328,6 +1328,99 @@
   flex-direction: column;
 }
 
+.entry-form {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.entry-form__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: 16px 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.entry-form__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  align-content: start;
+  max-width: 980px;
+}
+.entry-form__field {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+}
+.entry-form__field--wide { grid-column: 1 / -1; }
+.entry-form__field span,
+.entry-form__hint,
+.entry-form__error {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+}
+.entry-form__field span {
+  color: var(--text-3);
+  text-transform: lowercase;
+}
+.entry-form__field input,
+.entry-form__field textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--bg-card);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  outline: none;
+  transition: border-color .12s, background .12s;
+}
+.entry-form__field input {
+  height: 38px;
+  padding: 0 12px;
+}
+.entry-form__field textarea {
+  min-height: 140px;
+  resize: vertical;
+  padding: 11px 12px;
+  line-height: 1.5;
+}
+.entry-form__field input:focus,
+.entry-form__field textarea:focus {
+  border-color: var(--accent);
+  background: var(--bg-card-2);
+}
+.entry-form__error {
+  max-width: 980px;
+  padding: 10px 12px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.entry-form__footer {
+  max-width: 980px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 2px;
+}
+.entry-form__hint {
+  color: var(--text-3);
+}
+.entry-form__hint b {
+  color: var(--text-2);
+  font-weight: 500;
+}
+
 /* Filled "moss" panel — note/content (the lipgloss-purple equivalent) */
 .note-panel {
   background: var(--vault);
@@ -1595,6 +1688,20 @@
   padding: 12px 20px 16px;
   grid-template-columns: 1fr;
   gap: 10px;
+}
+.arca--mobile .entry-form__body {
+  padding: 12px 20px 16px;
+}
+.arca--mobile .entry-form__grid {
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+.arca--mobile .entry-form__footer {
+  align-items: stretch;
+  flex-direction: column;
+}
+.arca--mobile .entry-form__footer .btn {
+  width: 100%;
 }
 .arca--mobile .note-panel { grid-row: span 1; padding: 14px 16px; font-size: 12.5px; }
 .arca--mobile .field { padding: 11px 14px; grid-template-columns: 76px 1fr auto; }

--- a/apps/desktop/src/lib/components/VaultShell.svelte
+++ b/apps/desktop/src/lib/components/VaultShell.svelte
@@ -2,7 +2,7 @@
   import { lockVault } from '../ipc';
   import { vaultState } from '../stores/vault.svelte';
   import { uiState } from '../stores/ui.svelte';
-  import { EntryDetail } from './detail';
+  import { EntryDetail, EntryForm } from './detail';
   import { SettingsPanel } from './settings';
   import { EntryList } from './vault';
 
@@ -47,6 +47,8 @@
 
 {#if uiState.view === 'detail'}
   <EntryDetail />
+{:else if uiState.view === 'edit'}
+  <EntryForm />
 {:else if uiState.view === 'list'}
   <EntryList />
 {:else if uiState.view === 'settings'}

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  import { createEntry, updateEntry, type EntryDto } from '../../ipc';
+  import { uiState } from '../../stores/ui.svelte';
+  import { vaultState } from '../../stores/vault.svelte';
+  import { Icon } from '../icons';
+  import { Button, Tag } from '../primitives';
+
+  const editingEntry = $derived(vaultState.selectedEntry);
+  const mode = $derived(editingEntry ? 'edit' : 'create');
+  const titleText = $derived(mode === 'edit' ? 'edit_entry' : 'new_entry');
+  const submitText = $derived(mode === 'edit' ? 'save_changes' : 'create_entry');
+
+  let title = $state('');
+  let username = $state('');
+  let password = $state('');
+  let url = $state('');
+  let notes = $state('');
+  let tags = $state('');
+  let busy = $state(false);
+  let errorMessage = $state('');
+  let loadedEntryId = $state<string | null>(null);
+
+  const canSubmit = $derived(title.trim().length > 0 && password.length > 0 && !busy);
+
+  $effect(() => {
+    const entry = editingEntry;
+    const entryId = entry?.id ?? null;
+
+    if (loadedEntryId === entryId) {
+      return;
+    }
+
+    loadedEntryId = entryId;
+    title = entry?.title ?? '';
+    username = entry?.username ?? '';
+    password = entry?.password ?? '';
+    url = entry?.url ?? '';
+    notes = entry?.notes ?? '';
+    tags = entry?.tags.join(', ') ?? '';
+    errorMessage = '';
+  });
+
+  async function submit() {
+    if (!canSubmit) {
+      return;
+    }
+
+    busy = true;
+    errorMessage = '';
+
+    try {
+      const payload = {
+        title: title.trim(),
+        username: username.trim(),
+        password,
+        url: optionalText(url),
+        notes: optionalText(notes),
+        tags: parseTags(tags),
+      };
+      const saved =
+        mode === 'edit' && editingEntry
+          ? await updateEntry(editingEntry.id, payload)
+          : await createEntry(payload);
+
+      applySavedEntry(saved);
+      vaultState.lastSaved = new Date(saved.updatedAt);
+      uiState.view = 'detail';
+    } catch (error) {
+      errorMessage = messageFromError(error);
+    } finally {
+      busy = false;
+    }
+  }
+
+  function applySavedEntry(entry: EntryDto) {
+    const existingIndex = vaultState.entries.findIndex((item) => item.id === entry.id);
+
+    if (existingIndex === -1) {
+      vaultState.entries = [entry, ...vaultState.entries];
+    } else {
+      vaultState.entries = vaultState.entries.map((item) => (item.id === entry.id ? entry : item));
+    }
+
+    vaultState.selectedEntry = entry;
+  }
+
+  function cancel() {
+    uiState.view = editingEntry ? 'detail' : 'list';
+  }
+
+  function optionalText(value: string): string | null {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  function parseTags(value: string): string[] {
+    const seen = new Set<string>();
+
+    return value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter((tag) => {
+        const key = tag.toLowerCase();
+
+        if (!key || seen.has(key)) {
+          return false;
+        }
+
+        seen.add(key);
+        return true;
+      });
+  }
+
+  function messageFromError(error: unknown): string {
+    if (typeof error === 'object' && error !== null && 'message' in error) {
+      return String(error.message);
+    }
+
+    return 'Unable to save entry';
+  }
+</script>
+
+<section class="entry-form" aria-labelledby="entry-form-title">
+  <div class="detail-head">
+    <div class="detail__title-wrap">
+      <div class="detail__crumbs mono">
+        <button type="button" class="detail__crumb-link" onclick={cancel}>vault</button>
+        &nbsp;/&nbsp; <b>{titleText}</b>
+      </div>
+      <h1 id="entry-form-title" class="detail__title">{titleText}<em>.</em></h1>
+      <div class="detail__meta mono">
+        <Tag value={mode} />
+        <span>vault · <b>{vaultState.vaultName || 'local'}</b></span>
+        <span>fields · <b>password</b></span>
+      </div>
+    </div>
+    <div class="detail__actions">
+      <Button variant="ghost" size="sm" onclick={cancel} disabled={busy}>cancel</Button>
+    </div>
+  </div>
+
+  <form
+    class="entry-form__body"
+    onsubmit={(event) => {
+      event.preventDefault();
+      submit();
+    }}
+  >
+    <div class="entry-form__grid">
+      <label class="entry-form__field entry-form__field--wide">
+        <span>title</span>
+        <input bind:value={title} autocomplete="off" maxlength="120" required />
+      </label>
+
+      <label class="entry-form__field">
+        <span>username</span>
+        <input bind:value={username} autocomplete="username" maxlength="160" />
+      </label>
+
+      <label class="entry-form__field">
+        <span>password</span>
+        <input bind:value={password} autocomplete="new-password" required type="password" />
+      </label>
+
+      <label class="entry-form__field entry-form__field--wide">
+        <span>url</span>
+        <input bind:value={url} autocomplete="url" inputmode="url" maxlength="400" />
+      </label>
+
+      <label class="entry-form__field entry-form__field--wide">
+        <span>tags</span>
+        <input bind:value={tags} autocomplete="off" maxlength="240" />
+      </label>
+
+      <label class="entry-form__field entry-form__field--wide">
+        <span>notes</span>
+        <textarea bind:value={notes} rows="7"></textarea>
+      </label>
+    </div>
+
+    {#if errorMessage}
+      <div class="entry-form__error mono" role="alert">{errorMessage}</div>
+    {/if}
+
+    <div class="entry-form__footer">
+      <div class="entry-form__hint mono">
+        required · <b>title password</b>
+      </div>
+      <Button variant="primary" type="submit" disabled={!canSubmit}>
+        <Icon name={mode === 'edit' ? 'edit' : 'plus'} size={12} />
+        {busy ? 'saving' : submitText}
+      </Button>
+    </div>
+  </form>
+</section>

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -146,7 +146,7 @@
       <div class="detail__meta mono">
         <Tag value={mode} />
         <span>vault · <b>{vaultState.vaultName || 'local'}</b></span>
-        <span>fields · <b>password</b></span>
+        <span>fields · <b>{passwordRequired ? 'password' : 'optional_password'}</b></span>
       </div>
     </div>
     <div class="detail__actions">

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -19,8 +19,10 @@
   let busy = $state(false);
   let errorMessage = $state('');
   let loadedEntryId = $state<string | null>(null);
+  let loadedPassword = $state('');
 
-  const canSubmit = $derived(title.trim().length > 0 && password.length > 0 && !busy);
+  const passwordRequired = $derived(mode === 'create');
+  const canSubmit = $derived(title.trim().length > 0 && (!passwordRequired || password.length > 0) && !busy);
 
   $effect(() => {
     const entry = editingEntry;
@@ -34,6 +36,7 @@
     title = entry?.title ?? '';
     username = entry?.username ?? '';
     password = entry?.password ?? '';
+    loadedPassword = password;
     url = entry?.url ?? '';
     notes = entry?.notes ?? '';
     tags = entry?.tags.join(', ') ?? '';
@@ -49,18 +52,17 @@
     errorMessage = '';
 
     try {
-      const payload = {
-        title: title.trim(),
-        username: username.trim(),
-        password,
-        url: optionalText(url),
-        notes: optionalText(notes),
-        tags: parseTags(tags),
-      };
       const saved =
         mode === 'edit' && editingEntry
-          ? await updateEntry(editingEntry.id, payload)
-          : await createEntry(payload);
+          ? await updateEntry(editingEntry.id, updatePayload())
+          : await createEntry({
+              title: title.trim(),
+              username: username.trim(),
+              password,
+              url: optionalText(url),
+              notes: optionalText(notes),
+              tags: parseTags(tags),
+            });
 
       applySavedEntry(saved);
       vaultState.lastSaved = new Date(saved.updatedAt);
@@ -91,6 +93,19 @@
   function optionalText(value: string): string | null {
     const trimmed = value.trim();
     return trimmed.length > 0 ? trimmed : null;
+  }
+
+  function updatePayload() {
+    const payload = {
+      title: title.trim(),
+      username: username.trim(),
+      url: optionalText(url),
+      notes: optionalText(notes),
+      tags: parseTags(tags),
+      ...(password.length > 0 && password !== loadedPassword ? { password } : {}),
+    };
+
+    return payload;
   }
 
   function parseTags(value: string): string[] {
@@ -159,7 +174,7 @@
 
       <label class="entry-form__field">
         <span>password</span>
-        <input bind:value={password} autocomplete="new-password" required type="password" />
+        <input bind:value={password} autocomplete="new-password" required={passwordRequired} type="password" />
       </label>
 
       <label class="entry-form__field entry-form__field--wide">
@@ -184,7 +199,7 @@
 
     <div class="entry-form__footer">
       <div class="entry-form__hint mono">
-        required · <b>title password</b>
+        required · <b>{passwordRequired ? 'title password' : 'title'}</b>
       </div>
       <Button variant="primary" type="submit" disabled={!canSubmit}>
         <Icon name={mode === 'edit' ? 'edit' : 'plus'} size={12} />

--- a/apps/desktop/src/lib/components/detail/index.ts
+++ b/apps/desktop/src/lib/components/detail/index.ts
@@ -1,4 +1,5 @@
 export { default as EntryDetail } from './EntryDetail.svelte';
+export { default as EntryForm } from './EntryForm.svelte';
 export { default as FieldStack } from './FieldStack.svelte';
 export { default as MetricStrip } from './MetricStrip.svelte';
 export { default as NotePanel } from './NotePanel.svelte';

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -48,6 +48,7 @@
   }
 
   function openNewEntry() {
+    vaultState.selectedEntry = null;
     uiState.view = 'edit';
   }
 

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -26,8 +26,8 @@ export interface CreateEntryDto {
   title: string;
   username: string;
   password: string;
-  url?: string;
-  notes?: string;
+  url?: string | null;
+  notes?: string | null;
   tags?: string[];
 }
 


### PR DESCRIPTION
## Summary

- Adds a desktop form for creating and editing vault entries.
- Wires the existing edit view to the new form from the vault shell.
- Updates local vault state after create or update so the detail view reflects the saved entry immediately.
- Allows optional create-entry text fields to be sent as null, matching the Tauri Option contract.

## Validation

- pnpm typecheck
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a create/edit entry form with mode-aware titles, submit behavior, and localized header actions.

* **Bug Fixes**
  * Starting a new entry no longer keeps the previously selected entry’s data.
  * URL and notes can now be explicitly cleared (set to empty/removed).

* **UI Improvements**
  * Refreshed entry-form styling: scrollable body, two-column desktop grid that collapses to one column on mobile, and clearer error/footer layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->