### PR TITLE
feat: use custom desktop window chrome

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,9 @@
   "identifier": "default",
   "description": "Default permissions for the Arca desktop window.",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": [
+    "core:default",
+    "core:window:allow-internal-toggle-maximize",
+    "core:window:allow-start-dragging"
+  ]
 }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -17,7 +17,13 @@
         "width": 1100,
         "height": 720,
         "minWidth": 900,
-        "minHeight": 600
+        "minHeight": 600,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": {
+          "x": 18,
+          "y": 23
+        }
       }
     ],
     "security": {

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getCurrentWindow } from '@tauri-apps/api/window';
   import { onMount } from 'svelte';
   import { cancelClipboardClear } from './lib/clipboard';
   import UnlockScreen from './lib/components/UnlockScreen.svelte';
@@ -11,9 +12,13 @@
 
   const BASE_FONT_SIZE = 13;
   const ACTIVITY_EVENTS = ['pointerdown', 'keydown', 'wheel', 'touchstart'] as const;
+  const isMacWindow =
+    typeof navigator !== 'undefined' &&
+    (navigator.platform.includes('Mac') || navigator.userAgent.includes('Macintosh'));
 
   let lastActivityAt = $state(Date.now());
   let autoLockTimer: ReturnType<typeof setTimeout> | null = null;
+  let isFullscreen = $state(false);
 
   const tabItems = $derived<TabItem[]>([
     { key: 'vault', label: 'vault', count: vaultState.entries.length },
@@ -64,6 +69,9 @@
   const appStyle = $derived(
     `--arca-font-size: ${fontSize}px; --arca-font-scale: ${fontSize / BASE_FONT_SIZE};`,
   );
+  const appClasses = $derived(
+    ['arca', 'arca--desktop', isMacWindow && !isFullscreen ? 'arca--mac' : ''].filter(Boolean).join(' '),
+  );
 
   function selectTab(key: string) {
     const viewByTab: Record<string, ViewName> = {
@@ -105,19 +113,46 @@
     }
   }
 
-  onMount(() => {
-    loadThemePreference();
+  async function syncFullscreenState() {
+    try {
+      isFullscreen = await getCurrentWindow().isFullscreen();
+    } catch {
+      isFullscreen = false;
+    }
+  }
 
+  onMount(() => {
+    let mounted = true;
+    let unlistenResize: (() => void) | null = null;
+
+    loadThemePreference();
     void loadRuntimeSettings().catch(() => {
       // Browser previews keep the default runtime settings when Tauri IPC is unavailable.
     });
+    void syncFullscreenState();
+    void getCurrentWindow()
+      .onResized(() => {
+        void syncFullscreenState();
+      })
+      .then((unlisten) => {
+        if (mounted) {
+          unlistenResize = unlisten;
+        } else {
+          unlisten();
+        }
+      })
+      .catch(() => {
+        // Browser previews do not have a Tauri window to observe.
+      });
 
     for (const eventName of ACTIVITY_EVENTS) {
       window.addEventListener(eventName, recordActivity, { passive: true });
     }
 
     return () => {
+      mounted = false;
       clearAutoLockTimer();
+      unlistenResize?.();
 
       for (const eventName of ACTIVITY_EVENTS) {
         window.removeEventListener(eventName, recordActivity);
@@ -158,7 +193,7 @@
   });
 </script>
 
-<main class="arca arca--desktop" data-theme={uiState.theme} style={appStyle}>
+<main class={appClasses} data-theme={uiState.theme} style={appStyle}>
   <WindowChrome path={chromePath} />
 
   {#if !vaultState.locked}

--- a/apps/desktop/src/lib/components/chrome/WindowChrome.svelte
+++ b/apps/desktop/src/lib/components/chrome/WindowChrome.svelte
@@ -21,7 +21,7 @@
   const classes = $derived(['chrome', className].filter(Boolean).join(' '));
 </script>
 
-<div {...rest} class={classes}>
+<div {...rest} class={classes} data-tauri-drag-region="deep">
   <span class="chrome__lockup">
     <Lockup size={18} />
   </span>


### PR DESCRIPTION
## Summary
- configure Tauri overlay titlebar and traffic light positioning
- make the custom top chrome the drag region
- adjust fullscreen/macOS inset behavior

## Verification
- pnpm typecheck
- pnpm build
- cargo fmt --all --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced desktop window chrome configuration with overlay title bar styling and customized window controls positioning for improved native appearance.
  * Improved fullscreen state detection and real-time tracking to ensure responsive window behavior and dynamic interface adjustments based on fullscreen mode.
  * Extended window drag-region capabilities for smoother window interaction and control handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->