### PR TITLE
feat: redesign tab page surfaces

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -115,25 +115,48 @@
     }
   }
 
-  async function syncFullscreenState() {
+  async function syncFullscreenState(windowHandle = safeGetCurrentWindow()) {
+    if (!windowHandle) {
+      isFullscreen = false;
+      return;
+    }
+
     try {
-      isFullscreen = await getCurrentWindow().isFullscreen();
+      isFullscreen = await windowHandle.isFullscreen();
     } catch {
       isFullscreen = false;
+    }
+  }
+
+  function safeGetCurrentWindow() {
+    if (
+      typeof window === 'undefined' ||
+      !('__TAURI_INTERNALS__' in window) ||
+      !window.__TAURI_INTERNALS__
+    ) {
+      return null;
+    }
+
+    try {
+      return getCurrentWindow();
+    } catch {
+      return null;
     }
   }
 
   onMount(() => {
     let mounted = true;
     let unlistenResize: (() => void) | null = null;
+    const windowHandle = safeGetCurrentWindow();
 
     loadThemePreference();
     void loadRuntimeSettings().catch(() => {
       // Browser previews keep the default runtime settings when Tauri IPC is unavailable.
     });
-    void syncFullscreenState();
-    void getCurrentWindow()
-      .onResized(() => {
+    void syncFullscreenState(windowHandle);
+
+    void windowHandle
+      ?.onResized(() => {
         void syncFullscreenState();
       })
       .then((unlisten) => {

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2149,6 +2149,429 @@ body {
 .form__spacer {
   flex: 1 1 auto;
 }
+.page {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  overflow: auto;
+  padding: 22px 26px 28px;
+}
+.page .page__head {
+  margin-bottom: 18px;
+}
+
+.switch {
+  width: 38px;
+  height: 22px;
+  border-radius: 999px;
+  background: var(--bg-inset);
+  border: 1px solid var(--rule-strong);
+  position: relative;
+  cursor: pointer;
+  flex: 0 0 auto;
+  transition: background .15s, border-color .15s;
+}
+.switch::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text-3);
+  transition: transform .18s cubic-bezier(0.22, 1, 0.36, 1), background .15s;
+}
+.switch--on {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.switch--on::after {
+  transform: translateX(16px);
+  background: var(--accent-on);
+}
+.switch--vault.switch--on {
+  background: var(--vault);
+  border-color: var(--vault);
+}
+
+.seg {
+  display: inline-flex;
+  background: var(--bg-inset);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  padding: 2px;
+  gap: 2px;
+}
+.seg.is-disabled {
+  opacity: 0.58;
+}
+.seg__opt {
+  font-family: var(--font-mono);
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+  color: var(--text-3);
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: background .12s, color .12s;
+}
+.seg__opt:disabled {
+  cursor: not-allowed;
+}
+.seg__opt--active {
+  background: var(--bg-card);
+  color: var(--text);
+}
+
+.slider {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+  width: 100%;
+}
+.slider__track {
+  flex: 1;
+  height: 4px;
+  background: var(--bg-inset);
+  border-radius: 999px;
+  position: relative;
+  min-width: 0;
+}
+.slider__fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  background: var(--accent);
+  border-radius: 999px;
+}
+.slider__knob {
+  position: absolute;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid var(--bg-card);
+  transform: translate(-50%, -50%);
+}
+.slider__native {
+  position: absolute;
+  inset: -10px 0;
+  width: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+.slider__val {
+  font-family: var(--font-mono);
+  font-size: calc(14px * var(--arca-font-scale, 1));
+  font-weight: 600;
+  color: var(--text);
+  min-width: 48px;
+  text-align: right;
+}
+
+.gen {
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.gen__output {
+  background: var(--bg-card);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  padding: 22px 22px 18px;
+}
+.gen__pw {
+  font-family: var(--font-mono);
+  font-size: calc(26px * var(--arca-font-scale, 1));
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--text);
+  line-height: 1.3;
+  word-break: break-all;
+  user-select: all;
+}
+.gen__pw .c-num { color: var(--accent); }
+.gen__pw .c-sym { color: var(--vault); }
+.gen__pw-placeholder {
+  color: var(--text-3);
+  font-size: calc(14px * var(--arca-font-scale, 1));
+  letter-spacing: 0.02em;
+}
+.gen__pw-foot {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--rule-dashed);
+}
+.gen__controls {
+  background: var(--bg-card);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.gen__ctrl {
+  display: grid;
+  grid-template-columns: 150px 1fr auto;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 18px;
+  border-bottom: 1px dashed var(--rule-dashed);
+}
+.gen__ctrl:last-child { border-bottom: none; }
+.gen__ctrl-k {
+  font-family: var(--font-mono);
+  font-size: calc(11px * var(--arca-font-scale, 1));
+  letter-spacing: 0.04em;
+  color: var(--text-2);
+}
+.gen__ctrl-k small {
+  display: block;
+  font-size: calc(9px * var(--arca-font-scale, 1));
+  color: var(--text-3);
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  margin-top: 3px;
+}
+.gen__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.audit {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  max-width: 960px;
+}
+.audit__score {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 24px;
+  align-items: center;
+  background: var(--bg-card);
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  padding: 22px 26px;
+}
+.audit__ring {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  position: relative;
+  flex: 0 0 auto;
+}
+.audit__ring-core {
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  background: var(--bg-card);
+  display: grid;
+  place-items: center;
+}
+.audit__ring-num {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: calc(30px * var(--arca-font-scale, 1));
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+.audit__ring-num small {
+  font-size: calc(13px * var(--arca-font-scale, 1));
+  color: var(--text-3);
+  font-weight: 500;
+}
+.audit__score-copy h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: calc(19px * var(--arca-font-scale, 1));
+  letter-spacing: -0.015em;
+  margin: 0 0 4px;
+  color: var(--text);
+}
+.audit__score-copy p {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: calc(13px * var(--arca-font-scale, 1));
+  color: var(--text-2);
+  line-height: 1.5;
+}
+.audit__stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+.audit__stat {
+  background: var(--bg-card);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+.audit__stat-n {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: calc(26px * var(--arca-font-scale, 1));
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: var(--text);
+}
+.audit__stat-n--warn { color: var(--accent); }
+.audit__stat-n--ok { color: var(--vault); }
+.audit__stat-k {
+  font-family: var(--font-mono);
+  font-size: calc(9px * var(--arca-font-scale, 1));
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  margin-top: 8px;
+}
+.audit__list-title {
+  font-family: var(--font-mono);
+  font-size: calc(9px * var(--arca-font-scale, 1));
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 6px 0 2px;
+}
+.audit__list-title .entries__rule { flex: 1; }
+.audit__entries {
+  display: grid;
+  gap: 8px;
+  overflow: visible;
+  padding-left: 0;
+}
+.row__sev {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.row__sev--high { background: var(--accent); }
+.row__sev--med { background: #C99A52; }
+.row__sev--low { background: var(--text-4); }
+
+.settings {
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+.set-group {
+  background: var(--bg-card);
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.set-group__title {
+  font-family: var(--font-mono);
+  font-size: calc(9px * var(--arca-font-scale, 1));
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  padding: 14px 18px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.set-group__title::before { content: '#'; opacity: 0.6; }
+.set-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 18px;
+  padding: 13px 18px;
+  border-top: 1px dashed var(--rule-dashed);
+}
+.set-row__k {
+  font-family: var(--font-body);
+  font-size: calc(13px * var(--arca-font-scale, 1));
+  color: var(--text);
+}
+.set-row__k small {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  color: var(--text-3);
+  letter-spacing: 0.02em;
+  margin-top: 3px;
+}
+.set-row__v {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  font-family: var(--font-mono);
+  font-size: calc(12px * var(--arca-font-scale, 1));
+  color: var(--text-2);
+}
+.set-row__v--wide {
+  min-width: min(280px, 100%);
+}
+.settings__actions {
+  display: flex;
+  gap: 8px;
+}
+.settings-error {
+  color: var(--accent);
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  letter-spacing: 0.05em;
+}
+
+.shared {
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.shared-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 18px 16px;
+  border: 1px dashed var(--rule-dashed);
+  border-radius: 8px;
+  background: var(--bg-card);
+}
+.shared-empty b {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: calc(12px * var(--arca-font-scale, 1));
+  font-weight: 500;
+  letter-spacing: 0.04em;
+}
+.shared-empty small,
+.shared__note {
+  color: var(--text-3);
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  letter-spacing: 0.04em;
+}
+.shared__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 14px;
+  margin-top: 6px;
+}
 
 @media (max-width: 980px) {
   .page__head {
@@ -2167,21 +2590,38 @@ body {
   .form-row__k {
     padding-top: 0;
   }
+  .audit__score,
+  .audit__stats,
+  .gen__ctrl,
+  .set-row {
+    grid-template-columns: 1fr;
+  }
+  .set-row__v {
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 720px) {
-  .entry-compose {
+  .entry-compose,
+  .page {
     padding: 18px 18px 24px;
   }
   .finput-row,
   .form__actions,
-  .cat-newwrap {
+  .cat-newwrap,
+  .gen__pw-foot {
     flex-wrap: wrap;
   }
   .finput-row .iconbtn,
   .finput-row .btn,
   .form__actions .btn {
     flex: 0 0 auto;
+  }
+  .audit__stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .gen__pw {
+    font-size: calc(20px * var(--arca-font-scale, 1));
   }
 }
 

--- a/apps/desktop/src/lib/components/VaultShell.svelte
+++ b/apps/desktop/src/lib/components/VaultShell.svelte
@@ -5,6 +5,7 @@
   import { EntryDetail, EntryForm } from './detail';
   import { GeneratorPanel } from './generator';
   import { SettingsPanel } from './settings';
+  import { SharedPanel } from './shared';
   import { EntryList } from './vault';
 
   let busy = $state(false);
@@ -51,6 +52,8 @@
   <AuditPanel />
 {:else if uiState.view === 'generator'}
   <GeneratorPanel />
+{:else if uiState.view === 'shared'}
+  <SharedPanel />
 {:else}
   <section class="vault-placeholder" aria-labelledby="vault-placeholder-title">
     <p class="vault-placeholder__eyebrow">placeholder</p>

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -2,74 +2,119 @@
   import { getAuditState } from '../../stores/audit.svelte';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
-  import { Icon } from '../icons';
-  import { Button, Tag } from '../primitives';
+  import { Tag } from '../primitives';
 
   const auditState = $derived(getAuditState());
+  const score = $derived(Number(auditState.score));
+  const weakCount = $derived(countByTitle('weak_password'));
+  const reusedCount = $derived(countByTitle('reused_password'));
+  const agingCount = $derived(countByTitle('stale_entry'));
+  const flaggedEntryCount = $derived(new Set(auditState.findings.map((finding) => finding.entry.id)).size);
+  const healthyCount = $derived(Math.max(0, vaultState.entries.length - flaggedEntryCount));
+  const headline = $derived(
+    score >= 85 ? 'vault health is strong.' : score >= 65 ? 'vault health needs review.' : 'vault health needs attention.',
+  );
+  const summary = $derived(
+    vaultState.entries.length === 0
+      ? 'Add entries to start measuring password health and vault hygiene.'
+      : `${healthyCount} of ${vaultState.entries.length} entries are healthy. ${auditState.findingCount} findings need attention — ${weakCount} weak, ${reusedCount} reused, ${agingCount} aging past six months.`,
+  );
 
   function openEntry(entry: (typeof vaultState.entries)[number]) {
     vaultState.selectedEntry = entry;
     uiState.view = 'detail';
   }
+
+  function countByTitle(title: string): number {
+    return auditState.findings.filter((finding) => finding.title === title).length;
+  }
+
+  function severityVariant(severity: string): 'out' | 'vault' | 'slate' {
+    return severity === 'high' ? 'out' : severity === 'medium' ? 'vault' : 'slate';
+  }
+
+  function severityLabel(severity: string): string {
+    return severity === 'high' ? 'high' : severity === 'medium' ? 'review' : 'minor';
+  }
+
+  function severityDotClass(severity: string): string {
+    return severity === 'high' ? 'row__sev row__sev--high' : severity === 'medium' ? 'row__sev row__sev--med' : 'row__sev row__sev--low';
+  }
 </script>
 
-<section class="audit-panel" aria-labelledby="audit-title">
-  <div class="detail-head">
-    <div class="detail__title-wrap">
-      <div class="detail__crumbs mono">vault &nbsp;/&nbsp; <b>audit</b></div>
-      <h1 id="audit-title" class="detail__title">audit<em>.</em></h1>
-      <div class="detail__meta mono">
-        <Tag value={`${auditState.score}/100`} />
-        <span>entries · <b>{vaultState.entries.length}</b></span>
-        <span>findings · <b>{auditState.findingCount}</b></span>
-      </div>
-    </div>
-    <div class="detail__actions">
-      <Button variant="ghost" size="sm" onclick={() => (uiState.view = 'list')}>back_to_vault</Button>
+<section class="page audit-page" aria-labelledby="audit-title">
+  <div class="page__head">
+    <span class="page__hash mono">#</span>
+    <h1 id="audit-title" class="page__title">audit<em>.</em></h1>
+    <div class="page__meta mono">
+      <span>entries · <b>{vaultState.entries.length}</b></span>
+      <span>findings · <b>{auditState.findingCount}</b></span>
     </div>
   </div>
 
-  <div class="audit-body">
-    <section class="audit-summary" aria-label="Audit summary">
-      <div>
-        <span>high</span>
-        <b>{auditState.highCount}</b>
+  <div class="audit">
+    <div class="audit__score">
+      <div
+        class="audit__ring"
+        style={`background: conic-gradient(var(--vault) 0% ${score}%, var(--bg-inset) ${score}% 100%);`}
+        aria-hidden="true"
+      >
+        <div class="audit__ring-core">
+          <div class="audit__ring-num">{score}<small>/100</small></div>
+        </div>
       </div>
-      <div>
-        <span>medium</span>
-        <b>{auditState.mediumCount}</b>
-      </div>
-      <div>
-        <span>low</span>
-        <b>{auditState.lowCount}</b>
-      </div>
-      <div class="audit-summary__note">
-        <span>coverage</span>
-        <b>loaded_secret</b>
-      </div>
-    </section>
 
-    <div class="audit-list" role="list">
-      {#if auditState.findingCount > 0}
+      <div class="audit__score-copy">
+        <h3>{headline}</h3>
+        <p>{summary}</p>
+      </div>
+    </div>
+
+    <div class="audit__stats">
+      <div class="audit__stat">
+        <div class="audit__stat-n audit__stat-n--warn">{weakCount}</div>
+        <div class="audit__stat-k">weak</div>
+      </div>
+      <div class="audit__stat">
+        <div class="audit__stat-n audit__stat-n--warn">{reusedCount}</div>
+        <div class="audit__stat-k">reused</div>
+      </div>
+      <div class="audit__stat">
+        <div class="audit__stat-n">{agingCount}</div>
+        <div class="audit__stat-k">aging</div>
+      </div>
+      <div class="audit__stat">
+        <div class="audit__stat-n audit__stat-n--ok">{healthyCount}</div>
+        <div class="audit__stat-k">healthy</div>
+      </div>
+    </div>
+
+    <div class="audit__list-title">
+      needs attention
+      <span class="entries__rule"></span>
+      <span class="entries__count">{auditState.findingCount.toString().padStart(2, '0')}</span>
+    </div>
+
+    {#if auditState.findingCount > 0}
+      <div class="entries audit__entries" role="list">
         {#each auditState.findings as finding (finding.key)}
-          <button type="button" class="audit-finding" onclick={() => openEntry(finding.entry)}>
-            <span class={`audit-finding__severity audit-finding__severity--${finding.severity}`}>
-              {finding.severity}
-            </span>
-            <span class="audit-finding__main">
-              <b>{finding.title}</b>
-              <span>{finding.entry.title}</span>
-            </span>
-            <span class="audit-finding__meta mono">{finding.meta}</span>
-            <Icon name="external" size={12} />
+          <button type="button" class="row" onclick={() => openEntry(finding.entry)}>
+            <div class="row__bullet">
+              <span class={severityDotClass(finding.severity)}></span>
+            </div>
+            <div class="row__main">
+              <div class="row__title">{finding.entry.title}</div>
+              <div class="row__sub">{finding.title.replaceAll('_', ' ')} · {finding.meta}</div>
+            </div>
+            <Tag variant={severityVariant(finding.severity)} value={severityLabel(finding.severity)} />
           </button>
         {/each}
-      {:else}
-        <div class="audit-empty">
-          <span>&gt;</span>
-          no_findings
-        </div>
-      {/if}
-    </div>
+      </div>
+    {:else}
+      <div class="shared-empty">
+        <b>no findings</b>
+        <small>Your loaded vault is in good shape. Add more entries or rescan after updates to spot regressions.</small>
+      </div>
+    {/if}
   </div>
 </section>

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { AuditSeverity } from '../../audit';
   import { getAuditState } from '../../stores/audit.svelte';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
@@ -29,16 +30,37 @@
     return auditState.findings.filter((finding) => finding.title === title).length;
   }
 
-  function severityVariant(severity: string): 'out' | 'vault' | 'slate' {
-    return severity === 'high' ? 'out' : severity === 'medium' ? 'vault' : 'slate';
+  function severityVariant(severity: AuditSeverity): 'out' | 'vault' | 'slate' {
+    switch (severity) {
+      case 'high':
+        return 'out';
+      case 'medium':
+        return 'vault';
+      case 'low':
+        return 'slate';
+    }
   }
 
-  function severityLabel(severity: string): string {
-    return severity === 'high' ? 'high' : severity === 'medium' ? 'review' : 'minor';
+  function severityLabel(severity: AuditSeverity): string {
+    switch (severity) {
+      case 'high':
+        return 'high';
+      case 'medium':
+        return 'review';
+      case 'low':
+        return 'minor';
+    }
   }
 
-  function severityDotClass(severity: string): string {
-    return severity === 'high' ? 'row__sev row__sev--high' : severity === 'medium' ? 'row__sev row__sev--med' : 'row__sev row__sev--low';
+  function severityDotClass(severity: AuditSeverity): string {
+    switch (severity) {
+      case 'high':
+        return 'row__sev row__sev--high';
+      case 'medium':
+        return 'row__sev row__sev--med';
+      case 'low':
+        return 'row__sev row__sev--low';
+    }
   }
 </script>
 

--- a/apps/desktop/src/lib/components/detail/EntryDetail.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryDetail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { deleteEntry, type EntryDto } from '../../ipc';
   import { uiState } from '../../stores/ui.svelte';
-  import { vaultState } from '../../stores/vault.svelte';
+  import { clearEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
   import { Button, IconButton, Tag } from '../primitives';
   import FieldStack from './FieldStack.svelte';
@@ -18,6 +18,7 @@
   }
 
   function editEntry() {
+    clearEntryDraft();
     uiState.view = 'edit';
   }
 

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { createEntry, generatePassword, updateEntry, type EntryDto } from '../../ipc';
   import { uiState } from '../../stores/ui.svelte';
-  import { vaultState } from '../../stores/vault.svelte';
+  import { clearEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
   import { Button, Entropy, IconButton, Kbd } from '../primitives';
 
@@ -22,7 +22,7 @@
   let tagInput = $state('');
   let busy = $state(false);
   let errorMessage = $state('');
-  let loadedEntryId = $state<string | null>(null);
+  let loadedContext = $state('');
   let loadedPassword = $state('');
   let revealPassword = $state(false);
   let newCollectionOpen = $state(false);
@@ -47,21 +47,22 @@
 
   $effect(() => {
     const entry = editingEntry;
-    const entryId = entry?.id ?? null;
+    const draft = entry ? null : vaultState.entryDraft;
+    const context = entry ? `edit:${entry.id}` : `new:${vaultState.entryDraftNonce}`;
 
-    if (loadedEntryId === entryId) {
+    if (loadedContext === context) {
       return;
     }
 
-    loadedEntryId = entryId;
-    title = entry?.title ?? '';
-    username = entry?.username ?? '';
-    password = entry?.password ?? '';
+    loadedContext = context;
+    title = entry?.title ?? draft?.title ?? '';
+    username = entry?.username ?? draft?.username ?? '';
+    password = entry?.password ?? draft?.password ?? '';
     loadedPassword = password;
-    collection = normalizeCollection(entry?.collection ?? 'work') || 'work';
-    url = entry?.url ?? '';
-    notes = entry?.notes ?? '';
-    tags = entry?.tags.join(', ') ?? '';
+    collection = normalizeCollection(entry?.collection ?? draft?.collection ?? 'work') || 'work';
+    url = entry?.url ?? draft?.url ?? '';
+    notes = entry?.notes ?? draft?.notes ?? '';
+    tags = entry?.tags.join(', ') ?? draft?.tags?.join(', ') ?? '';
     tagInput = '';
     revealPassword = false;
     newCollectionOpen = false;
@@ -117,6 +118,7 @@
             });
 
       applySavedEntry(saved);
+      clearEntryDraft();
       vaultState.lastSaved = new Date(saved.updatedAt);
       uiState.view = 'detail';
     } catch (error) {
@@ -139,6 +141,10 @@
   }
 
   function cancel() {
+    if (!editingEntry) {
+      clearEntryDraft();
+    }
+
     uiState.view = editingEntry ? 'detail' : 'list';
   }
 

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -51,7 +51,7 @@
 
     busy = true;
     copied = false;
-    isRevealed = true;
+    isRevealed = false;
     errorMessage = '';
 
     try {
@@ -69,6 +69,7 @@
       }
 
       generated = nextGenerated;
+      isRevealed = true;
     } catch (error) {
       if (currentGeneration !== generationCounter) {
         return;

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -2,9 +2,10 @@
   import { onMount } from 'svelte';
   import { writeConfiguredClipboardText } from '../../clipboard';
   import { generatePassword, type GeneratedPassword } from '../../ipc';
-  import { vaultState } from '../../stores/vault.svelte';
+  import { uiState } from '../../stores/ui.svelte';
+  import { clearEntryDraft, setEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
-  import { Button, IconButton, Tag } from '../primitives';
+  import { Button, Entropy, IconButton, Slider, Toggle } from '../primitives';
 
   let length = $state(24);
   let uppercase = $state(true);
@@ -21,10 +22,12 @@
   let generationCounter = 0;
 
   const hasCharacterSet = $derived(uppercase || lowercase || digits || symbols);
-  const entropyLabel = $derived(generated ? `${Math.round(generated.entropyBits)} bits` : 'pending');
-  const strengthLabel = $derived(strengthFromEntropy(generated?.entropyBits ?? 0));
-  const outputValue = $derived(
-    generated ? (isRevealed ? generated.password : maskPassword(generated.password)) : '••••••••••••••••••••••••',
+  const entropyBits = $derived(generated ? Math.round(generated.entropyBits) : 0);
+  const strengthLabel = $derived(strengthFromEntropy(entropyBits));
+  const entropyFilled = $derived(generated ? Math.max(1, Math.min(16, Math.round(entropyBits / 8))) : 0);
+  const metaEntropy = $derived(generated ? `${entropyBits} bits` : 'pending');
+  const displayedPassword = $derived(
+    generated ? (isRevealed ? generated.password : '•'.repeat(Math.max(generated.password.length, 12))) : '',
   );
 
   onMount(() => {
@@ -48,7 +51,7 @@
 
     busy = true;
     copied = false;
-    isRevealed = false;
+    isRevealed = true;
     errorMessage = '';
 
     try {
@@ -65,7 +68,6 @@
         return;
       }
 
-      isRevealed = false;
       generated = nextGenerated;
     } catch (error) {
       if (currentGeneration !== generationCounter) {
@@ -73,7 +75,6 @@
       }
 
       generated = null;
-      isRevealed = false;
       errorMessage = messageFromError(error);
     } finally {
       if (currentGeneration === generationCounter) {
@@ -96,7 +97,7 @@
     copyTimer = setTimeout(() => {
       copied = false;
       copyTimer = null;
-    }, 1500);
+    }, 1400);
   }
 
   function resetGenerated() {
@@ -109,18 +110,41 @@
   }
 
   function toggleReveal() {
-    if (busy || !generated?.password) {
+    if (!generated?.password) {
       return;
     }
 
     isRevealed = !isRevealed;
   }
 
-  function maskPassword(value: string): string {
-    return '•'.repeat(Math.max(value.length, 8));
+  function useInNewEntry() {
+    if (!generated?.password) {
+      return;
+    }
+
+    setEntryDraft({ password: generated.password });
+    vaultState.selectedEntry = null;
+    uiState.view = 'edit';
+  }
+
+  function openBlankEntry() {
+    clearEntryDraft();
+    vaultState.selectedEntry = null;
+    uiState.view = 'edit';
+  }
+
+  function renderParts(value: string) {
+    return Array.from(value).map((character) => ({
+      character,
+      tone: /\d/.test(character) ? 'c-num' : /[^a-zA-Z0-9]/.test(character) ? 'c-sym' : '',
+    }));
   }
 
   function strengthFromEntropy(entropy: number): string {
+    if (!generated) {
+      return 'pending';
+    }
+
     if (entropy >= 120) {
       return 'excellent';
     }
@@ -133,7 +157,7 @@
       return 'fair';
     }
 
-    return generated ? 'weak' : 'pending';
+    return 'weak';
   }
 
   function messageFromError(error: unknown): string {
@@ -145,87 +169,151 @@
   }
 </script>
 
-<section class="generator-panel" aria-labelledby="generator-title">
-  <div class="detail-head">
-    <div class="detail__title-wrap">
-      <div class="detail__crumbs mono">vault &nbsp;/&nbsp; <b>generator</b></div>
-      <h1 id="generator-title" class="detail__title">generate<em>.</em></h1>
-      <div class="detail__meta mono">
-        <Tag value={strengthLabel} />
-        <span>vault · <b>{vaultState.vaultName || 'local'}</b></span>
-        <span>entropy · <b>{entropyLabel}</b></span>
-      </div>
-    </div>
-    <div class="detail__actions">
-      <Button variant="primary" size="sm" onclick={generate} disabled={busy || !hasCharacterSet}>
-        <Icon name="refresh" size={12} />
-        {busy ? 'generating' : 'generate'}
-      </Button>
+<section class="page generator-page" aria-labelledby="generator-title">
+  <div class="page__head">
+    <span class="page__hash mono">#</span>
+    <h1 id="generator-title" class="page__title">generate<em>.</em></h1>
+    <div class="page__meta mono">
+      <span>vault · <b>{vaultState.vaultName || 'vault.local'}</b></span>
+      <span>entropy · <b>{metaEntropy}</b></span>
     </div>
   </div>
 
-  <div class="generator-body">
-    <section class="generator-output" aria-labelledby="generator-output-title">
-      <div class="generator-output__head">
-        <span id="generator-output-title">password</span>
-        <div class="generator-output__actions">
-          <IconButton
-            label={isRevealed ? 'Hide generated password' : 'Reveal generated password'}
-            onclick={toggleReveal}
-            disabled={busy || !generated?.password}
-          >
-            <Icon name="eye" size={13} />
-          </IconButton>
-          <IconButton label="Copy generated password" onclick={copyGenerated} disabled={busy || !generated?.password}>
-            <Icon name="copy" size={13} />
-          </IconButton>
-        </div>
+  <div class="gen">
+    <div class="gen__output">
+      <div class="gen__pw" aria-live="polite">
+        {#if generated}
+          {#if isRevealed}
+            {#each renderParts(displayedPassword) as part, index (`${part.character}-${index}`)}
+              <span class={part.tone}>{part.character}</span>
+            {/each}
+          {:else}
+            {displayedPassword}
+          {/if}
+        {:else}
+          <span class="gen__pw-placeholder">press generate to mint a fresh password.</span>
+        {/if}
       </div>
-      <output class="generator-output__value">{outputValue}</output>
-      <div class="generator-output__meta mono">
-        <span>length · <b>{length}</b></span>
-        <span>entropy · <b>{entropyLabel}</b></span>
-        <span>copy · <b>{copied ? 'done' : 'ready'}</b></span>
+
+      <div class="gen__pw-foot">
+        <Entropy filled={entropyFilled} bits={entropyBits} strength={strengthLabel} />
+        <span class="status__spacer"></span>
+        <Button variant="ghost" size="sm" onclick={generate} disabled={busy || !hasCharacterSet}>
+          <Icon name="refresh" size={12} />
+          {busy ? 'generating' : generated ? 'regenerate' : 'generate'}
+        </Button>
+        <IconButton
+          label={isRevealed ? 'Hide generated password' : 'Reveal generated password'}
+          onclick={toggleReveal}
+          disabled={!generated?.password}
+        >
+          <Icon name="eye" size={13} />
+        </IconButton>
+        <Button variant={copied ? 'vault' : 'primary'} size="sm" onclick={copyGenerated} disabled={!generated?.password}>
+          {#if copied}
+            copied
+          {:else}
+            <Icon name="copy" size={12} />
+            copy
+          {/if}
+        </Button>
       </div>
+
       {#if errorMessage}
         <div class="generator-error mono error" role="alert">{errorMessage}</div>
       {/if}
-    </section>
+    </div>
 
-    <section class="generator-controls" aria-labelledby="generator-controls-title">
-      <div class="generator-controls__head">
-        <p class="generator-controls__eyebrow mono">policy</p>
-        <h2 id="generator-controls-title">random</h2>
+    <div class="gen__controls">
+      <div class="gen__ctrl">
+        <div class="gen__ctrl-k">length<small>characters</small></div>
+        <Slider
+          value={length}
+          min={8}
+          max={48}
+          step={1}
+          ariaLabel="Password length"
+          valueLabel={String(length)}
+          oninput={(next) => {
+            length = next;
+            resetGenerated();
+          }}
+        />
       </div>
 
-      <label class="generator-slider">
-        <span>length</span>
-        <input bind:value={length} type="range" min="8" max="128" step="1" oninput={resetGenerated} />
-        <b>{length}</b>
-      </label>
-
-      <div class="generator-options">
-        <label>
-          <input bind:checked={uppercase} type="checkbox" onchange={resetGenerated} />
-          <span>uppercase</span>
-        </label>
-        <label>
-          <input bind:checked={lowercase} type="checkbox" onchange={resetGenerated} />
-          <span>lowercase</span>
-        </label>
-        <label>
-          <input bind:checked={digits} type="checkbox" onchange={resetGenerated} />
-          <span>digits</span>
-        </label>
-        <label>
-          <input bind:checked={symbols} type="checkbox" onchange={resetGenerated} />
-          <span>symbols</span>
-        </label>
-        <label>
-          <input bind:checked={excludeAmbiguous} type="checkbox" onchange={resetGenerated} />
-          <span>no_ambiguous</span>
-        </label>
+      <div class="gen__ctrl">
+        <div class="gen__ctrl-k">uppercase<small>A–Z</small></div>
+        <div></div>
+        <Toggle
+          label="Uppercase letters"
+          checked={uppercase}
+          ontoggle={(next) => {
+            uppercase = next;
+            resetGenerated();
+          }}
+        />
       </div>
-    </section>
+
+      <div class="gen__ctrl">
+        <div class="gen__ctrl-k">lowercase<small>a–z</small></div>
+        <div></div>
+        <Toggle
+          label="Lowercase letters"
+          checked={lowercase}
+          ontoggle={(next) => {
+            lowercase = next;
+            resetGenerated();
+          }}
+        />
+      </div>
+
+      <div class="gen__ctrl">
+        <div class="gen__ctrl-k">numbers<small>0–9</small></div>
+        <div></div>
+        <Toggle
+          label="Numbers"
+          checked={digits}
+          ontoggle={(next) => {
+            digits = next;
+            resetGenerated();
+          }}
+        />
+      </div>
+
+      <div class="gen__ctrl">
+        <div class="gen__ctrl-k">symbols<small>!@#$</small></div>
+        <div></div>
+        <Toggle
+          label="Symbols"
+          checked={symbols}
+          ontoggle={(next) => {
+            symbols = next;
+            resetGenerated();
+          }}
+        />
+      </div>
+
+      <div class="gen__ctrl">
+        <div class="gen__ctrl-k">exclude ambiguous<small>0 O 1 l I</small></div>
+        <div></div>
+        <Toggle
+          label="Exclude ambiguous characters"
+          checked={excludeAmbiguous}
+          variant="vault"
+          ontoggle={(next) => {
+            excludeAmbiguous = next;
+            resetGenerated();
+          }}
+        />
+      </div>
+    </div>
+
+    <div class="gen__actions">
+      <Button variant="primary" onclick={useInNewEntry} disabled={!generated?.password}>
+        <Icon name="plus" size={11} sw={2} />
+        use in new entry
+      </Button>
+      <Button variant="bare" onclick={openBlankEntry}>blank entry</Button>
+    </div>
   </div>
 </section>

--- a/apps/desktop/src/lib/components/primitives/Segmented.svelte
+++ b/apps/desktop/src/lib/components/primitives/Segmented.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  export interface SegmentedOption {
+    value: string;
+    label: string;
+    disabled?: boolean;
+  }
+
+  let {
+    options = [],
+    value,
+    ariaLabel,
+    onselect,
+    class: className = '',
+    ...rest
+  } = $props<{
+    options?: SegmentedOption[];
+    value: string;
+    ariaLabel?: string;
+    onselect?: (value: string) => void;
+    class?: string;
+    [key: string]: unknown;
+  }>();
+
+  const classes = $derived(['seg', className].filter(Boolean).join(' '));
+</script>
+
+<div {...rest} class={classes} role="group" aria-label={ariaLabel}>
+  {#each options as option (option.value)}
+    <button
+      type="button"
+      class={value === option.value ? 'seg__opt seg__opt--active' : 'seg__opt'}
+      aria-pressed={value === option.value}
+      disabled={option.disabled}
+      onclick={() => onselect?.(option.value)}
+    >
+      {option.label}
+    </button>
+  {/each}
+</div>

--- a/apps/desktop/src/lib/components/primitives/Slider.svelte
+++ b/apps/desktop/src/lib/components/primitives/Slider.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  let {
+    value,
+    min = 0,
+    max = 100,
+    step = 1,
+    ariaLabel,
+    valueLabel,
+    oninput,
+    onchange,
+    class: className = '',
+    ...rest
+  } = $props<{
+    value: number;
+    min?: number;
+    max?: number;
+    step?: number;
+    ariaLabel?: string;
+    valueLabel?: string;
+    oninput?: (value: number) => void;
+    onchange?: (value: number) => void;
+    class?: string;
+    [key: string]: unknown;
+  }>();
+
+  const classes = $derived(['slider', className].filter(Boolean).join(' '));
+  const percent = $derived(max <= min ? 0 : ((value - min) / (max - min)) * 100);
+
+  function readValue(raw: string): number {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : value;
+  }
+</script>
+
+<div {...rest} class={classes}>
+  <div class="slider__track">
+    <div class="slider__fill" style:width={`${percent}%`}></div>
+    <div class="slider__knob" style:left={`${percent}%`}></div>
+    <input
+      class="slider__native"
+      type="range"
+      aria-label={ariaLabel}
+      {min}
+      {max}
+      {step}
+      {value}
+      oninput={(event) => oninput?.(readValue(event.currentTarget.value))}
+      onchange={(event) => onchange?.(readValue(event.currentTarget.value))}
+    />
+  </div>
+  <div class="slider__val">{valueLabel ?? value}</div>
+</div>

--- a/apps/desktop/src/lib/components/primitives/Slider.svelte
+++ b/apps/desktop/src/lib/components/primitives/Slider.svelte
@@ -24,7 +24,7 @@
   }>();
 
   const classes = $derived(['slider', className].filter(Boolean).join(' '));
-  const percent = $derived(max <= min ? 0 : ((value - min) / (max - min)) * 100);
+  const percent = $derived(max <= min ? 0 : Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100)));
 
   function readValue(raw: string): number {
     const parsed = Number(raw);

--- a/apps/desktop/src/lib/components/primitives/Toggle.svelte
+++ b/apps/desktop/src/lib/components/primitives/Toggle.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  let {
+    checked = false,
+    variant = 'default',
+    label,
+    ontoggle,
+    class: className = '',
+    ...rest
+  } = $props<{
+    checked?: boolean;
+    variant?: 'default' | 'vault';
+    label: string;
+    ontoggle?: (checked: boolean) => void;
+    class?: string;
+    [key: string]: unknown;
+  }>();
+
+  const classes = $derived(
+    ['switch', checked ? 'switch--on' : '', variant === 'vault' ? 'switch--vault' : '', className]
+      .filter(Boolean)
+      .join(' '),
+  );
+</script>
+
+<button
+  {...rest}
+  type="button"
+  class={classes}
+  role="switch"
+  aria-label={label}
+  aria-checked={checked}
+  onclick={() => ontoggle?.(!checked)}
+></button>

--- a/apps/desktop/src/lib/components/primitives/index.ts
+++ b/apps/desktop/src/lib/components/primitives/index.ts
@@ -2,4 +2,7 @@ export { default as Button } from './Button.svelte';
 export { default as Entropy } from './Entropy.svelte';
 export { default as IconButton } from './IconButton.svelte';
 export { default as Kbd } from './Kbd.svelte';
+export { default as Segmented } from './Segmented.svelte';
+export { default as Slider } from './Slider.svelte';
 export { default as Tag } from './Tag.svelte';
+export { default as Toggle } from './Toggle.svelte';

--- a/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
@@ -41,6 +41,9 @@
 
   const autoLockValue = $derived(autoLockEnabled ? String(autoLockMinutes) : 'never');
   const clipboardValue = $derived(String(clipboardSeconds));
+  const clipboardDurationOptions = $derived(
+    clipboardOptions.map((option) => ({ ...option, disabled: !clipboardEnabled })),
+  );
 
   onMount(() => {
     if (runtimeSettings.loaded) {
@@ -99,11 +102,10 @@
   }
 
   async function setClipboardDuration(value: string) {
-    if (!loaded || busy) {
+    if (!loaded || busy || !clipboardEnabled) {
       return;
     }
 
-    clipboardEnabled = true;
     clipboardSeconds = Number(value);
     await saveSettings();
   }
@@ -185,10 +187,15 @@
 
   function applySettings(settings: Settings) {
     autoLockEnabled = settings.autoLockTimeoutMinutes !== null && settings.autoLockTimeoutMinutes !== undefined;
-    autoLockMinutes = Number(settings.autoLockTimeoutMinutes ?? 15);
+    autoLockMinutes = normalizeInteger(settings.autoLockTimeoutMinutes ?? 15, 15, 1, 240);
     clipboardEnabled = settings.clipboardClearSeconds !== null && settings.clipboardClearSeconds !== undefined;
-    clipboardSeconds = Number(settings.clipboardClearSeconds ?? 30);
-    fontSize = settings.fontSize;
+    clipboardSeconds = normalizeInteger(settings.clipboardClearSeconds ?? 30, 30, 5, 300, 5);
+    fontSize = normalizeInteger(settings.fontSize, 13, 11, 16);
+  }
+
+  function normalizeInteger(value: unknown, fallback: number, min: number, max: number, multiple = 1): number {
+    const next = Number(value);
+    return Number.isInteger(next) && next >= min && next <= max && next % multiple === 0 ? next : fallback;
   }
 
   function messageFromError(error: unknown): string {
@@ -262,8 +269,8 @@
           <Segmented
             ariaLabel="Clipboard clear timeout"
             value={clipboardValue}
-            options={clipboardOptions}
-            onselect={setClipboardDuration}
+            options={clipboardDurationOptions}
+            onselect={clipboardEnabled ? setClipboardDuration : undefined}
             class={clipboardEnabled ? '' : 'is-disabled'}
           />
         </div>

--- a/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { Settings } from '../../ipc';
+  import { lockCurrentVault } from '../../session';
   import {
     loadRuntimeSettings,
     runtimeSettings,
@@ -8,31 +9,25 @@
     themeForUi,
   } from '../../stores/settings.svelte';
   import { uiState, type ThemeName } from '../../stores/ui.svelte';
-  import { Button, Kbd, Tag } from '../primitives';
+  import { vaultState } from '../../stores/vault.svelte';
+  import { Button, Segmented, Slider, Toggle } from '../primitives';
 
-  type ThemeOption = {
-    key: ThemeName;
-    label: string;
-    surface: string;
-    accent: string;
-    meta: string;
-  };
-
-  const themeOptions: ThemeOption[] = [
-    {
-      key: 'paper',
-      label: 'paper',
-      surface: '#EBE5D6',
-      accent: '#C8553D',
-      meta: 'default',
-    },
-    {
-      key: 'ink',
-      label: 'ink',
-      surface: '#14110D',
-      accent: '#D86A52',
-      meta: 'alternate',
-    },
+  const themeOptions = [
+    { value: 'paper', label: 'paper' },
+    { value: 'ink', label: 'ink' },
+  ] as const;
+  const autoLockOptions = [
+    { value: '1', label: '1 min' },
+    { value: '5', label: '5 min' },
+    { value: '15', label: '15 min' },
+    { value: '60', label: '60 min' },
+    { value: 'never', label: 'never' },
+  ];
+  const clipboardOptions = [
+    { value: '15', label: '15s' },
+    { value: '30', label: '30s' },
+    { value: '60', label: '60s' },
+    { value: '120', label: '120s' },
   ];
 
   let autoLockEnabled = $state(true);
@@ -44,8 +39,8 @@
   let loaded = $state(false);
   let errorMessage = $state('');
 
-  const settingsStatus = $derived(loaded ? (busy ? 'saving' : 'saved') : 'loading');
-  const autoLockTag = $derived(autoLockEnabled ? `${autoLockMinutes}m` : 'off');
+  const autoLockValue = $derived(autoLockEnabled ? String(autoLockMinutes) : 'never');
+  const clipboardValue = $derived(String(clipboardSeconds));
 
   onMount(() => {
     if (runtimeSettings.loaded) {
@@ -71,12 +66,72 @@
     }
   }
 
-  async function selectTheme(theme: ThemeName) {
-    if (theme === uiState.theme) {
+  async function setTheme(theme: string) {
+    if (!loaded || busy) {
       return;
     }
 
-    await saveSettings(theme);
+    await saveSettings(theme as ThemeName);
+  }
+
+  async function setAutoLock(value: string) {
+    if (!loaded || busy) {
+      return;
+    }
+
+    if (value === 'never') {
+      autoLockEnabled = false;
+    } else {
+      autoLockEnabled = true;
+      autoLockMinutes = Number(value);
+    }
+
+    await saveSettings();
+  }
+
+  async function setClipboardEnabled(next: boolean) {
+    if (!loaded || busy) {
+      return;
+    }
+
+    clipboardEnabled = next;
+    await saveSettings();
+  }
+
+  async function setClipboardDuration(value: string) {
+    if (!loaded || busy) {
+      return;
+    }
+
+    clipboardEnabled = true;
+    clipboardSeconds = Number(value);
+    await saveSettings();
+  }
+
+  async function setFontSize(next: number) {
+    if (!loaded || busy) {
+      return;
+    }
+
+    fontSize = next;
+    await saveSettings();
+  }
+
+  async function lockNow() {
+    if (busy) {
+      return;
+    }
+
+    busy = true;
+    errorMessage = '';
+
+    try {
+      await lockCurrentVault();
+    } catch (error) {
+      errorMessage = messageFromError(error);
+    } finally {
+      busy = false;
+    }
   }
 
   async function saveSettings(theme = uiState.theme): Promise<boolean> {
@@ -145,114 +200,101 @@
   }
 </script>
 
-<section class="settings-panel" aria-labelledby="settings-title">
-  <div class="settings-head">
-    <div>
-      <div class="detail__crumbs mono">vault &nbsp;/&nbsp; <b>settings</b></div>
-      <h1 id="settings-title" class="detail__title">settings<em>.</em></h1>
-      <div class="detail__meta mono">
-        <Tag value={settingsStatus} />
-        <span>theme · <b>{uiState.theme}</b></span>
-        <span>surface · <b>{uiState.theme === 'paper' ? 'warm' : 'dark'}</b></span>
-      </div>
+<section class="page settings-page" aria-labelledby="settings-title">
+  <div class="page__head">
+    <span class="page__hash mono">#</span>
+    <h1 id="settings-title" class="page__title">settings<em>.</em></h1>
+    <div class="page__meta mono">
+      <span>vault · <b>{vaultState.vaultName || 'vault.local'}</b></span>
+      <span>theme · <b>{uiState.theme}</b></span>
     </div>
-    <Button variant="ghost" size="sm" onclick={() => (uiState.view = 'list')}>back_to_vault</Button>
   </div>
 
-  <div class="settings-body">
-    <section class="settings-group" aria-labelledby="settings-theme-title">
-      <div class="settings-group__head">
-        <div>
-          <p class="settings-group__eyebrow mono">appearance</p>
-          <h2 id="settings-theme-title">theme</h2>
+  <div class="settings">
+    <div class="set-group">
+      <div class="set-group__title">appearance</div>
+
+      <div class="set-row">
+        <div class="set-row__k">theme<small>paper is the default surface · ink for low light</small></div>
+        <div class="set-row__v">
+          <Segmented
+            ariaLabel="Theme"
+            value={uiState.theme}
+            options={[...themeOptions]}
+            onselect={setTheme}
+          />
         </div>
-        <Tag variant={uiState.theme === 'ink' ? 'ink' : 'paper'} value={uiState.theme} />
       </div>
 
-      <div class="theme-switch" role="group" aria-label="Theme">
-        {#each themeOptions as option}
-          <button
-            type="button"
-            class={uiState.theme === option.key ? 'theme-option theme-option--active' : 'theme-option'}
-            aria-pressed={uiState.theme === option.key}
-            onclick={() => selectTheme(option.key)}
-            disabled={busy || !loaded}
-          >
-            <span class="theme-option__swatches" aria-hidden="true">
-              <span class="theme-option__swatch" style:background={option.surface}></span>
-              <span class="theme-option__swatch" style:background={option.accent}></span>
-            </span>
-            <span class="theme-option__label">{option.label}</span>
-            <span class="theme-option__meta mono">{option.meta}</span>
-          </button>
-        {/each}
-      </div>
-
-      <label class="settings-row settings-row--control">
-        <span>font_size</span>
-        <span class="settings-control">
-          <input
-            bind:value={fontSize}
-            type="number"
-            min="11"
-            max="16"
-            step="1"
-            onchange={() => void saveSettings()}
-            disabled={busy || !loaded}
+      <div class="set-row">
+        <div class="set-row__k">font size<small>applies across lists, detail, and settings surfaces</small></div>
+        <div class="set-row__v set-row__v--wide">
+          <Slider
+            ariaLabel="Font size"
+            value={fontSize}
+            min={11}
+            max={16}
+            step={1}
+            valueLabel={`${fontSize}px`}
+            oninput={(next) => {
+              fontSize = next;
+            }}
+            onchange={setFontSize}
           />
-          <b>px</b>
-        </span>
-      </label>
-    </section>
-
-    <section class="settings-group settings-group--compact" aria-labelledby="settings-session-title">
-      <div class="settings-group__head">
-        <div>
-          <p class="settings-group__eyebrow mono">session</p>
-          <h2 id="settings-session-title">lock</h2>
         </div>
-        <Tag variant="vault" value={autoLockTag} />
+      </div>
+    </div>
+
+    <div class="set-group">
+      <div class="set-group__title">security</div>
+
+      <div class="set-row">
+        <div class="set-row__k">auto-lock<small>seal the vault after inactivity</small></div>
+        <div class="set-row__v">
+          <Segmented ariaLabel="Auto-lock timeout" value={autoLockValue} options={autoLockOptions} onselect={setAutoLock} />
+        </div>
       </div>
 
-      <label class="settings-row settings-row--control">
-        <span>auto_lock</span>
-        <span class="settings-control">
-          <input bind:checked={autoLockEnabled} type="checkbox" onchange={() => void saveSettings()} disabled={busy || !loaded} />
-          <input
-            bind:value={autoLockMinutes}
-            type="number"
-            min="1"
-            max="240"
-            step="1"
-            onchange={() => void saveSettings()}
-            disabled={busy || !loaded || !autoLockEnabled}
+      <div class="set-row">
+        <div class="set-row__k">clear clipboard<small>wipe copied secrets on the configured timer</small></div>
+        <div class="set-row__v">
+          <Toggle label="Clear clipboard automatically" checked={clipboardEnabled} ontoggle={setClipboardEnabled} />
+          <Segmented
+            ariaLabel="Clipboard clear timeout"
+            value={clipboardValue}
+            options={clipboardOptions}
+            onselect={setClipboardDuration}
+            class={clipboardEnabled ? '' : 'is-disabled'}
           />
-          <b>minutes</b>
-        </span>
-      </label>
-      <label class="settings-row settings-row--control">
-        <span>clipboard_clear</span>
-        <span class="settings-control">
-          <input bind:checked={clipboardEnabled} type="checkbox" onchange={() => void saveSettings()} disabled={busy || !loaded} />
-          <input
-            bind:value={clipboardSeconds}
-            type="number"
-            min="5"
-            max="300"
-            step="5"
-            onchange={() => void saveSettings()}
-            disabled={busy || !loaded || !clipboardEnabled}
-          />
-          <b>seconds</b>
-        </span>
-      </label>
-      <div class="settings-row">
-        <span>shortcut</span>
-        <b><Kbd value="⌘" /> + <Kbd value="," /></b>
+        </div>
       </div>
-      {#if errorMessage}
-        <div class="settings-error mono error" role="alert">{errorMessage}</div>
-      {/if}
-    </section>
+    </div>
+
+    <div class="set-group">
+      <div class="set-group__title">vault</div>
+
+      <div class="set-row">
+        <div class="set-row__k">location<small>{vaultState.vaultPath || '~/.arca/vault.local'}</small></div>
+        <div class="set-row__v">local</div>
+      </div>
+
+      <div class="set-row">
+        <div class="set-row__k">kdf<small>argon2id · aes-512</small></div>
+        <div class="set-row__v">tuned</div>
+      </div>
+
+      <div class="set-row">
+        <div class="set-row__k">networking<small>local-first desktop build · no remote transport configured</small></div>
+        <div class="set-row__v">offline by design</div>
+      </div>
+    </div>
+
+    <div class="settings__actions">
+      <Button variant="ghost" onclick={lockNow} disabled={!loaded || busy}>lock now</Button>
+    </div>
+
+    {#if errorMessage}
+      <div class="settings-error mono error" role="alert">{errorMessage}</div>
+    {/if}
   </div>
 </section>

--- a/apps/desktop/src/lib/components/shared/SharedPanel.svelte
+++ b/apps/desktop/src/lib/components/shared/SharedPanel.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { Icon } from '../icons';
+  import { Button } from '../primitives';
+
+  const outgoingShares: [] = [];
+  const incomingShares: [] = [];
+</script>
+
+<section class="page shared-panel" aria-labelledby="shared-title">
+  <div class="page__head">
+    <span class="page__hash mono">#</span>
+    <h1 id="shared-title" class="page__title">shared<em>.</em></h1>
+    <div class="page__meta mono">
+      <span>active · <b>{outgoingShares.length + incomingShares.length}</b></span>
+      <span>incoming · <b>{incomingShares.length}</b></span>
+    </div>
+  </div>
+
+  <div class="shared">
+    <div class="audit__list-title">shared by you <span class="entries__rule"></span></div>
+    {#if outgoingShares.length > 0}
+      {#each outgoingShares as share}
+        <div>{share}</div>
+      {/each}
+    {:else}
+      <div class="shared-empty">
+        <b>no active outgoing shares</b>
+        <small>Arca is still local-only here. Secure sharing transport has not been wired into vault-core yet.</small>
+      </div>
+    {/if}
+
+    <div class="audit__list-title">shared with you <span class="entries__rule"></span></div>
+    {#if incomingShares.length > 0}
+      {#each incomingShares as share}
+        <div>{share}</div>
+      {/each}
+    {:else}
+      <div class="shared-empty">
+        <b>nothing incoming</b>
+        <small>When secure share import lands, received secrets will appear in this section.</small>
+      </div>
+    {/if}
+
+    <div class="shared__actions">
+      <Button variant="ghost" disabled>
+        <Icon name="share" size={12} />
+        new secure share
+      </Button>
+      <p class="shared__note mono">local-only vault · secure share transport pending</p>
+    </div>
+  </div>
+</section>

--- a/apps/desktop/src/lib/components/shared/index.ts
+++ b/apps/desktop/src/lib/components/shared/index.ts
@@ -1,0 +1,1 @@
+export { default as SharedPanel } from './SharedPanel.svelte';

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { EntryDto } from '../../ipc';
   import { uiState } from '../../stores/ui.svelte';
-  import { vaultState } from '../../stores/vault.svelte';
+  import { clearEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
   import { Button, Kbd } from '../primitives';
   import EntryRow from './EntryRow.svelte';
@@ -58,6 +58,7 @@
   }
 
   function openNewEntry() {
+    clearEntryDraft();
     vaultState.selectedEntry = null;
     uiState.view = 'edit';
   }

--- a/apps/desktop/src/lib/session.ts
+++ b/apps/desktop/src/lib/session.ts
@@ -1,6 +1,6 @@
 import { lockVault } from './ipc';
 import { uiState } from './stores/ui.svelte';
-import { vaultState } from './stores/vault.svelte';
+import { clearEntryDraft, vaultState } from './stores/vault.svelte';
 
 export async function lockCurrentVault(): Promise<void> {
   if (vaultState.locked) {
@@ -15,6 +15,7 @@ export function applyLockedVaultState() {
   vaultState.locked = true;
   vaultState.entries = [];
   vaultState.selectedEntry = null;
+  clearEntryDraft();
   vaultState.searchQuery = '';
   uiState.unlockSurface = vaultState.vaultPath ? 'sealed' : 'two-pane';
   uiState.sealedPromptOpen = false;

--- a/apps/desktop/src/lib/stores/vault.svelte.ts
+++ b/apps/desktop/src/lib/stores/vault.svelte.ts
@@ -1,11 +1,23 @@
-import type { EntryDto } from '../ipc';
+import type { CreateEntryDto, EntryDto } from '../ipc';
 
 export const vaultState = $state({
   locked: true,
   entries: [] as EntryDto[],
   selectedEntry: null as EntryDto | null,
+  entryDraft: null as Partial<CreateEntryDto> | null,
+  entryDraftNonce: 0,
   searchQuery: '',
   vaultName: '',
   vaultPath: '',
   lastSaved: null as Date | null,
 });
+
+export function setEntryDraft(draft: Partial<CreateEntryDto>) {
+  vaultState.entryDraft = draft;
+  vaultState.entryDraftNonce += 1;
+}
+
+export function clearEntryDraft() {
+  vaultState.entryDraft = null;
+  vaultState.entryDraftNonce += 1;
+}


### PR DESCRIPTION
## Summary
- redesign the generator, audit, settings, and shared tab surfaces around the interactive prototype layout
- add shared segmented, slider, and toggle primitives for the new settings and generator controls
- wire generated passwords into a new-entry draft flow and guard browser preview window access outside Tauri

## Verification
- pnpm typecheck
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Shared view panel and navigation branch (shared-by you / with you UI).
  * Redesigned password generator with improved controls, entropy visualization, and reveal/copy behavior.
  * Added vault health score and updated audit page with findings, severity tags, and stats.
  * Introduced segmented controls, sliders, and toggles; updated settings to use them.
* **Bug Fixes**
  * Improved fullscreen state detection and resize handling when a window handle isn’t available.
  * Fixed entry draft lifecycle by clearing drafts when switching modes and when the vault is locked.
* **Style**
  * Updated overall page/widget styling and responsive layout for the new UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->