### PR TITLE
feat: add desktop password generator screen

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -1252,6 +1252,148 @@
   font-weight: 500;
 }
 
+/* ───────────────────────────────────────────────────────────
+   Password generator
+   ─────────────────────────────────────────────────────────── */
+.generator-panel {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.generator-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+  gap: 14px;
+  padding: 16px 26px;
+  align-content: start;
+}
+.generator-output,
+.generator-controls {
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  background: var(--bg-card);
+}
+.generator-output {
+  min-width: 0;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.generator-output__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.generator-output__value {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  border: 1px dashed var(--rule-dashed);
+  border-radius: 6px;
+  padding: 18px;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 18px;
+  line-height: 1.45;
+  letter-spacing: 0.02em;
+}
+.generator-output__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  color: var(--text-3);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+}
+.generator-output__meta b { color: var(--text-2); font-weight: 500; }
+.generator-error {
+  color: var(--accent);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+}
+.generator-controls {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.generator-controls__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 14px;
+  border-bottom: 1px dashed var(--rule-dashed);
+}
+.generator-controls__eyebrow {
+  margin: 0;
+  color: var(--text-3);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.generator-controls h2 {
+  margin: 0;
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: 0;
+}
+.generator-slider {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) 36px;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+}
+.generator-slider input {
+  min-width: 0;
+  accent-color: var(--accent);
+}
+.generator-slider b {
+  color: var(--text-2);
+  font-weight: 500;
+  text-align: right;
+}
+.generator-options {
+  display: grid;
+  gap: 8px;
+}
+.generator-options label {
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  padding: 0 10px;
+  color: var(--text-2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+.generator-options input {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--accent);
+}
+
 .error {
   animation: arca-shake 200ms linear;
 }
@@ -1595,6 +1737,13 @@
   padding: 12px 20px 16px;
   grid-template-columns: 1fr;
   gap: 10px;
+}
+.arca--mobile .generator-body {
+  padding: 12px 20px 16px;
+  grid-template-columns: 1fr;
+}
+.arca--mobile .generator-output__value {
+  font-size: 14px;
 }
 .arca--mobile .note-panel { grid-row: span 1; padding: 14px 16px; font-size: 12.5px; }
 .arca--mobile .field { padding: 11px 14px; grid-template-columns: 76px 1fr auto; }

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -1296,6 +1296,10 @@
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
+.generator-output__actions {
+  display: flex;
+  gap: 6px;
+}
 .generator-output__value {
   min-width: 0;
   overflow-wrap: anywhere;

--- a/apps/desktop/src/lib/components/VaultShell.svelte
+++ b/apps/desktop/src/lib/components/VaultShell.svelte
@@ -3,6 +3,7 @@
   import { vaultState } from '../stores/vault.svelte';
   import { uiState } from '../stores/ui.svelte';
   import { EntryDetail } from './detail';
+  import { GeneratorPanel } from './generator';
   import { SettingsPanel } from './settings';
   import { EntryList } from './vault';
 
@@ -51,6 +52,8 @@
   <EntryList />
 {:else if uiState.view === 'settings'}
   <SettingsPanel />
+{:else if uiState.view === 'generator'}
+  <GeneratorPanel />
 {:else}
   <section class="vault-placeholder" aria-labelledby="vault-placeholder-title">
     <p class="vault-placeholder__eyebrow">placeholder</p>

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { writeClipboardText } from '../../clipboard';
+  import { generatePassword, type GeneratedPassword } from '../../ipc';
+  import { vaultState } from '../../stores/vault.svelte';
+  import { Icon } from '../icons';
+  import { Button, IconButton, Tag } from '../primitives';
+
+  let length = $state(24);
+  let uppercase = $state(true);
+  let lowercase = $state(true);
+  let digits = $state(true);
+  let symbols = $state(true);
+  let excludeAmbiguous = $state(false);
+  let generated = $state<GeneratedPassword | null>(null);
+  let busy = $state(false);
+  let copied = $state(false);
+  let errorMessage = $state('');
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const hasCharacterSet = $derived(uppercase || lowercase || digits || symbols);
+  const entropyLabel = $derived(generated ? `${Math.round(generated.entropyBits)} bits` : 'pending');
+  const strengthLabel = $derived(strengthFromEntropy(generated?.entropyBits ?? 0));
+
+  onMount(() => {
+    void generate();
+
+    return () => {
+      if (copyTimer) {
+        clearTimeout(copyTimer);
+      }
+    };
+  });
+
+  async function generate() {
+    if (!hasCharacterSet) {
+      errorMessage = 'Select at least one character set';
+      return;
+    }
+
+    busy = true;
+    copied = false;
+    errorMessage = '';
+
+    try {
+      generated = await generatePassword({
+        length,
+        uppercase,
+        lowercase,
+        digits,
+        symbols,
+        excludeAmbiguous,
+      });
+    } catch (error) {
+      generated = null;
+      errorMessage = messageFromError(error);
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function copyGenerated() {
+    if (!generated?.password) {
+      return;
+    }
+
+    copied = await writeClipboardText(generated.password);
+
+    if (copyTimer) {
+      clearTimeout(copyTimer);
+    }
+
+    copyTimer = setTimeout(() => {
+      copied = false;
+      copyTimer = null;
+    }, 1500);
+  }
+
+  function strengthFromEntropy(entropy: number): string {
+    if (entropy >= 120) {
+      return 'excellent';
+    }
+
+    if (entropy >= 80) {
+      return 'strong';
+    }
+
+    if (entropy >= 50) {
+      return 'fair';
+    }
+
+    return generated ? 'weak' : 'pending';
+  }
+
+  function messageFromError(error: unknown): string {
+    if (typeof error === 'object' && error !== null && 'message' in error) {
+      return String(error.message);
+    }
+
+    return 'Unable to generate password';
+  }
+</script>
+
+<section class="generator-panel" aria-labelledby="generator-title">
+  <div class="detail-head">
+    <div class="detail__title-wrap">
+      <div class="detail__crumbs mono">vault &nbsp;/&nbsp; <b>generator</b></div>
+      <h1 id="generator-title" class="detail__title">generate<em>.</em></h1>
+      <div class="detail__meta mono">
+        <Tag value={strengthLabel} />
+        <span>vault · <b>{vaultState.vaultName || 'local'}</b></span>
+        <span>entropy · <b>{entropyLabel}</b></span>
+      </div>
+    </div>
+    <div class="detail__actions">
+      <Button variant="primary" size="sm" onclick={generate} disabled={busy || !hasCharacterSet}>
+        <Icon name="refresh" size={12} />
+        {busy ? 'generating' : 'generate'}
+      </Button>
+    </div>
+  </div>
+
+  <div class="generator-body">
+    <section class="generator-output" aria-labelledby="generator-output-title">
+      <div class="generator-output__head">
+        <span id="generator-output-title">password</span>
+        <IconButton label="Copy generated password" onclick={copyGenerated} disabled={!generated?.password}>
+          <Icon name="copy" size={13} />
+        </IconButton>
+      </div>
+      <output class="generator-output__value" aria-live="polite">
+        {generated?.password ?? '••••••••••••••••••••••••'}
+      </output>
+      <div class="generator-output__meta mono">
+        <span>length · <b>{length}</b></span>
+        <span>entropy · <b>{entropyLabel}</b></span>
+        <span>copy · <b>{copied ? 'done' : 'ready'}</b></span>
+      </div>
+      {#if errorMessage}
+        <div class="generator-error mono error" role="alert">{errorMessage}</div>
+      {/if}
+    </section>
+
+    <section class="generator-controls" aria-labelledby="generator-controls-title">
+      <div class="generator-controls__head">
+        <p class="generator-controls__eyebrow mono">policy</p>
+        <h2 id="generator-controls-title">random</h2>
+      </div>
+
+      <label class="generator-slider">
+        <span>length</span>
+        <input bind:value={length} type="range" min="8" max="128" step="1" oninput={generate} />
+        <b>{length}</b>
+      </label>
+
+      <div class="generator-options">
+        <label>
+          <input bind:checked={uppercase} type="checkbox" onchange={generate} />
+          <span>uppercase</span>
+        </label>
+        <label>
+          <input bind:checked={lowercase} type="checkbox" onchange={generate} />
+          <span>lowercase</span>
+        </label>
+        <label>
+          <input bind:checked={digits} type="checkbox" onchange={generate} />
+          <span>digits</span>
+        </label>
+        <label>
+          <input bind:checked={symbols} type="checkbox" onchange={generate} />
+          <span>symbols</span>
+        </label>
+        <label>
+          <input bind:checked={excludeAmbiguous} type="checkbox" onchange={generate} />
+          <span>no_ambiguous</span>
+        </label>
+      </div>
+    </section>
+  </div>
+</section>

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -13,18 +13,21 @@
   let symbols = $state(true);
   let excludeAmbiguous = $state(false);
   let generated = $state<GeneratedPassword | null>(null);
+  let isRevealed = $state(false);
   let busy = $state(false);
   let copied = $state(false);
   let errorMessage = $state('');
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
+  let generationCounter = 0;
 
   const hasCharacterSet = $derived(uppercase || lowercase || digits || symbols);
   const entropyLabel = $derived(generated ? `${Math.round(generated.entropyBits)} bits` : 'pending');
   const strengthLabel = $derived(strengthFromEntropy(generated?.entropyBits ?? 0));
+  const outputValue = $derived(
+    generated ? (isRevealed ? generated.password : maskPassword(generated.password)) : '••••••••••••••••••••••••',
+  );
 
   onMount(() => {
-    void generate();
-
     return () => {
       if (copyTimer) {
         clearTimeout(copyTimer);
@@ -33,17 +36,23 @@
   });
 
   async function generate() {
+    const currentGeneration = ++generationCounter;
+
     if (!hasCharacterSet) {
+      generated = null;
+      isRevealed = false;
+      copied = false;
       errorMessage = 'Select at least one character set';
       return;
     }
 
     busy = true;
     copied = false;
+    isRevealed = false;
     errorMessage = '';
 
     try {
-      generated = await generatePassword({
+      const nextGenerated = await generatePassword({
         length,
         uppercase,
         lowercase,
@@ -51,11 +60,24 @@
         symbols,
         excludeAmbiguous,
       });
+
+      if (currentGeneration !== generationCounter) {
+        return;
+      }
+
+      generated = nextGenerated;
     } catch (error) {
+      if (currentGeneration !== generationCounter) {
+        return;
+      }
+
       generated = null;
+      isRevealed = false;
       errorMessage = messageFromError(error);
     } finally {
-      busy = false;
+      if (currentGeneration === generationCounter) {
+        busy = false;
+      }
     }
   }
 
@@ -74,6 +96,23 @@
       copied = false;
       copyTimer = null;
     }, 1500);
+  }
+
+  function resetGenerated() {
+    generationCounter += 1;
+    generated = null;
+    isRevealed = false;
+    copied = false;
+    busy = false;
+    errorMessage = '';
+  }
+
+  function toggleReveal() {
+    isRevealed = !isRevealed;
+  }
+
+  function maskPassword(value: string): string {
+    return '•'.repeat(Math.max(value.length, 8));
   }
 
   function strengthFromEntropy(entropy: number): string {
@@ -124,13 +163,20 @@
     <section class="generator-output" aria-labelledby="generator-output-title">
       <div class="generator-output__head">
         <span id="generator-output-title">password</span>
-        <IconButton label="Copy generated password" onclick={copyGenerated} disabled={!generated?.password}>
-          <Icon name="copy" size={13} />
-        </IconButton>
+        <div class="generator-output__actions">
+          <IconButton
+            label={isRevealed ? 'Hide generated password' : 'Reveal generated password'}
+            onclick={toggleReveal}
+            disabled={!generated?.password}
+          >
+            <Icon name="eye" size={13} />
+          </IconButton>
+          <IconButton label="Copy generated password" onclick={copyGenerated} disabled={!generated?.password}>
+            <Icon name="copy" size={13} />
+          </IconButton>
+        </div>
       </div>
-      <output class="generator-output__value" aria-live="polite">
-        {generated?.password ?? '••••••••••••••••••••••••'}
-      </output>
+      <output class="generator-output__value">{outputValue}</output>
       <div class="generator-output__meta mono">
         <span>length · <b>{length}</b></span>
         <span>entropy · <b>{entropyLabel}</b></span>
@@ -149,29 +195,29 @@
 
       <label class="generator-slider">
         <span>length</span>
-        <input bind:value={length} type="range" min="8" max="128" step="1" oninput={generate} />
+        <input bind:value={length} type="range" min="8" max="128" step="1" oninput={resetGenerated} />
         <b>{length}</b>
       </label>
 
       <div class="generator-options">
         <label>
-          <input bind:checked={uppercase} type="checkbox" onchange={generate} />
+          <input bind:checked={uppercase} type="checkbox" onchange={resetGenerated} />
           <span>uppercase</span>
         </label>
         <label>
-          <input bind:checked={lowercase} type="checkbox" onchange={generate} />
+          <input bind:checked={lowercase} type="checkbox" onchange={resetGenerated} />
           <span>lowercase</span>
         </label>
         <label>
-          <input bind:checked={digits} type="checkbox" onchange={generate} />
+          <input bind:checked={digits} type="checkbox" onchange={resetGenerated} />
           <span>digits</span>
         </label>
         <label>
-          <input bind:checked={symbols} type="checkbox" onchange={generate} />
+          <input bind:checked={symbols} type="checkbox" onchange={resetGenerated} />
           <span>symbols</span>
         </label>
         <label>
-          <input bind:checked={excludeAmbiguous} type="checkbox" onchange={generate} />
+          <input bind:checked={excludeAmbiguous} type="checkbox" onchange={resetGenerated} />
           <span>no_ambiguous</span>
         </label>
       </div>

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -65,6 +65,7 @@
         return;
       }
 
+      isRevealed = false;
       generated = nextGenerated;
     } catch (error) {
       if (currentGeneration !== generationCounter) {
@@ -82,7 +83,7 @@
   }
 
   async function copyGenerated() {
-    if (!generated?.password) {
+    if (busy || !generated?.password) {
       return;
     }
 
@@ -108,6 +109,10 @@
   }
 
   function toggleReveal() {
+    if (busy || !generated?.password) {
+      return;
+    }
+
     isRevealed = !isRevealed;
   }
 
@@ -167,11 +172,11 @@
           <IconButton
             label={isRevealed ? 'Hide generated password' : 'Reveal generated password'}
             onclick={toggleReveal}
-            disabled={!generated?.password}
+            disabled={busy || !generated?.password}
           >
             <Icon name="eye" size={13} />
           </IconButton>
-          <IconButton label="Copy generated password" onclick={copyGenerated} disabled={!generated?.password}>
+          <IconButton label="Copy generated password" onclick={copyGenerated} disabled={busy || !generated?.password}>
             <Icon name="copy" size={13} />
           </IconButton>
         </div>

--- a/apps/desktop/src/lib/components/generator/index.ts
+++ b/apps/desktop/src/lib/components/generator/index.ts
@@ -1,0 +1,1 @@
+export { default as GeneratorPanel } from './GeneratorPanel.svelte';


### PR DESCRIPTION
## Summary

- Adds a desktop password generator screen for the existing generator tab.
- Wires the UI to the Tauri password generation command.
- Includes length, charset, ambiguous-character controls, entropy display, and copy support.
- Keeps passphrase mode hidden because the current Rust backend maps it to the random generator behavior.

## Validation

- pnpm typecheck
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a password generator panel to the vault interface (length slider, uppercase/lowercase/digits/symbols, and “exclude ambiguous characters”).
  * Generated passwords now display strength/entropy metadata.
  * Added reveal/hide and one-click copy with a temporary “copied” confirmation.
* **Bug Fixes**
  * Improved generator busy/error handling to prevent stale updates during rapid changes.
* **UI/UX**
  * Refreshed generator styling, including mobile layout tweaks for tighter spacing and improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->