### PR TITLE
feat: show audit finding count

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { getCurrentWindow } from '@tauri-apps/api/window';
   import { onMount } from 'svelte';
-  import { buildAuditFindings } from './lib/audit';
   import { cancelClipboardClear } from './lib/clipboard';
   import UnlockScreen from './lib/components/UnlockScreen.svelte';
   import VaultShell from './lib/components/VaultShell.svelte';
   import { StatusBar, Tabs, WindowChrome, type TabItem } from './lib/components/chrome';
   import { lockCurrentVault } from './lib/session';
+  import { getAuditState } from './lib/stores/audit.svelte';
   import { loadRuntimeSettings, runtimeSettings } from './lib/stores/settings.svelte';
   import { vaultState } from './lib/stores/vault.svelte';
   import { loadThemePreference, uiState, type ViewName } from './lib/stores/ui.svelte';
@@ -21,11 +21,11 @@
   let autoLockTimer: ReturnType<typeof setTimeout> | null = null;
   let isFullscreen = $state(false);
 
-  const auditFindingCount = $derived(buildAuditFindings(vaultState.entries).length);
+  const auditState = $derived(getAuditState());
   const tabItems = $derived<TabItem[]>([
     { key: 'vault', label: 'vault', count: vaultState.entries.length },
     { key: 'generate', label: 'generate' },
-    { key: 'audit', label: 'audit', count: auditFindingCount },
+    { key: 'audit', label: 'audit', count: auditState.findingCount },
     { key: 'shared', label: 'shared' },
     { key: 'settings', label: 'settings' },
   ]);

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getCurrentWindow } from '@tauri-apps/api/window';
   import { onMount } from 'svelte';
+  import { buildAuditFindings } from './lib/audit';
   import { cancelClipboardClear } from './lib/clipboard';
   import UnlockScreen from './lib/components/UnlockScreen.svelte';
   import VaultShell from './lib/components/VaultShell.svelte';
@@ -20,10 +21,11 @@
   let autoLockTimer: ReturnType<typeof setTimeout> | null = null;
   let isFullscreen = $state(false);
 
+  const auditFindingCount = $derived(buildAuditFindings(vaultState.entries).length);
   const tabItems = $derived<TabItem[]>([
     { key: 'vault', label: 'vault', count: vaultState.entries.length },
     { key: 'generate', label: 'generate' },
-    { key: 'audit', label: 'audit' },
+    { key: 'audit', label: 'audit', count: auditFindingCount },
     { key: 'shared', label: 'shared' },
     { key: 'settings', label: 'settings' },
   ]);

--- a/apps/desktop/src/lib/audit.ts
+++ b/apps/desktop/src/lib/audit.ts
@@ -1,0 +1,116 @@
+import type { EntryDto } from './ipc';
+
+export type AuditSeverity = 'high' | 'medium' | 'low';
+
+export interface AuditFinding {
+  key: string;
+  severity: AuditSeverity;
+  title: string;
+  entry: EntryDto;
+  meta: string;
+}
+
+export function buildAuditFindings(entries: EntryDto[]): AuditFinding[] {
+  const results: AuditFinding[] = [];
+  const usernames = groupBy(entries, (entry) => normalize(entry.username));
+  const loadedPasswords = groupBy(
+    entries.filter((entry) => entry.password),
+    (entry) => entry.password ?? '',
+  );
+
+  for (const entry of entries) {
+    if (!entry.url) {
+      results.push(finding('missing-url', 'low', 'missing_url', entry, 'metadata'));
+    }
+
+    if (entry.tags.length === 0) {
+      results.push(finding('untagged', 'low', 'untagged', entry, 'metadata'));
+    }
+
+    if (isStale(entry.updatedAt)) {
+      results.push(finding('stale', 'medium', 'stale_entry', entry, modified(entry)));
+    }
+
+    if (entry.username && (usernames.get(normalize(entry.username))?.length ?? 0) > 1) {
+      results.push(finding('duplicate-username', 'medium', 'duplicate_username', entry, 'duplicate_detected'));
+    }
+
+    if (entry.password && entry.password.length < 12) {
+      results.push(finding('weak-password', 'high', 'weak_password', entry, 'loaded_secret'));
+    }
+
+    if (entry.password && (loadedPasswords.get(entry.password)?.length ?? 0) > 1) {
+      results.push(finding('reused-password', 'high', 'reused_password', entry, 'loaded_secret'));
+    }
+  }
+
+  return results.sort((a, b) => severityRank(a.severity) - severityRank(b.severity) || a.title.localeCompare(b.title));
+}
+
+export function scoreAudit(entryCount: number, findingCount: number, high: number): string {
+  if (entryCount === 0) {
+    return '0';
+  }
+
+  return Math.max(0, 100 - high * 18 - findingCount * 4).toString();
+}
+
+function finding(
+  type: string,
+  severity: AuditSeverity,
+  title: string,
+  entry: EntryDto,
+  meta: string,
+): AuditFinding {
+  return {
+    key: `${type}:${entry.id}`,
+    severity,
+    title,
+    entry,
+    meta,
+  };
+}
+
+function groupBy(entries: EntryDto[], keyFor: (entry: EntryDto) => string): Map<string, EntryDto[]> {
+  const groups = new Map<string, EntryDto[]>();
+
+  for (const entry of entries) {
+    const key = keyFor(entry);
+
+    if (!key) {
+      continue;
+    }
+
+    groups.set(key, [...(groups.get(key) ?? []), entry]);
+  }
+
+  return groups;
+}
+
+function isStale(updatedAt: string): boolean {
+  const time = Date.parse(updatedAt);
+
+  if (Number.isNaN(time)) {
+    return false;
+  }
+
+  return Date.now() - time > 1000 * 60 * 60 * 24 * 180;
+}
+
+function modified(entry: EntryDto): string {
+  const time = Date.parse(entry.updatedAt);
+
+  if (Number.isNaN(time)) {
+    return 'unknown';
+  }
+
+  return new Date(time).toISOString().slice(0, 10);
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function severityRank(severity: AuditSeverity): number {
+  return severity === 'high' ? 0 : severity === 'medium' ? 1 : 2;
+}

--- a/apps/desktop/src/lib/audit.ts
+++ b/apps/desktop/src/lib/audit.ts
@@ -14,8 +14,9 @@ export function buildAuditFindings(entries: EntryDto[]): AuditFinding[] {
   const results: AuditFinding[] = [];
   const usernames = groupBy(entries, (entry) => normalize(entry.username));
   const loadedPasswords = groupBy(
-    entries.filter((entry) => entry.password),
-    (entry) => entry.password ?? '',
+    entries.filter(hasLoadedPassword),
+    (entry) => entry.password,
+    { includeEmptyKey: true },
   );
 
   for (const entry of entries) {
@@ -35,11 +36,11 @@ export function buildAuditFindings(entries: EntryDto[]): AuditFinding[] {
       results.push(finding('duplicate-username', 'medium', 'duplicate_username', entry, 'duplicate_detected'));
     }
 
-    if (entry.password && entry.password.length < 12) {
+    if (hasValue(entry.password) && entry.password.length < 12) {
       results.push(finding('weak-password', 'high', 'weak_password', entry, 'loaded_secret'));
     }
 
-    if (entry.password && (loadedPasswords.get(entry.password)?.length ?? 0) > 1) {
+    if (hasValue(entry.password) && (loadedPasswords.get(entry.password)?.length ?? 0) > 1) {
       results.push(finding('reused-password', 'high', 'reused_password', entry, 'loaded_secret'));
     }
   }
@@ -71,13 +72,17 @@ function finding(
   };
 }
 
-function groupBy(entries: EntryDto[], keyFor: (entry: EntryDto) => string): Map<string, EntryDto[]> {
-  const groups = new Map<string, EntryDto[]>();
+function groupBy<T extends EntryDto>(
+  entries: T[],
+  keyFor: (entry: T) => string,
+  options?: { includeEmptyKey?: boolean },
+): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
 
   for (const entry of entries) {
     const key = keyFor(entry);
 
-    if (!key) {
+    if (!options?.includeEmptyKey && !key) {
       continue;
     }
 
@@ -109,6 +114,14 @@ function modified(entry: EntryDto): string {
 
 function normalize(value: string): string {
   return value.trim().toLowerCase();
+}
+
+function hasLoadedPassword(entry: EntryDto): entry is EntryDto & { password: string } {
+  return hasValue(entry.password);
+}
+
+function hasValue<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
 }
 
 function severityRank(severity: AuditSeverity): number {

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -1,134 +1,19 @@
 <script lang="ts">
-  import type { EntryDto } from '../../ipc';
+  import { buildAuditFindings, scoreAudit } from '../../audit';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
   import { Button, Tag } from '../primitives';
 
-  type AuditSeverity = 'high' | 'medium' | 'low';
-
-  interface AuditFinding {
-    key: string;
-    severity: AuditSeverity;
-    title: string;
-    entry: EntryDto;
-    meta: string;
-  }
-
-  const findings = $derived(buildFindings(vaultState.entries));
+  const findings = $derived(buildAuditFindings(vaultState.entries));
   const highCount = $derived(findings.filter((finding) => finding.severity === 'high').length);
   const mediumCount = $derived(findings.filter((finding) => finding.severity === 'medium').length);
   const lowCount = $derived(findings.filter((finding) => finding.severity === 'low').length);
-  const auditScore = $derived(scoreFor(vaultState.entries.length, findings.length, highCount));
+  const auditScore = $derived(scoreAudit(vaultState.entries.length, findings.length, highCount));
 
-  function openEntry(entry: EntryDto) {
+  function openEntry(entry: (typeof vaultState.entries)[number]) {
     vaultState.selectedEntry = entry;
     uiState.view = 'detail';
-  }
-
-  function buildFindings(entries: EntryDto[]): AuditFinding[] {
-    const results: AuditFinding[] = [];
-    const usernames = groupBy(entries, (entry) => normalize(entry.username));
-    const loadedPasswords = groupBy(
-      entries.filter((entry) => entry.password),
-      (entry) => entry.password ?? '',
-    );
-
-    for (const entry of entries) {
-      if (!entry.url) {
-        results.push(finding('missing-url', 'low', 'missing_url', entry, 'metadata'));
-      }
-
-      if (entry.tags.length === 0) {
-        results.push(finding('untagged', 'low', 'untagged', entry, 'metadata'));
-      }
-
-      if (isStale(entry.updatedAt)) {
-        results.push(finding('stale', 'medium', 'stale_entry', entry, modified(entry)));
-      }
-
-      if (entry.username && (usernames.get(normalize(entry.username))?.length ?? 0) > 1) {
-        results.push(finding('duplicate-username', 'medium', 'duplicate_username', entry, 'duplicate_detected'));
-      }
-
-      if (entry.password && entry.password.length < 12) {
-        results.push(finding('weak-password', 'high', 'weak_password', entry, 'loaded_secret'));
-      }
-
-      if (entry.password && (loadedPasswords.get(entry.password)?.length ?? 0) > 1) {
-        results.push(finding('reused-password', 'high', 'reused_password', entry, 'loaded_secret'));
-      }
-    }
-
-    return results.sort((a, b) => severityRank(a.severity) - severityRank(b.severity) || a.title.localeCompare(b.title));
-  }
-
-  function finding(
-    type: string,
-    severity: AuditSeverity,
-    title: string,
-    entry: EntryDto,
-    meta: string,
-  ): AuditFinding {
-    return {
-      key: `${type}:${entry.id}`,
-      severity,
-      title,
-      entry,
-      meta,
-    };
-  }
-
-  function groupBy(entries: EntryDto[], keyFor: (entry: EntryDto) => string): Map<string, EntryDto[]> {
-    const groups = new Map<string, EntryDto[]>();
-
-    for (const entry of entries) {
-      const key = keyFor(entry);
-
-      if (!key) {
-        continue;
-      }
-
-      groups.set(key, [...(groups.get(key) ?? []), entry]);
-    }
-
-    return groups;
-  }
-
-  function scoreFor(entryCount: number, findingCount: number, high: number): string {
-    if (entryCount === 0) {
-      return '0';
-    }
-
-    return Math.max(0, 100 - high * 18 - findingCount * 4).toString();
-  }
-
-  function isStale(updatedAt: string): boolean {
-    const time = Date.parse(updatedAt);
-
-    if (Number.isNaN(time)) {
-      return false;
-    }
-
-    return Date.now() - time > 1000 * 60 * 60 * 24 * 180;
-  }
-
-  function modified(entry: EntryDto): string {
-    const time = Date.parse(entry.updatedAt);
-
-    if (Number.isNaN(time)) {
-      return 'unknown';
-    }
-
-    return new Date(time).toISOString().slice(0, 10);
-  }
-
-  function normalize(value: string): string {
-    return value.trim().toLowerCase();
-  }
-
-  function severityRank(severity: AuditSeverity): number {
-    return severity === 'high' ? 0 : severity === 'medium' ? 1 : 2;
   }
 </script>
 

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
-  import { buildAuditFindings, scoreAudit } from '../../audit';
+  import { getAuditState } from '../../stores/audit.svelte';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
   import { Button, Tag } from '../primitives';
 
-  const findings = $derived(buildAuditFindings(vaultState.entries));
-  const highCount = $derived(findings.filter((finding) => finding.severity === 'high').length);
-  const mediumCount = $derived(findings.filter((finding) => finding.severity === 'medium').length);
-  const lowCount = $derived(findings.filter((finding) => finding.severity === 'low').length);
-  const auditScore = $derived(scoreAudit(vaultState.entries.length, findings.length, highCount));
+  const auditState = $derived(getAuditState());
 
   function openEntry(entry: (typeof vaultState.entries)[number]) {
     vaultState.selectedEntry = entry;
@@ -23,9 +19,9 @@
       <div class="detail__crumbs mono">vault &nbsp;/&nbsp; <b>audit</b></div>
       <h1 id="audit-title" class="detail__title">audit<em>.</em></h1>
       <div class="detail__meta mono">
-        <Tag value={`${auditScore}/100`} />
+        <Tag value={`${auditState.score}/100`} />
         <span>entries · <b>{vaultState.entries.length}</b></span>
-        <span>findings · <b>{findings.length}</b></span>
+        <span>findings · <b>{auditState.findingCount}</b></span>
       </div>
     </div>
     <div class="detail__actions">
@@ -37,15 +33,15 @@
     <section class="audit-summary" aria-label="Audit summary">
       <div>
         <span>high</span>
-        <b>{highCount}</b>
+        <b>{auditState.highCount}</b>
       </div>
       <div>
         <span>medium</span>
-        <b>{mediumCount}</b>
+        <b>{auditState.mediumCount}</b>
       </div>
       <div>
         <span>low</span>
-        <b>{lowCount}</b>
+        <b>{auditState.lowCount}</b>
       </div>
       <div class="audit-summary__note">
         <span>coverage</span>
@@ -54,8 +50,8 @@
     </section>
 
     <div class="audit-list" role="list">
-      {#if findings.length > 0}
-        {#each findings as finding (finding.key)}
+      {#if auditState.findingCount > 0}
+        {#each auditState.findings as finding (finding.key)}
           <button type="button" class="audit-finding" onclick={() => openEntry(finding.entry)}>
             <span class={`audit-finding__severity audit-finding__severity--${finding.severity}`}>
               {finding.severity}

--- a/apps/desktop/src/lib/stores/audit.svelte.ts
+++ b/apps/desktop/src/lib/stores/audit.svelte.ts
@@ -1,0 +1,31 @@
+import { buildAuditFindings, scoreAudit, type AuditFinding } from '../audit';
+import { vaultState } from './vault.svelte';
+
+export interface AuditStateSnapshot {
+  findings: AuditFinding[];
+  findingCount: number;
+  highCount: number;
+  mediumCount: number;
+  lowCount: number;
+  score: string;
+}
+
+const auditState = $derived.by((): AuditStateSnapshot => {
+  const findings = buildAuditFindings(vaultState.entries);
+  const highCount = findings.filter((finding) => finding.severity === 'high').length;
+  const mediumCount = findings.filter((finding) => finding.severity === 'medium').length;
+  const lowCount = findings.filter((finding) => finding.severity === 'low').length;
+
+  return {
+    findings,
+    findingCount: findings.length,
+    highCount,
+    mediumCount,
+    lowCount,
+    score: scoreAudit(vaultState.entries.length, findings.length, highCount),
+  };
+});
+
+export function getAuditState(): AuditStateSnapshot {
+  return auditState;
+}


### PR DESCRIPTION
## Summary
- extract audit finding logic into a shared helper
- reuse the helper in the audit panel
- show audit finding count in the top audit tab

## Verification
- pnpm typecheck
- pnpm build
- cargo fmt --all --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an Audit system that flags security and data issues such as missing URLs, untagged entries, stale updates, duplicate usernames, weak passwords, and reused passwords.
  * Added an Audit score based on severity and total findings.
* **Bug Fixes**
  * The Audit tab badge now reliably shows a dynamic, accurate findings count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->