### PR TITLE
fix: polish secret reveal controls

### DIFF
--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
   import type { EntryDto } from '../../ipc';
-  import { writeClipboardText } from '../../clipboard';
+  import { writeConfiguredClipboardText } from '../../clipboard';
   import { Icon } from '../icons';
   import { Entropy, IconButton, Kbd } from '../primitives';
 
@@ -13,11 +13,13 @@
 
   const passwordMask = '●●●●●●●●●●●●●●●●●●●●●●●●';
   let copied = $state<'username' | 'password' | null>(null);
+  let passwordRevealed = $state(false);
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
 
   const url = $derived(entry.url?.trim() || 'not_set');
   const username = $derived(entry.username.trim() || 'not_set');
   const password = $derived(entry.password?.trim() || '');
+  const displayedPassword = $derived(passwordRevealed ? password : passwordMask);
   const entropyBits = $derived(Math.max(72, Math.min(112, entry.title.length * 6 + entry.username.length * 4 + 48)));
   const entropyFilled = $derived(Math.max(10, Math.min(16, Math.round(entropyBits / 7))));
 
@@ -32,7 +34,10 @@
       return;
     }
 
-    await writeClipboardText(value);
+    if (!(await writeConfiguredClipboardText(value))) {
+      return;
+    }
+
     copied = kind;
 
     if (copyTimer) {
@@ -44,6 +49,19 @@
       copyTimer = null;
     }, 1500);
   }
+
+  function togglePasswordReveal() {
+    if (!password) {
+      return;
+    }
+
+    passwordRevealed = !passwordRevealed;
+  }
+
+  $effect(() => {
+    entry.id;
+    passwordRevealed = false;
+  });
 </script>
 
 <div class="fields">
@@ -78,9 +96,14 @@
 
   <div class="field field--focus">
     <div class="field__k">password <Kbd value="C" /></div>
-    <div class="field__v field__v--mask">{passwordMask}</div>
+    <div class={passwordRevealed ? 'field__v field__v--secret' : 'field__v field__v--mask'}>{displayedPassword}</div>
     <div class="field__actions">
-      <IconButton label={`Reveal ${entry.title} password`}>
+      <IconButton
+        label={passwordRevealed ? `Hide ${entry.title} password` : `Reveal ${entry.title} password`}
+        variant={passwordRevealed ? 'accent' : 'default'}
+        disabled={!password}
+        onclick={togglePasswordReveal}
+      >
         <Icon name="eye" size={13} />
       </IconButton>
       <IconButton

--- a/apps/desktop/src/lib/components/vault/SearchBar.svelte
+++ b/apps/desktop/src/lib/components/vault/SearchBar.svelte
@@ -33,8 +33,5 @@
     onfocus={onfocus}
     onblur={onblur}
   />
-  {#if focused}
-    <span class="search__caret" aria-hidden="true"></span>
-  {/if}
   <span class="search__hint">⌘F</span>
 </label>


### PR DESCRIPTION
## Summary
- make entry detail password reveal toggle work
- route detail copy actions through configured clipboard clearing
- remove the fake vault search caret that stayed pinned right

## Verification
- pnpm typecheck
- pnpm build
- cargo fmt --all --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added password reveal/hide toggle for enhanced control over password visibility.

* **Bug Fixes**
  * Improved clipboard handling with enhanced error detection that aborts copy operations on failure.
  * Refined search bar interface for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->