### PR TITLE
feat: refresh entry compose flow

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2138,6 +2138,9 @@ body {
 .form-hint {
   margin-top: 10px;
 }
+.form-hint--warn {
+  color: var(--accent);
+}
 .form__actions {
   display: flex;
   align-items: center;

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -1885,6 +1885,303 @@ body {
   font-weight: 500;
 }
 
+.entry-compose {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  overflow: auto;
+  padding: 22px 26px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.page__head {
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+}
+.page__hash {
+  font-family: var(--font-mono);
+  color: var(--accent);
+  font-size: calc(18px * var(--arca-font-scale, 1));
+  font-weight: 600;
+  line-height: 1;
+}
+.page__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: calc(22px * var(--arca-font-scale, 1));
+  line-height: 1;
+  letter-spacing: -0.018em;
+  color: var(--text);
+}
+.page__title em {
+  font-style: normal;
+  color: var(--accent);
+}
+.page__meta {
+  margin-left: auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px 16px;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+}
+.page__meta b {
+  color: var(--text-2);
+  font-weight: 500;
+}
+.form {
+  width: min(100%, 1080px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.form__panel {
+  display: grid;
+  gap: 12px;
+  padding: 16px 18px;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  background: var(--bg-card);
+}
+.form-row {
+  display: grid;
+  grid-template-columns: 116px minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+  min-width: 0;
+}
+.form-row__k {
+  padding-top: 10px;
+  font-family: var(--font-mono);
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+.finput,
+.ftextarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: calc(12px * var(--arca-font-scale, 1));
+  letter-spacing: 0.02em;
+  outline: none;
+  transition: border-color .12s, background .12s;
+}
+.finput {
+  height: 38px;
+  padding: 0 12px;
+}
+.ftextarea {
+  min-height: 180px;
+  resize: vertical;
+  padding: 11px 12px;
+  line-height: 1.5;
+}
+.finput:focus,
+.ftextarea:focus,
+.cat-opt:focus-visible,
+.tag-sugg__item:focus-visible,
+.tag-chip__x:focus-visible {
+  border-color: var(--accent);
+  background: var(--bg-card-2);
+  outline: none;
+}
+.finput::placeholder,
+.ftextarea::placeholder,
+.tag-add::placeholder {
+  color: var(--text-3);
+  opacity: 0.9;
+}
+.finput-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.finput-row .finput {
+  flex: 1 1 auto;
+}
+.form-entropy {
+  margin-top: 10px;
+}
+.cat-select {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.cat-opt {
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border-radius: 5px;
+  border: 1px solid var(--rule-strong);
+  background: transparent;
+  color: var(--text-3);
+  cursor: pointer;
+  transition: border-color .12s, background .12s, color .12s;
+}
+.cat-opt:hover {
+  border-color: var(--text-3);
+  color: var(--text-2);
+}
+.cat-opt--on {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.cat-opt--new {
+  border-style: dashed;
+}
+.cat-newwrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.cat-newwrap .finput {
+  width: 170px;
+  height: 30px;
+  padding: 4px 8px;
+}
+.tagedit {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 6px 8px;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--bg);
+}
+.tagedit:focus-within {
+  border-color: var(--accent);
+  background: var(--bg-card-2);
+}
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  padding: 5px 8px;
+  border-radius: 5px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid rgba(200, 85, 61, 0.18);
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  letter-spacing: 0.08em;
+}
+.tag-chip__x {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+}
+.tag-add {
+  flex: 1 1 180px;
+  min-width: 120px;
+  height: 28px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font-size: calc(12px * var(--arca-font-scale, 1));
+  letter-spacing: 0.02em;
+}
+.tag-sugg {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.tag-sugg__k,
+.form-hint {
+  font-family: var(--font-mono);
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  letter-spacing: 0.05em;
+  color: var(--text-3);
+}
+.tag-sugg__item {
+  border: 1px solid var(--rule-strong);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-2);
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  letter-spacing: 0.08em;
+  transition: border-color .12s, background .12s, color .12s;
+}
+.tag-sugg__item:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.form-hint {
+  margin-top: 10px;
+}
+.form__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.form__spacer {
+  flex: 1 1 auto;
+}
+
+@media (max-width: 980px) {
+  .page__head {
+    flex-wrap: wrap;
+    gap: 12px 16px;
+  }
+  .page__meta {
+    width: 100%;
+    margin-left: 0;
+    justify-content: flex-start;
+  }
+  .form-row {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+  .form-row__k {
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  .entry-compose {
+    padding: 18px 18px 24px;
+  }
+  .finput-row,
+  .form__actions,
+  .cat-newwrap {
+    flex-wrap: wrap;
+  }
+  .finput-row .iconbtn,
+  .finput-row .btn,
+  .form__actions .btn {
+    flex: 0 0 auto;
+  }
+}
+
 /* Filled "moss" panel — note/content (the lipgloss-purple equivalent) */
 .note-panel {
   background: var(--vault);

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -1,30 +1,42 @@
 <script lang="ts">
-  import { createEntry, updateEntry, type EntryDto } from '../../ipc';
+  import { onMount } from 'svelte';
+  import { createEntry, generatePassword, updateEntry, type EntryDto } from '../../ipc';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
-  import { Button, Tag } from '../primitives';
+  import { Button, Entropy, IconButton, Kbd } from '../primitives';
 
   const editingEntry = $derived(vaultState.selectedEntry);
   const mode = $derived(editingEntry ? 'edit' : 'create');
   const titleText = $derived(mode === 'edit' ? 'edit_entry' : 'new_entry');
-  const submitText = $derived(mode === 'edit' ? 'save_changes' : 'create_entry');
-  const collectionOptions = ['work', 'personal', 'infrastructure', 'shared', 'archive'] as const;
+  const submitText = $derived(mode === 'edit' ? 'save_changes' : 'save_entry');
+  const baseCollections = ['work', 'personal', 'infrastructure', 'shared', 'archive'] as const;
 
   let title = $state('');
   let username = $state('');
   let password = $state('');
-  let collection = $state('');
+  let collection = $state('work');
   let url = $state('');
   let notes = $state('');
   let tags = $state('');
+  let tagInput = $state('');
   let busy = $state(false);
   let errorMessage = $state('');
   let loadedEntryId = $state<string | null>(null);
   let loadedPassword = $state('');
+  let revealPassword = $state(false);
+  let newCollectionOpen = $state(false);
+  let newCollectionValue = $state('');
+  let generatingPassword = $state(false);
 
   const passwordRequired = $derived(mode === 'create');
   const canSubmit = $derived(title.trim().length > 0 && (!passwordRequired || password.length > 0) && !busy);
+  const collectionOptions = $derived(deriveCollectionOptions(vaultState.entries, collection));
+  const normalizedTags = $derived(parseTags(tags));
+  const suggestedTags = $derived(deriveSuggestedTags(vaultState.entries, normalizedTags));
+  const entropyBits = $derived(estimateEntropyBits(password));
+  const entropyFilled = $derived(password ? Math.max(1, Math.min(16, Math.round(entropyBits / 8))) : 0);
+  const entropyStrength = $derived(entropyBits >= 90 ? 'strong' : entropyBits >= 60 ? 'medium' : 'weak');
 
   $effect(() => {
     const entry = editingEntry;
@@ -39,11 +51,36 @@
     username = entry?.username ?? '';
     password = entry?.password ?? '';
     loadedPassword = password;
-    collection = entry?.collection ?? '';
+    collection = entry?.collection ?? 'work';
     url = entry?.url ?? '';
     notes = entry?.notes ?? '';
     tags = entry?.tags.join(', ') ?? '';
+    tagInput = '';
+    revealPassword = false;
+    newCollectionOpen = false;
+    newCollectionValue = '';
     errorMessage = '';
+  });
+
+  onMount(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        cancel();
+        return;
+      }
+
+      if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+        event.preventDefault();
+        void submit();
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeydown);
+    };
   });
 
   async function submit() {
@@ -65,7 +102,7 @@
               collection: optionalText(collection),
               url: optionalText(url),
               notes: optionalText(notes),
-              tags: parseTags(tags),
+              tags: normalizedTags,
             });
 
       applySavedEntry(saved);
@@ -100,17 +137,77 @@
   }
 
   function updatePayload() {
-    const payload = {
+    return {
       title: title.trim(),
       username: username.trim(),
       collection: optionalText(collection),
       url: optionalText(url),
       notes: optionalText(notes),
-      tags: parseTags(tags),
+      tags: normalizedTags,
       ...(password.length > 0 && password !== loadedPassword ? { password } : {}),
     };
+  }
 
-    return payload;
+  async function generateEntryPassword() {
+    generatingPassword = true;
+    errorMessage = '';
+
+    try {
+      const generated = await generatePassword({
+        length: 20,
+        uppercase: true,
+        lowercase: true,
+        digits: true,
+        symbols: true,
+        excludeAmbiguous: true,
+      });
+
+      password = generated.password;
+      revealPassword = true;
+    } catch (error) {
+      errorMessage = messageFromError(error);
+    } finally {
+      generatingPassword = false;
+    }
+  }
+
+  function togglePasswordReveal() {
+    if (!password) {
+      return;
+    }
+
+    revealPassword = !revealPassword;
+  }
+
+  function addCollection() {
+    const nextCollection = normalizeCollection(newCollectionValue);
+
+    if (!nextCollection) {
+      newCollectionOpen = false;
+      newCollectionValue = '';
+      return;
+    }
+
+    collection = nextCollection;
+    newCollectionOpen = false;
+    newCollectionValue = '';
+  }
+
+  function addTag(raw = tagInput) {
+    const nextTag = normalizeTag(raw);
+
+    if (!nextTag) {
+      tagInput = '';
+      return;
+    }
+
+    const nextTags = normalizedTags.includes(nextTag) ? normalizedTags : [...normalizedTags, nextTag];
+    tags = nextTags.join(', ');
+    tagInput = '';
+  }
+
+  function removeTag(tag: string) {
+    tags = normalizedTags.filter((existingTag) => existingTag !== tag).join(', ');
   }
 
   function parseTags(value: string): string[] {
@@ -118,17 +215,94 @@
 
     return value
       .split(',')
-      .map((tag) => tag.trim())
+      .map(normalizeTag)
       .filter((tag) => {
-        const key = tag.toLowerCase();
-
-        if (!key || seen.has(key)) {
+        if (!tag || seen.has(tag)) {
           return false;
         }
 
-        seen.add(key);
+        seen.add(tag);
         return true;
       });
+  }
+
+  function deriveSuggestedTags(entries: EntryDto[], selectedTags: string[]): string[] {
+    const counts = new Map<string, number>();
+
+    for (const entry of entries) {
+      for (const tag of entry.tags) {
+        const normalizedTag = normalizeTag(tag);
+
+        if (!normalizedTag || selectedTags.includes(normalizedTag)) {
+          continue;
+        }
+
+        counts.set(normalizedTag, (counts.get(normalizedTag) ?? 0) + 1);
+      }
+    }
+
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, 8)
+      .map(([tag]) => tag);
+  }
+
+  function deriveCollectionOptions(entries: EntryDto[], currentCollection: string): string[] {
+    const seen = new Set<string>();
+
+    for (const option of baseCollections) {
+      seen.add(option);
+    }
+
+    for (const entry of entries) {
+      const normalizedCollection = normalizeCollection(entry.collection ?? '');
+
+      if (normalizedCollection) {
+        seen.add(normalizedCollection);
+      }
+    }
+
+    const normalizedCurrent = normalizeCollection(currentCollection);
+
+    if (normalizedCurrent) {
+      seen.add(normalizedCurrent);
+    }
+
+    return [...seen];
+  }
+
+  function estimateEntropyBits(value: string): number {
+    if (!value) {
+      return 0;
+    }
+
+    let pool = 0;
+
+    if (/[a-z]/.test(value)) {
+      pool += 26;
+    }
+
+    if (/[A-Z]/.test(value)) {
+      pool += 26;
+    }
+
+    if (/[0-9]/.test(value)) {
+      pool += 10;
+    }
+
+    if (/[^a-zA-Z0-9]/.test(value)) {
+      pool += 24;
+    }
+
+    return Math.round(value.length * Math.log2(pool || 26));
+  }
+
+  function normalizeCollection(value: string): string {
+    return value.trim().toLowerCase().replace(/\s+/g, '-');
+  }
+
+  function normalizeTag(value: string): string {
+    return value.trim().toLowerCase().replace(/\s+/g, '-');
   }
 
   function messageFromError(error: unknown): string {
@@ -140,71 +314,165 @@
   }
 </script>
 
-<section class="entry-form" aria-labelledby="entry-form-title">
-  <div class="detail-head">
-    <div class="detail__title-wrap">
-      <div class="detail__crumbs mono">
-        <button type="button" class="detail__crumb-link" onclick={cancel}>vault</button>
-        &nbsp;/&nbsp; <b>{titleText}</b>
-      </div>
-      <h1 id="entry-form-title" class="detail__title">{titleText}<em>.</em></h1>
-      <div class="detail__meta mono">
-        <Tag value={mode} />
-        <span>vault · <b>{vaultState.vaultName || 'local'}</b></span>
-        <span>fields · <b>{passwordRequired ? 'password' : 'optional_password'}</b></span>
-      </div>
-    </div>
-    <div class="detail__actions">
-      <Button variant="ghost" size="sm" onclick={cancel} disabled={busy}>cancel</Button>
+<section class="entry-compose" aria-labelledby="entry-form-title">
+  <div class="page__head">
+    <span class="page__hash mono">#</span>
+    <h1 id="entry-form-title" class="page__title">{titleText}<em>.</em></h1>
+    <div class="page__meta mono">
+      <span>vault · <b>{vaultState.vaultName || 'vault.local'}</b></span>
+      <span>{mode === 'edit' ? 'editing' : 'encrypted'} · <b>{mode === 'edit' ? editingEntry?.id ?? 'selected' : 'on save'}</b></span>
     </div>
   </div>
 
   <form
-    class="entry-form__body"
+    class="form"
     onsubmit={(event) => {
       event.preventDefault();
-      submit();
+      void submit();
     }}
   >
-    <div class="entry-form__grid">
-      <label class="entry-form__field entry-form__field--wide">
-        <span>title</span>
-        <input bind:value={title} autocomplete="off" maxlength="120" required />
+    <div class="form__panel">
+      <label class="form-row">
+        <span class="form-row__k">name</span>
+        <input class="finput mono" bind:value={title} autocomplete="off" maxlength="120" placeholder="e.g. cloudflare" required />
       </label>
 
-      <label class="entry-form__field">
-        <span>username</span>
-        <input bind:value={username} autocomplete="username" maxlength="160" />
-      </label>
-
-      <label class="entry-form__field">
-        <span>password</span>
-        <input bind:value={password} autocomplete="new-password" required={passwordRequired} type="password" />
-      </label>
-
-      <label class="entry-form__field">
-        <span>collection</span>
-        <select bind:value={collection}>
-          <option value="">none</option>
+      <div class="form-row">
+        <div class="form-row__k">category</div>
+        <div class="cat-select">
           {#each collectionOptions as option}
-            <option value={option}>{option}</option>
+            <button
+              type="button"
+              class={collection === option ? 'cat-opt cat-opt--on mono' : 'cat-opt mono'}
+              onclick={() => {
+                collection = option;
+                newCollectionOpen = false;
+                newCollectionValue = '';
+              }}
+            >
+              {option}
+            </button>
           {/each}
-        </select>
+
+          {#if !newCollectionOpen}
+            <button type="button" class="cat-opt cat-opt--new mono" onclick={() => (newCollectionOpen = true)}>+ new</button>
+          {:else}
+            <span class="cat-newwrap">
+              <input
+                class="finput mono"
+                bind:value={newCollectionValue}
+                placeholder="collection name"
+                onkeydown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    addCollection();
+                  }
+
+                  if (event.key === 'Escape') {
+                    event.preventDefault();
+                    newCollectionOpen = false;
+                    newCollectionValue = '';
+                  }
+                }}
+              />
+              <Button variant="ghost" size="xs" onclick={addCollection}>add</Button>
+            </span>
+          {/if}
+        </div>
+      </div>
+
+      <label class="form-row">
+        <span class="form-row__k">url</span>
+        <input class="finput mono" bind:value={url} autocomplete="url" inputmode="url" maxlength="400" placeholder="https://" />
       </label>
 
-      <label class="entry-form__field entry-form__field--wide">
-        <span>url</span>
-        <input bind:value={url} autocomplete="url" inputmode="url" maxlength="400" />
+      <label class="form-row">
+        <span class="form-row__k">username</span>
+        <input class="finput mono" bind:value={username} autocomplete="username" maxlength="160" placeholder="user or email" />
       </label>
 
-      <label class="entry-form__field entry-form__field--wide">
-        <span>tags</span>
-        <input bind:value={tags} autocomplete="off" maxlength="240" />
-      </label>
+      <div class="form-row">
+        <div class="form-row__k">password</div>
+        <div>
+          <div class="finput-row">
+            <input
+              class="finput mono"
+              bind:value={password}
+              autocomplete="new-password"
+              required={passwordRequired}
+              type={revealPassword ? 'text' : 'password'}
+              placeholder="type or generate"
+            />
+            <IconButton
+              label={revealPassword ? 'Hide entry password' : 'Reveal entry password'}
+              onclick={togglePasswordReveal}
+              disabled={!password}
+            >
+              <Icon name="eye" size={13} />
+            </IconButton>
+            <Button variant="ghost" size="sm" onclick={generateEntryPassword} disabled={generatingPassword}>
+              <Icon name="refresh" size={12} />
+              {generatingPassword ? 'generating' : 'generate'}
+            </Button>
+          </div>
 
-      <label class="entry-form__field entry-form__field--wide">
-        <span>notes</span>
-        <textarea bind:value={notes} rows="7"></textarea>
+          {#if password}
+            <div class="form-entropy">
+              <Entropy filled={entropyFilled} bits={entropyBits} strength={entropyStrength} />
+            </div>
+          {/if}
+        </div>
+      </div>
+    </div>
+
+    <div class="form__panel">
+      <div class="form-row">
+        <div class="form-row__k">tags</div>
+        <div>
+          <div class="tagedit">
+            {#each normalizedTags as tag (tag)}
+              <span class="tag-chip mono">
+                #{tag}
+                <button type="button" class="tag-chip__x" aria-label={`Remove ${tag}`} onclick={() => removeTag(tag)}>✕</button>
+              </span>
+            {/each}
+            <input
+              class="tag-add mono"
+              bind:value={tagInput}
+              placeholder={normalizedTags.length > 0 ? 'add another…' : 'add a tag, press enter'}
+              onkeydown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  addTag();
+                } else if (event.key === 'Backspace' && tagInput.length === 0 && normalizedTags.length > 0) {
+                  event.preventDefault();
+                  removeTag(normalizedTags[normalizedTags.length - 1]);
+                }
+              }}
+            />
+          </div>
+
+          {#if suggestedTags.length > 0}
+            <div class="tag-sugg">
+              <span class="tag-sugg__k mono">suggested</span>
+              {#each suggestedTags as tag (tag)}
+                <button type="button" class="tag-sugg__item mono" onclick={() => addTag(tag)}>#{tag}</button>
+              {/each}
+            </div>
+          {/if}
+
+          <div class="form-hint mono">tags slice across categories — once saved, filter the vault by any tag from the sidebar.</div>
+        </div>
+      </div>
+
+      <label class="form-row">
+        <span class="form-row__k">notes</span>
+        <textarea
+          class="ftextarea mono"
+          bind:value={notes}
+          rows="8"
+          placeholder="optional · plain text, encrypted with the entry"
+        ></textarea>
       </label>
     </div>
 
@@ -212,13 +480,16 @@
       <div class="entry-form__error mono" role="alert">{errorMessage}</div>
     {/if}
 
-    <div class="entry-form__footer">
-      <div class="entry-form__hint mono">
-        required · <b>{passwordRequired ? 'title password' : 'title'}</b>
-      </div>
+    <div class="form__actions">
+      <Button variant="bare" onclick={cancel} disabled={busy}>
+        cancel
+        <Kbd value="esc" />
+      </Button>
+      <span class="form__spacer"></span>
       <Button variant="primary" type="submit" disabled={!canSubmit}>
         <Icon name={mode === 'edit' ? 'edit' : 'plus'} size={12} />
         {busy ? 'saving' : submitText}
+        <Kbd value="⌘↵" />
       </Button>
     </div>
   </form>

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -30,13 +30,15 @@
   let generatingPassword = $state(false);
 
   const passwordRequired = $derived(mode === 'create');
-  const canSubmit = $derived(title.trim().length > 0 && (!passwordRequired || password.length > 0) && !busy);
+  const canSubmit = $derived(
+    title.trim().length > 0 && (!passwordRequired || password.length > 0) && !busy && !generatingPassword,
+  );
   const collectionOptions = $derived(deriveCollectionOptions(vaultState.entries, collection));
   const normalizedTags = $derived(parseTags(tags));
   const suggestedTags = $derived(deriveSuggestedTags(vaultState.entries, normalizedTags));
   const entropyBits = $derived(estimateEntropyBits(password));
   const entropyFilled = $derived(password ? Math.max(1, Math.min(16, Math.round(entropyBits / 8))) : 0);
-  const entropyStrength = $derived(entropyBits >= 90 ? 'strong' : entropyBits >= 60 ? 'medium' : 'weak');
+  const entropyStrength = $derived(passwordStrength(password, entropyBits));
 
   $effect(() => {
     const entry = editingEntry;
@@ -51,7 +53,7 @@
     username = entry?.username ?? '';
     password = entry?.password ?? '';
     loadedPassword = password;
-    collection = entry?.collection ?? 'work';
+    collection = normalizeCollection(entry?.collection ?? 'work') || 'work';
     url = entry?.url ?? '';
     notes = entry?.notes ?? '';
     tags = entry?.tags.join(', ') ?? '';
@@ -64,6 +66,10 @@
 
   onMount(() => {
     function handleKeydown(event: KeyboardEvent) {
+      if (event.defaultPrevented) {
+        return;
+      }
+
       if (event.key === 'Escape') {
         event.preventDefault();
         cancel();
@@ -102,7 +108,7 @@
               collection: optionalText(collection),
               url: optionalText(url),
               notes: optionalText(notes),
-              tags: normalizedTags,
+              tags: tagsForSubmit(),
             });
 
       applySavedEntry(saved);
@@ -143,9 +149,13 @@
       collection: optionalText(collection),
       url: optionalText(url),
       notes: optionalText(notes),
-      tags: normalizedTags,
+      tags: tagsForSubmit(),
       ...(password.length > 0 && password !== loadedPassword ? { password } : {}),
     };
+  }
+
+  function tagsForSubmit(): string[] {
+    return parseTags([tags, tagInput].filter((value) => value.trim().length > 0).join(','));
   }
 
   async function generateEntryPassword() {
@@ -163,7 +173,6 @@
       });
 
       password = generated.password;
-      revealPassword = true;
     } catch (error) {
       errorMessage = messageFromError(error);
     } finally {
@@ -297,6 +306,68 @@
     return Math.round(value.length * Math.log2(pool || 26));
   }
 
+  function passwordStrength(value: string, entropy: number): 'strong' | 'medium' | 'weak' {
+    if (!value || hasLowComplexityPattern(value)) {
+      return 'weak';
+    }
+
+    if (entropy >= 90) {
+      return 'strong';
+    }
+
+    if (entropy >= 60) {
+      return 'medium';
+    }
+
+    return 'weak';
+  }
+
+  function hasLowComplexityPattern(value: string): boolean {
+    const normalized = value.toLowerCase();
+
+    if (/(.)\1{3,}/.test(normalized) || isRepeatedToken(normalized) || hasSequentialRun(normalized)) {
+      return true;
+    }
+
+    const commonWords = ['password', 'admin', 'qwerty', 'welcome', 'letmein', 'secret', 'login', 'monkey', 'dragon'];
+
+    return commonWords.some((word) => normalized.includes(word));
+  }
+
+  function isRepeatedToken(value: string): boolean {
+    for (let size = 1; size <= Math.floor(value.length / 2); size += 1) {
+      if (value.length % size !== 0) {
+        continue;
+      }
+
+      const token = value.slice(0, size);
+
+      if (token.repeat(value.length / size) === value) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  function hasSequentialRun(value: string): boolean {
+    const sequences = ['abcdefghijklmnopqrstuvwxyz', '0123456789', 'qwertyuiop', 'asdfghjkl', 'zxcvbnm'];
+
+    return sequences.some((sequence) => {
+      for (let length = 4; length <= Math.min(value.length, sequence.length); length += 1) {
+        for (let index = 0; index <= sequence.length - length; index += 1) {
+          const run = sequence.slice(index, index + length);
+
+          if (value.includes(run) || value.includes(Array.from(run).reverse().join(''))) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    });
+  }
+
   function normalizeCollection(value: string): string {
     return value.trim().toLowerCase().replace(/\s+/g, '-');
   }
@@ -370,6 +441,7 @@
 
                   if (event.key === 'Escape') {
                     event.preventDefault();
+                    event.stopPropagation();
                     newCollectionOpen = false;
                     newCollectionValue = '';
                   }

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -30,8 +30,13 @@
   let generatingPassword = $state(false);
 
   const passwordRequired = $derived(mode === 'create');
+  const passwordClearBlocked = $derived(mode === 'edit' && loadedPassword.length > 0 && password.length === 0);
   const canSubmit = $derived(
-    title.trim().length > 0 && (!passwordRequired || password.length > 0) && !busy && !generatingPassword,
+    title.trim().length > 0 &&
+      (!passwordRequired || password.length > 0) &&
+      !passwordClearBlocked &&
+      !busy &&
+      !generatingPassword,
   );
   const collectionOptions = $derived(deriveCollectionOptions(vaultState.entries, collection));
   const normalizedTags = $derived(parseTags(tags));
@@ -492,6 +497,8 @@
             <div class="form-entropy">
               <Entropy filled={entropyFilled} bits={entropyBits} strength={entropyStrength} />
             </div>
+          {:else if passwordClearBlocked}
+            <div class="form-hint form-hint--warn mono">password clearing is not supported yet</div>
           {/if}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace the legacy entry form with the prototype-inspired compose and edit flow
- add collection chips, tag editing, inline tag suggestions, and password generation/reveal controls
- style the compose screen with the new page shell and responsive behavior

## Verification
- pnpm typecheck
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned entry composition form with inline category selection and “+ new” category creation
  * Tag management with visual chips, suggested tags, and keyboard navigation (Enter to add, Backspace to remove)
  * Password tools: generate, reveal toggle, and password strength/entropy display
  * Keyboard shortcuts: Escape to cancel, Ctrl/Cmd+Enter to submit
* **Style**
  * Added comprehensive styling for the entry compose section and form controls, including improved responsive behavior on smaller screens
<!-- end of auto-generated comment: release notes by coderabbit.ai -->