### PR TITLE
feat: add entry collections foundation

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -29,6 +29,7 @@ pub struct EntryDto {
     pub title: String,
     pub username: String,
     pub password: Option<String>,
+    pub collection: Option<String>,
     pub url: Option<String>,
     pub notes: Option<String>,
     pub tags: Vec<String>,
@@ -41,6 +42,7 @@ pub struct CreateEntryDto {
     pub title: String,
     pub username: String,
     pub password: String,
+    pub collection: Option<String>,
     pub url: Option<String>,
     pub notes: Option<String>,
     #[serde(default)]
@@ -52,6 +54,7 @@ pub struct UpdateEntryDto {
     pub title: Option<String>,
     pub username: Option<String>,
     pub password: Option<String>,
+    pub collection: Option<Option<String>>,
     pub url: Option<Option<String>>,
     pub notes: Option<Option<String>>,
     pub tags: Option<Vec<String>>,
@@ -171,6 +174,7 @@ pub fn create_entry(
     ensure_unlocked(&session)?;
 
     let mut entry = core_entry::create_entry(&data.title, &data.username, &data.password);
+    entry.collection = data.collection;
     entry.url = data.url;
     entry.notes = data.notes;
     entry.tags = data.tags;
@@ -275,6 +279,7 @@ impl EntryDto {
             title: entry.title.clone(),
             username: entry.username.clone(),
             password: include_password.then(|| entry.password.clone()),
+            collection: entry.collection.clone(),
             url: entry.url.clone(),
             notes: entry.notes.clone(),
             tags: entry.tags.clone(),
@@ -290,6 +295,7 @@ impl From<UpdateEntryDto> for core_entry::EntryPatch {
             title: value.title,
             username: value.username,
             password: value.password,
+            collection: value.collection,
             url: value.url,
             notes: value.notes,
             tags: value.tags,
@@ -525,6 +531,7 @@ mod tests {
         let dto: CreateEntryDto =
             serde_json::from_str(json).expect("create entry dto should deserialize");
 
+        assert!(dto.collection.is_none());
         assert!(dto.tags.is_empty());
     }
 

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -1772,6 +1772,7 @@ body {
   text-transform: lowercase;
 }
 .entry-form__field input,
+.entry-form__field select,
 .entry-form__field textarea {
   width: 100%;
   min-width: 0;
@@ -1785,7 +1786,8 @@ body {
   outline: none;
   transition: border-color .12s, background .12s;
 }
-.entry-form__field input {
+.entry-form__field input,
+.entry-form__field select {
   height: 38px;
   padding: 0 12px;
 }
@@ -1796,6 +1798,7 @@ body {
   line-height: 1.5;
 }
 .entry-form__field input:focus,
+.entry-form__field select:focus,
 .entry-form__field textarea:focus {
   border-color: var(--accent);
   background: var(--bg-card-2);

--- a/apps/desktop/src/lib/components/detail/EntryDetail.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryDetail.svelte
@@ -77,11 +77,12 @@
       <div class="detail__title-wrap">
         <div class="detail__crumbs mono">
           <button type="button" class="detail__crumb-link" onclick={backToList}>vault</button>
-          &nbsp;/&nbsp; recent &nbsp;/&nbsp; <b>{entry.title}</b>
+          &nbsp;/&nbsp; {entry.collection ?? 'uncategorized'} &nbsp;/&nbsp; <b>{entry.title}</b>
         </div>
         <h1 id="entry-detail-title" class="detail__title">{entry.title}<em>.</em></h1>
         <div class="detail__meta mono">
           <Tag value="⌘1" />
+          <span>collection · <b>{entry.collection ?? 'none'}</b></span>
           <span>id · <b>{entry.id}</b></span>
           <span>modified · <b>{modified(entry)}</b></span>
           <span>auth · <b>password</b></span>

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -9,10 +9,12 @@
   const mode = $derived(editingEntry ? 'edit' : 'create');
   const titleText = $derived(mode === 'edit' ? 'edit_entry' : 'new_entry');
   const submitText = $derived(mode === 'edit' ? 'save_changes' : 'create_entry');
+  const collectionOptions = ['work', 'personal', 'infrastructure', 'shared', 'archive'] as const;
 
   let title = $state('');
   let username = $state('');
   let password = $state('');
+  let collection = $state('');
   let url = $state('');
   let notes = $state('');
   let tags = $state('');
@@ -37,6 +39,7 @@
     username = entry?.username ?? '';
     password = entry?.password ?? '';
     loadedPassword = password;
+    collection = entry?.collection ?? '';
     url = entry?.url ?? '';
     notes = entry?.notes ?? '';
     tags = entry?.tags.join(', ') ?? '';
@@ -59,6 +62,7 @@
               title: title.trim(),
               username: username.trim(),
               password,
+              collection: optionalText(collection),
               url: optionalText(url),
               notes: optionalText(notes),
               tags: parseTags(tags),
@@ -99,6 +103,7 @@
     const payload = {
       title: title.trim(),
       username: username.trim(),
+      collection: optionalText(collection),
       url: optionalText(url),
       notes: optionalText(notes),
       tags: parseTags(tags),
@@ -175,6 +180,16 @@
       <label class="entry-form__field">
         <span>password</span>
         <input bind:value={password} autocomplete="new-password" required={passwordRequired} type="password" />
+      </label>
+
+      <label class="entry-form__field">
+        <span>collection</span>
+        <select bind:value={collection}>
+          <option value="">none</option>
+          {#each collectionOptions as option}
+            <option value={option}>{option}</option>
+          {/each}
+        </select>
       </label>
 
       <label class="entry-form__field entry-form__field--wide">

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -69,6 +69,7 @@
     }
 
     return [entry.title, entry.username, entry.url ?? '', ...entry.tags]
+      .concat(entry.collection ?? '')
       .join(' ')
       .toLowerCase()
       .includes(query);
@@ -83,7 +84,7 @@
       return recent.has(entry.id);
     }
 
-    return tagsFor(entry).has(filter);
+    return collectionFor(entry) === filter;
   }
 
   function buildSections(entries: EntryDto[], filter: FilterKey, recent: Set<string>): EntrySection[] {
@@ -91,34 +92,43 @@
       return [{ key: filter, label: filter, entries }];
     }
 
-    const grouped: EntrySection[] = [
-      { key: 'recent', label: 'recent', entries: [] },
-      { key: 'work', label: 'work', entries: [] },
-      { key: 'infrastructure', label: 'infrastructure', entries: [] },
-      { key: 'other', label: 'other', entries: [] },
-    ];
+    const grouped = new Map<string, EntrySection>([
+      ['recent', { key: 'recent', label: 'recent', entries: [] }],
+      ['work', { key: 'work', label: 'work', entries: [] }],
+      ['personal', { key: 'personal', label: 'personal', entries: [] }],
+      ['infrastructure', { key: 'infrastructure', label: 'infrastructure', entries: [] }],
+      ['shared', { key: 'shared', label: 'shared', entries: [] }],
+      ['archive', { key: 'archive', label: 'archive', entries: [] }],
+      ['other', { key: 'other', label: 'other', entries: [] }],
+    ]);
 
     for (const entry of entries) {
       if (recent.has(entry.id)) {
-        grouped[0].entries.push(entry);
-      } else if (tagsFor(entry).has('work')) {
-        grouped[1].entries.push(entry);
-      } else if (tagsFor(entry).has('infrastructure')) {
-        grouped[2].entries.push(entry);
+        grouped.get('recent')?.entries.push(entry);
       } else {
-        grouped[3].entries.push(entry);
+        grouped.get(collectionFor(entry) ?? 'other')?.entries.push(entry);
       }
     }
 
-    return grouped.filter((section) => section.entries.length > 0);
+    return [...grouped.values()].filter((section) => section.entries.length > 0);
   }
 
   function countByFilter(filter: FilterKey, recent: Set<string>): number {
     return vaultState.entries.filter((entry) => matchesFilter(entry, filter, recent)).length;
   }
 
-  function tagsFor(entry: EntryDto): Set<string> {
-    return new Set(entry.tags.map(normalize).map((tag) => (tag === 'infra' ? 'infrastructure' : tag)));
+  function collectionFor(entry: EntryDto): FilterKey | null {
+    const collection = normalize(entry.collection ?? '');
+
+    if (collection === 'work' || collection === 'personal' || collection === 'infrastructure' || collection === 'shared' || collection === 'archive') {
+      return collection;
+    }
+
+    if (collection === 'infra') {
+      return 'infrastructure';
+    }
+
+    return null;
   }
 
   function deriveTags(entries: EntryDto[]): string[] {

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -15,6 +15,7 @@ export interface EntryDto {
   title: string;
   username: string;
   password: string | null;
+  collection: string | null;
   url: string | null;
   notes: string | null;
   tags: string[];
@@ -26,6 +27,7 @@ export interface CreateEntryDto {
   title: string;
   username: string;
   password: string;
+  collection?: string | null;
   url?: string | null;
   notes?: string | null;
   tags?: string[];
@@ -35,6 +37,7 @@ export interface UpdateEntryDto {
   title?: string;
   username?: string;
   password?: string;
+  collection?: string | null;
   url?: string | null;
   notes?: string | null;
   tags?: string[];

--- a/packages/vault-core/src/entry.rs
+++ b/packages/vault-core/src/entry.rs
@@ -11,6 +11,7 @@ pub fn create_entry(title: &str, username: &str, password: &str) -> VaultEntry {
         title: title.to_string(),
         username: username.to_string(),
         password: password.to_string(),
+        collection: None,
         url: None,
         notes: None,
         tags: Vec::new(),
@@ -24,6 +25,7 @@ pub struct EntryPatch {
     pub title: Option<String>,
     pub username: Option<String>,
     pub password: Option<String>,
+    pub collection: Option<Option<String>>,
     pub url: Option<Option<String>>,
     pub notes: Option<Option<String>>,
     pub tags: Option<Vec<String>>,
@@ -38,6 +40,9 @@ pub fn update_entry(entry: &mut VaultEntry, patch: EntryPatch) {
     }
     if let Some(password) = patch.password {
         entry.password = password;
+    }
+    if let Some(collection) = patch.collection {
+        entry.collection = collection;
     }
     if let Some(url) = patch.url {
         entry.url = url;
@@ -81,17 +86,23 @@ fn relevance(entry: &VaultEntry, query: &str) -> Option<u8> {
     } else if entry.username.to_lowercase().contains(query) {
         Some(1)
     } else if entry
+        .collection
+        .as_ref()
+        .is_some_and(|collection| collection.to_lowercase().contains(query))
+    {
+        Some(2)
+    } else if entry
         .url
         .as_ref()
         .is_some_and(|url| url.to_lowercase().contains(query))
     {
-        Some(2)
+        Some(3)
     } else if entry
         .tags
         .iter()
         .any(|tag| tag.to_lowercase().contains(query))
     {
-        Some(3)
+        Some(4)
     } else {
         None
     }
@@ -113,6 +124,7 @@ mod tests {
         assert_eq!(entry.password, "secret");
         assert!(entry.url.is_none());
         assert!(entry.notes.is_none());
+        assert!(entry.collection.is_none());
         assert!(entry.tags.is_empty());
         assert_eq!(entry.created_at, entry.updated_at);
         assert!(uuid::Uuid::parse_str(&entry.id).is_ok());
@@ -131,6 +143,7 @@ mod tests {
                 title: Some("GitLab".to_string()),
                 username: Some("akei9".to_string()),
                 password: Some("new-secret".to_string()),
+                collection: Some(Some("work".to_string())),
                 url: Some(Some("https://gitlab.com".to_string())),
                 notes: Some(None),
                 tags: Some(vec!["work".to_string(), "ssh".to_string()]),
@@ -140,6 +153,7 @@ mod tests {
         assert_eq!(entry.title, "GitLab");
         assert_eq!(entry.username, "akei9");
         assert_eq!(entry.password, "new-secret");
+        assert_eq!(entry.collection.as_deref(), Some("work"));
         assert_eq!(entry.url.as_deref(), Some("https://gitlab.com"));
         assert!(entry.notes.is_none());
         assert_eq!(entry.tags, vec!["work", "ssh"]);
@@ -151,19 +165,28 @@ mod tests {
     fn search_entries_matches_title_username_url_and_tags_by_relevance() {
         let title_match = create_entry("GitHub", "admin", "secret");
         let mut username_match = create_entry("Admin Console", "github_user", "secret");
+        let mut collection_match = create_entry("Ops Console", "ops", "secret");
         let mut url_match = create_entry("Code", "dev", "secret");
         let mut tag_match = create_entry("Deploy", "ops", "secret");
+        collection_match.collection = Some("github".to_string());
         url_match.url = Some("https://github.com".to_string());
         tag_match.tags = vec!["github".to_string()];
         username_match.tags = vec!["other".to_string()];
 
-        let entries = vec![tag_match, url_match, username_match, title_match];
+        let entries = vec![
+            tag_match,
+            url_match,
+            collection_match,
+            username_match,
+            title_match,
+        ];
         let results = search_entries(&entries, "github");
 
         assert_eq!(results[0].title, "GitHub");
         assert_eq!(results[1].title, "Admin Console");
-        assert_eq!(results[2].title, "Code");
-        assert_eq!(results[3].title, "Deploy");
+        assert_eq!(results[2].title, "Ops Console");
+        assert_eq!(results[3].title, "Code");
+        assert_eq!(results[4].title, "Deploy");
     }
 
     #[test]

--- a/packages/vault-core/src/types.rs
+++ b/packages/vault-core/src/types.rs
@@ -30,6 +30,7 @@ pub struct VaultEntry {
     pub title: String,
     pub username: String,
     pub password: String,
+    pub collection: Option<String>,
     pub url: Option<String>,
     pub notes: Option<String>,
     pub tags: Vec<String>,

--- a/packages/vault-core/src/vault.rs
+++ b/packages/vault-core/src/vault.rs
@@ -14,6 +14,7 @@ use crate::types::{VaultEntry, VaultMeta};
 const FIELD_TITLE: &str = "Title";
 const FIELD_USERNAME: &str = "UserName";
 const FIELD_PASSWORD: &str = "Password";
+const FIELD_COLLECTION: &str = "ArcaCollection";
 const FIELD_URL: &str = "URL";
 const FIELD_NOTES: &str = "Notes";
 
@@ -122,6 +123,9 @@ fn populate_keepass_entry(
     keepass_entry.set_unprotected(FIELD_USERNAME, entry.username.clone());
     keepass_entry.set_protected(FIELD_PASSWORD, entry.password.as_str());
 
+    if let Some(collection) = &entry.collection {
+        keepass_entry.set_unprotected(FIELD_COLLECTION, collection.clone());
+    }
     if let Some(url) = &entry.url {
         keepass_entry.set_unprotected(FIELD_URL, url.clone());
     }
@@ -192,6 +196,7 @@ fn vault_entry_from_keepass_entry(entry: &KeepassEntry) -> VaultEntry {
         title: entry.get_title().unwrap_or_default().to_string(),
         username: entry.get_username().unwrap_or_default().to_string(),
         password: entry.get_password().unwrap_or_default().to_string(),
+        collection: optional_string(entry.get(FIELD_COLLECTION)),
         url: optional_string(entry.get_url()),
         notes: optional_string(entry.get(FIELD_NOTES)),
         tags: entry.tags.clone(),

--- a/packages/vault-core/tests/vault_roundtrip.rs
+++ b/packages/vault-core/tests/vault_roundtrip.rs
@@ -16,6 +16,7 @@ fn test_create_open_roundtrip() {
     let meta =
         create_vault(&path, "master-password", "ROUNDTRIP").expect("vault should be created");
     let mut entry = create_entry("GitHub", "arca_admin", "correct horse");
+    entry.collection = Some("work".to_string());
     entry.url = Some("https://github.com".to_string());
     entry.notes = Some("primary repository account".to_string());
     entry.tags = vec!["work".to_string(), "ssh".to_string()];
@@ -30,6 +31,7 @@ fn test_create_open_roundtrip() {
     assert_eq!(entries[0].title, "GitHub");
     assert_eq!(entries[0].username, "arca_admin");
     assert_eq!(entries[0].password, "correct horse");
+    assert_eq!(entries[0].collection.as_deref(), Some("work"));
     assert_eq!(entries[0].url.as_deref(), Some("https://github.com"));
     assert_eq!(
         entries[0].notes.as_deref(),
@@ -74,6 +76,7 @@ fn test_current_save_opens_with_keepass_and_protects_password() {
     let mut entry = create_entry("Current KeePass", "fixture_user", &entry_password);
 
     entry.id = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee".to_string();
+    entry.collection = Some("infrastructure".to_string());
     entry.url = Some("https://example.test/current".to_string());
     entry.notes = Some("Non-secret fixture saved by current vault-core".to_string());
     entry.tags = vec!["compat".to_string(), "keepass-current".to_string()];


### PR DESCRIPTION
# Description

- add an optional `collection` field to entries across `vault-core`, Tauri DTOs, and desktop IPC types
- persist the field in the vault so categories become a real part of the data model instead of being inferred from tags
- wire the current desktop entry form, detail view, and vault list filters to use `collection`

## Security Checklist

- [x] No secrets, keys, passwords, vault contents, or generated credentials are hardcoded or logged
- [x] No new `unsafe` blocks without justification and human review
- [ ] Cryptographic changes reviewed against the threat model
- [ ] OSV/RustSec scan passes with no new vulnerabilities introduced
- [x] Changes touching `packages/vault-core`, Tauri IPC, or secret display/copy flows are marked for human review

## Testing

- [x] Unit tests added/updated
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `pnpm build`
- [ ] Tested locally on target platform when UI or Tauri behavior changed

## Agent-Assisted Changes

- [ ] AI-generated or AI-edited code was reviewed line by line by a human
- [x] `AGENTS.md` files remain accurate after this change