### PR TITLE
feat: add vault path autocomplete

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,9 @@
   "identifier": "default",
   "description": "Default permissions for the Arca desktop window.",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": [
+    "core:default",
+    "core:window:allow-internal-toggle-maximize",
+    "core:window:allow-start-dragging"
+  ]
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1,3 +1,5 @@
+use std::env;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -79,6 +81,22 @@ pub enum GeneratorModeDto {
 pub struct GeneratedPassword {
     pub password: String,
     pub entropy_bits: f64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PathSuggestionDto {
+    pub name: String,
+    pub path: String,
+    pub kind: PathSuggestionKind,
+    pub vault_candidate: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum PathSuggestionKind {
+    Directory,
+    File,
 }
 
 #[tauri::command]
@@ -231,6 +249,15 @@ pub fn generate_password(config: GeneratorConfigDto) -> Result<GeneratedPassword
 }
 
 #[tauri::command]
+pub fn suggest_paths(partial: String) -> Result<Vec<PathSuggestionDto>, ArcaError> {
+    if partial.len() > 4096 {
+        return Err(ArcaError::invalid_input("Path query is too long"));
+    }
+
+    Ok(suggest_paths_for(&partial))
+}
+
+#[tauri::command]
 pub fn get_settings(state: State<'_, AppState>) -> Result<Settings, ArcaError> {
     Ok(state.settings()?.clone())
 }
@@ -331,9 +358,143 @@ fn vault_info(path: &Path, meta: &VaultMeta, entry_count: usize) -> VaultInfo {
     }
 }
 
+fn suggest_paths_for(partial: &str) -> Vec<PathSuggestionDto> {
+    let trimmed = partial.trim_start();
+    let expanded = expand_path(trimmed);
+    let trailing_separator = trimmed.ends_with('/') || trimmed.ends_with('\\');
+    let home = home_dir();
+
+    let (search_dir, prefix) = if trimmed.is_empty() {
+        (home.unwrap_or_else(|| PathBuf::from("/")), String::new())
+    } else if trimmed == "~" || trailing_separator {
+        (expanded, String::new())
+    } else {
+        let parent = expanded
+            .parent()
+            .map(Path::to_path_buf)
+            .filter(|path| !path.as_os_str().is_empty())
+            .or_else(|| {
+                if expanded.is_absolute() {
+                    Some(PathBuf::from("/"))
+                } else {
+                    home
+                }
+            })
+            .unwrap_or_else(|| PathBuf::from("."));
+        let prefix = expanded
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_lowercase();
+
+        (parent, prefix)
+    };
+
+    let mut suggestions = match fs::read_dir(search_dir) {
+        Ok(entries) => entries
+            .filter_map(Result::ok)
+            .filter_map(|entry| path_suggestion(entry.path(), &prefix))
+            .collect::<Vec<_>>(),
+        Err(_) => Vec::new(),
+    };
+
+    suggestions.sort_by(|left, right| {
+        let left_rank = suggestion_rank(left);
+        let right_rank = suggestion_rank(right);
+
+        left_rank
+            .cmp(&right_rank)
+            .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
+    });
+    suggestions.truncate(8);
+
+    suggestions
+}
+
+fn path_suggestion(path: PathBuf, prefix: &str) -> Option<PathSuggestionDto> {
+    let metadata = fs::metadata(&path).ok()?;
+
+    if !metadata.is_dir() && !metadata.is_file() {
+        return None;
+    }
+
+    let raw_name = path.file_name()?.to_str()?;
+
+    if !prefix.is_empty() && !raw_name.to_lowercase().starts_with(prefix) {
+        return None;
+    }
+
+    let is_dir = metadata.is_dir();
+    let name = if is_dir {
+        format!("{raw_name}/")
+    } else {
+        raw_name.to_string()
+    };
+    let mut display_path = path.display().to_string();
+
+    if is_dir && !display_path.ends_with(std::path::MAIN_SEPARATOR) {
+        display_path.push(std::path::MAIN_SEPARATOR);
+    }
+
+    Some(PathSuggestionDto {
+        vault_candidate: !is_dir && is_vault_candidate(raw_name),
+        kind: if is_dir {
+            PathSuggestionKind::Directory
+        } else {
+            PathSuggestionKind::File
+        },
+        name,
+        path: display_path,
+    })
+}
+
+fn suggestion_rank(suggestion: &PathSuggestionDto) -> u8 {
+    match (&suggestion.kind, suggestion.vault_candidate) {
+        (PathSuggestionKind::File, true) => 0,
+        (PathSuggestionKind::Directory, _) => 1,
+        (PathSuggestionKind::File, false) => 2,
+    }
+}
+
+fn is_vault_candidate(name: &str) -> bool {
+    let lower = name.to_lowercase();
+
+    lower.ends_with(".arca") || lower.ends_with(".kdbx")
+}
+
+fn expand_path(value: &str) -> PathBuf {
+    if value == "~" {
+        return home_dir().unwrap_or_else(|| PathBuf::from(value));
+    }
+
+    if let Some(rest) = value.strip_prefix("~/") {
+        return home_dir()
+            .map(|home| home.join(rest))
+            .unwrap_or_else(|| PathBuf::from(value));
+    }
+
+    let path = PathBuf::from(value);
+
+    if path.is_absolute() {
+        path
+    } else {
+        home_dir()
+            .map(|home| home.join(path))
+            .unwrap_or_else(|| PathBuf::from(value))
+    }
+}
+
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("HOME")
+        .or_else(|| env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{CreateEntryDto, EntryDto, GeneratorConfigDto};
+    use super::{suggest_paths_for, CreateEntryDto, EntryDto, GeneratorConfigDto};
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
     use vault_core::entry::create_entry;
 
     #[test]
@@ -365,5 +526,52 @@ mod tests {
             serde_json::from_str(json).expect("create entry dto should deserialize");
 
         assert!(dto.tags.is_empty());
+    }
+
+    #[test]
+    fn path_suggestions_prioritize_vault_files_then_directories() {
+        let root = unique_temp_dir();
+        fs::create_dir_all(root.join("apps")).expect("create directory fixture");
+        fs::write(root.join("alpha.arca"), "").expect("create vault fixture");
+        fs::write(root.join("alpha.txt"), "").expect("create file fixture");
+
+        let partial = root.join("a").display().to_string();
+        let suggestions = suggest_paths_for(&partial);
+        let names = suggestions
+            .iter()
+            .map(|suggestion| suggestion.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["alpha.arca", "apps/", "alpha.txt"]);
+        assert!(suggestions[0].vault_candidate);
+
+        fs::remove_dir_all(root).expect("remove suggestion fixture");
+    }
+
+    #[test]
+    fn path_suggestions_complete_inside_trailing_directory() {
+        let root = unique_temp_dir();
+        let vaults = root.join("vaults");
+        fs::create_dir_all(&vaults).expect("create directory fixture");
+        fs::write(vaults.join("primary.kdbx"), "").expect("create vault fixture");
+
+        let partial = format!("{}{}", vaults.display(), std::path::MAIN_SEPARATOR);
+        let suggestions = suggest_paths_for(&partial);
+
+        assert_eq!(suggestions[0].name, "primary.kdbx");
+        assert!(suggestions[0].vault_candidate);
+
+        fs::remove_dir_all(root).expect("remove suggestion fixture");
+    }
+
+    fn unique_temp_dir() -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be after unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("arca-path-suggest-{nanos}"));
+
+        fs::create_dir_all(&dir).expect("create temp suggestion dir");
+        dir
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,7 +4,8 @@ pub mod state;
 
 use commands::{
     create_entry, create_vault, delete_entry, generate_password, get_entry, get_settings,
-    list_entries, lock_vault, search_entries, unlock_vault, update_entry, update_settings,
+    list_entries, lock_vault, search_entries, suggest_paths, unlock_vault, update_entry,
+    update_settings,
 };
 use state::AppState;
 
@@ -21,6 +22,7 @@ pub fn run() -> tauri::Result<()> {
             update_entry,
             delete_entry,
             search_entries,
+            suggest_paths,
             generate_password,
             get_settings,
             update_settings

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -17,7 +17,13 @@
         "width": 1100,
         "height": 720,
         "minWidth": 900,
-        "minHeight": 600
+        "minHeight": 600,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": {
+          "x": 18,
+          "y": 23
+        }
       }
     ],
     "security": {

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getCurrentWindow } from '@tauri-apps/api/window';
   import { onMount } from 'svelte';
   import { cancelClipboardClear } from './lib/clipboard';
   import UnlockScreen from './lib/components/UnlockScreen.svelte';
@@ -11,9 +12,13 @@
 
   const BASE_FONT_SIZE = 13;
   const ACTIVITY_EVENTS = ['pointerdown', 'keydown', 'wheel', 'touchstart'] as const;
+  const isMacWindow =
+    typeof navigator !== 'undefined' &&
+    (navigator.platform.includes('Mac') || navigator.userAgent.includes('Macintosh'));
 
   let lastActivityAt = $state(Date.now());
   let autoLockTimer: ReturnType<typeof setTimeout> | null = null;
+  let isFullscreen = $state(false);
 
   const tabItems = $derived<TabItem[]>([
     { key: 'vault', label: 'vault', count: vaultState.entries.length },
@@ -64,6 +69,9 @@
   const appStyle = $derived(
     `--arca-font-size: ${fontSize}px; --arca-font-scale: ${fontSize / BASE_FONT_SIZE};`,
   );
+  const appClasses = $derived(
+    ['arca', 'arca--desktop', isMacWindow && !isFullscreen ? 'arca--mac' : ''].filter(Boolean).join(' '),
+  );
 
   function selectTab(key: string) {
     const viewByTab: Record<string, ViewName> = {
@@ -105,19 +113,46 @@
     }
   }
 
-  onMount(() => {
-    loadThemePreference();
+  async function syncFullscreenState() {
+    try {
+      isFullscreen = await getCurrentWindow().isFullscreen();
+    } catch {
+      isFullscreen = false;
+    }
+  }
 
+  onMount(() => {
+    let mounted = true;
+    let unlistenResize: (() => void) | null = null;
+
+    loadThemePreference();
     void loadRuntimeSettings().catch(() => {
       // Browser previews keep the default runtime settings when Tauri IPC is unavailable.
     });
+    void syncFullscreenState();
+    void getCurrentWindow()
+      .onResized(() => {
+        void syncFullscreenState();
+      })
+      .then((unlisten) => {
+        if (mounted) {
+          unlistenResize = unlisten;
+        } else {
+          unlisten();
+        }
+      })
+      .catch(() => {
+        // Browser previews do not have a Tauri window to observe.
+      });
 
     for (const eventName of ACTIVITY_EVENTS) {
       window.addEventListener(eventName, recordActivity, { passive: true });
     }
 
     return () => {
+      mounted = false;
       clearAutoLockTimer();
+      unlistenResize?.();
 
       for (const eventName of ACTIVITY_EVENTS) {
         window.removeEventListener(eventName, recordActivity);
@@ -158,7 +193,7 @@
   });
 </script>
 
-<main class="arca arca--desktop" data-theme={uiState.theme} style={appStyle}>
+<main class={appClasses} data-theme={uiState.theme} style={appStyle}>
   <WindowChrome path={chromePath} />
 
   {#if !vaultState.locked}

--- a/apps/desktop/src/lib/components/UnlockScreen.svelte
+++ b/apps/desktop/src/lib/components/UnlockScreen.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { createVault, listEntries, unlockVault, type EntryDto } from '../ipc';
+  import { createVault, listEntries, suggestPaths, unlockVault, type EntryDto, type PathSuggestion } from '../ipc';
   import { vaultState } from '../stores/vault.svelte';
   import { uiState } from '../stores/ui.svelte';
   import { Lockup } from './brand';
@@ -19,12 +19,19 @@
   let mode: Mode = $state('open');
   let path = $state(vaultState.vaultPath);
   let password = $state('');
+  let passwordRevealed = $state(false);
   let vaultName = $state('personal');
   let busy = $state(false);
   let errorMessage = $state('');
   let openButton = $state<HTMLButtonElement | null>(null);
+  let pathInput = $state<HTMLInputElement | null>(null);
   let passwordInput = $state<HTMLInputElement | null>(null);
   let focusTimer: ReturnType<typeof setTimeout> | null = null;
+  let pathSuggestTimer: ReturnType<typeof setTimeout> | null = null;
+  let pathFocused = $state(false);
+  let pathSuggestions = $state<PathSuggestion[]>([]);
+  let selectedPathIndex = $state(0);
+  let suggestCounter = 0;
 
   const canSubmit = $derived(
     path.trim().length > 0 &&
@@ -34,6 +41,7 @@
   );
   const isSealed = $derived(variant === 'sealed');
   const sealedOpen = $derived(isSealed && uiState.sealedPromptOpen);
+  const showPathSuggestions = $derived(pathFocused && pathSuggestions.length > 0);
 
   onMount(() => {
     function handleKeydown(event: KeyboardEvent) {
@@ -61,6 +69,39 @@
       if (focusTimer) {
         clearTimeout(focusTimer);
       }
+
+      if (pathSuggestTimer) {
+        clearTimeout(pathSuggestTimer);
+      }
+    };
+  });
+
+  $effect(() => {
+    const query = path;
+
+    if (pathSuggestTimer) {
+      clearTimeout(pathSuggestTimer);
+      pathSuggestTimer = null;
+    }
+
+    if (!pathFocused || query.trim().length === 0 || isSealed) {
+      pathSuggestions = [];
+      selectedPathIndex = 0;
+      return;
+    }
+
+    const currentSuggest = ++suggestCounter;
+
+    pathSuggestTimer = setTimeout(() => {
+      void loadPathSuggestions(query, currentSuggest);
+      pathSuggestTimer = null;
+    }, 90);
+
+    return () => {
+      if (pathSuggestTimer) {
+        clearTimeout(pathSuggestTimer);
+        pathSuggestTimer = null;
+      }
     };
   });
 
@@ -83,6 +124,7 @@
       }
 
       password = '';
+      passwordRevealed = false;
       uiState.unlockSurface = 'two-pane';
       uiState.sealedPromptOpen = false;
       uiState.view = 'list';
@@ -101,6 +143,76 @@
     vaultState.vaultName = name;
     vaultState.vaultPath = vaultPath;
     vaultState.lastSaved = new Date(modifiedAt);
+  }
+
+  async function loadPathSuggestions(query: string, currentSuggest: number) {
+    try {
+      const suggestions = await suggestPaths(query);
+
+      if (currentSuggest !== suggestCounter) {
+        return;
+      }
+
+      pathSuggestions = suggestions;
+      selectedPathIndex = suggestions.length > 0 ? Math.min(selectedPathIndex, suggestions.length - 1) : 0;
+    } catch {
+      if (currentSuggest === suggestCounter) {
+        pathSuggestions = [];
+        selectedPathIndex = 0;
+      }
+    }
+  }
+
+  function handlePathKeydown(event: KeyboardEvent) {
+    if (!showPathSuggestions) {
+      return;
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      selectedPathIndex = (selectedPathIndex + 1) % pathSuggestions.length;
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      selectedPathIndex = (selectedPathIndex + pathSuggestions.length - 1) % pathSuggestions.length;
+      return;
+    }
+
+    if (event.key === 'Tab' || event.key === 'Enter') {
+      event.preventDefault();
+      applyPathSuggestion(pathSuggestions[selectedPathIndex]);
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      pathSuggestions = [];
+      selectedPathIndex = 0;
+    }
+  }
+
+  function applyPathSuggestion(suggestion: PathSuggestion | undefined) {
+    if (!suggestion) {
+      return;
+    }
+
+    path = suggestion.path;
+    selectedPathIndex = 0;
+
+    if (suggestion.kind === 'file') {
+      pathSuggestions = [];
+      passwordInput?.focus();
+    } else {
+      pathInput?.focus();
+    }
+  }
+
+  function handlePathBlur() {
+    window.setTimeout(() => {
+      pathFocused = false;
+    }, 120);
   }
 
   function messageFromError(error: unknown): string {
@@ -127,6 +239,7 @@
     }
 
     password = '';
+    passwordRevealed = false;
     errorMessage = '';
     uiState.sealedPromptOpen = false;
     openButton?.focus();
@@ -149,6 +262,10 @@
       passwordInput?.focus();
       focusTimer = null;
     }, delay);
+  }
+
+  function togglePasswordReveal() {
+    passwordRevealed = !passwordRevealed;
   }
 </script>
 
@@ -211,10 +328,15 @@
                 bind:value={password}
                 autocomplete="current-password"
                 class="unlock__input"
-                type="password"
+                type={passwordRevealed ? 'text' : 'password'}
                 aria-label="master password"
               />
-              <IconButton label="Password remains hidden" variant="ghost" disabled>
+              <IconButton
+                label={passwordRevealed ? 'Hide master password' : 'Reveal master password'}
+                variant="ghost"
+                onclick={togglePasswordReveal}
+                disabled={!password}
+              >
                 <Icon name="eye" size={14} />
               </IconButton>
             </div>
@@ -310,21 +432,53 @@
           </label>
         {/if}
 
-        <label>
-          <div class="unlock__field-label">
+        <div>
+          <div id="vault-path-label" class="unlock__field-label">
             <span>vault_path</span>
             <span>{mode === 'open' ? 'existing vault' : 'new vault'}</span>
           </div>
-          <div class="unlock__field unlock__field--compact">
+          <div class="unlock__field unlock__field--compact unlock__field--path">
             <input
+              bind:this={pathInput}
               bind:value={path}
               autocomplete="off"
               class="unlock__input"
               placeholder="/Users/you/.arca/vaults/primary.arca"
               spellcheck="false"
+              role="combobox"
+              aria-labelledby="vault-path-label"
+              aria-expanded={showPathSuggestions}
+              aria-controls="vault-path-suggestions"
+              aria-autocomplete="list"
+              onfocus={() => (pathFocused = true)}
+              onblur={handlePathBlur}
+              onkeydown={handlePathKeydown}
             />
+            {#if showPathSuggestions}
+              <div id="vault-path-suggestions" class="path-suggest" role="listbox" aria-label="Path suggestions">
+                {#each pathSuggestions as suggestion, index}
+                  <button
+                    type="button"
+                    class={index === selectedPathIndex ? 'path-suggest__item path-suggest__item--active' : 'path-suggest__item'}
+                    role="option"
+                    aria-selected={index === selectedPathIndex}
+                    onmouseenter={() => (selectedPathIndex = index)}
+                    onmousedown={(event) => {
+                      event.preventDefault();
+                      applyPathSuggestion(suggestion);
+                    }}
+                  >
+                    <span class="path-suggest__prompt">&gt;</span>
+                    <span class="path-suggest__name">{suggestion.name}</span>
+                    <span class={suggestion.vaultCandidate ? 'path-suggest__kind path-suggest__kind--vault' : 'path-suggest__kind'}>
+                      {suggestion.vaultCandidate ? 'vault' : suggestion.kind}
+                    </span>
+                  </button>
+                {/each}
+              </div>
+            {/if}
           </div>
-        </label>
+        </div>
 
         <label>
           <div class="unlock__field-label">
@@ -333,13 +487,19 @@
           </div>
           <div class="unlock__field">
             <input
+              bind:this={passwordInput}
               bind:value={password}
               autocomplete="current-password"
               class="unlock__input"
-              type="password"
+              type={passwordRevealed ? 'text' : 'password'}
               aria-label="master password"
             />
-            <IconButton label="Password remains hidden" variant="ghost" disabled>
+            <IconButton
+              label={passwordRevealed ? 'Hide master password' : 'Reveal master password'}
+              variant="ghost"
+              onclick={togglePasswordReveal}
+              disabled={!password}
+            >
               <Icon name="eye" size={14} />
             </IconButton>
           </div>

--- a/apps/desktop/src/lib/components/chrome/WindowChrome.svelte
+++ b/apps/desktop/src/lib/components/chrome/WindowChrome.svelte
@@ -21,7 +21,7 @@
   const classes = $derived(['chrome', className].filter(Boolean).join(' '));
 </script>
 
-<div {...rest} class={classes}>
+<div {...rest} class={classes} data-tauri-drag-region="deep">
   <span class="chrome__lockup">
     <Lockup size={18} />
   </span>

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -55,6 +55,13 @@ export interface GeneratedPassword {
   entropyBits: number;
 }
 
+export interface PathSuggestion {
+  name: string;
+  path: string;
+  kind: 'directory' | 'file';
+  vaultCandidate: boolean;
+}
+
 export interface Settings {
   autoLockTimeoutMinutes?: number | null;
   clipboardClearSeconds?: number | null;
@@ -96,6 +103,10 @@ export function deleteEntry(id: string): Promise<void> {
 
 export function searchEntries(query: string): Promise<EntryDto[]> {
   return invoke('search_entries', { query });
+}
+
+export function suggestPaths(partial: string): Promise<PathSuggestion[]> {
+  return invoke('suggest_paths', { partial });
 }
 
 export function generatePassword(config: GeneratorConfigDto): Promise<GeneratedPassword> {


### PR DESCRIPTION
## Summary
- add Tauri path suggestions for vault path entry
- wire IPC and unlock-screen autocomplete interactions
- add path suggestion ordering tests

## Verification
- pnpm typecheck
- pnpm build
- cargo fmt --all --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added path auto-suggestions when creating or unlocking vaults
  * Added password visibility toggle on the unlock/creation screen

* **UI/UX Improvements**
  * Enhanced window styling with overlay title bar and improved Mac window appearance
  * Improved window drag and fullscreen state handling
  * Added keyboard navigation for path suggestions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->