### PR TITLE
feat: polish empty vault state

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -951,6 +951,86 @@ body {
   font-size: calc(10px * var(--arca-font-scale, 1));
   letter-spacing: 0.05em;
 }
+.empty {
+  min-height: 420px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  justify-items: center;
+  gap: 16px;
+  padding: 36px 20px;
+  color: var(--text);
+  text-align: center;
+}
+.empty__mark {
+  width: 58px;
+  height: 58px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  background: var(--bg-card);
+  color: var(--vault);
+}
+.empty__kicker {
+  color: var(--text-3);
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.empty__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: calc(34px * var(--arca-font-scale, 1));
+  line-height: 1;
+  letter-spacing: -0.022em;
+}
+.empty__title em {
+  font-style: normal;
+  color: var(--accent);
+}
+.empty__sub {
+  max-width: 560px;
+  margin: 0;
+  color: var(--text-2);
+  font-size: calc(14px * var(--arca-font-scale, 1));
+  line-height: 1.55;
+}
+.empty__cta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+}
+.empty__hints {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px 18px;
+  color: var(--text-3);
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  letter-spacing: 0.05em;
+}
+.empty__hints span,
+.empty__hint-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.empty__hint-link {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+  transition: color .12s;
+}
+.empty__hint-link:hover {
+  color: var(--accent);
+}
 .vault-placeholder {
   display: grid;
   gap: 12px;
@@ -2692,7 +2772,9 @@ body {
   letter-spacing: 0.02em;
   color: var(--text);
   min-width: 0;
-  word-break: break-all;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .field__v--mask { letter-spacing: 0.20em; color: var(--text-2); }
 .field__v--url { color: var(--accent); text-decoration: underline; text-decoration-color: var(--accent-soft); text-underline-offset: 3px; cursor: pointer; }

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -63,6 +63,10 @@
     uiState.view = 'edit';
   }
 
+  function openGenerator() {
+    uiState.view = 'generator';
+  }
+
   function selectFilter(key: string) {
     selectedFilter = key as FilterKey;
   }
@@ -291,7 +295,36 @@
         </div>
       {/if}
 
-      {#if sections.length > 0}
+      {#if vaultState.entries.length === 0}
+        <div class="empty">
+          <div class="empty__mark">
+            <Icon name="vault" size={32} sw={1.4} />
+          </div>
+          <div class="empty__kicker mono">{vaultState.vaultName || 'vault.local'} · created just now</div>
+          <h2 class="empty__title">your vault is <em>clean.</em></h2>
+          <p class="empty__sub">
+            nothing stored yet. add your first secret or generate a fresh password — everything stays on this device,
+            encrypted at rest.
+          </p>
+          <div class="empty__cta">
+            <Button variant="primary" onclick={openNewEntry}>
+              <Icon name="plus" size={11} sw={2} />
+              new_entry
+              <Kbd value="N" />
+            </Button>
+            <Button variant="ghost" onclick={openGenerator}>
+              <Icon name="refresh" size={12} />
+              generate
+              <Kbd value="G" />
+            </Button>
+          </div>
+          <div class="empty__hints mono">
+            <span><Kbd value="N" /> new entry</span>
+            <button type="button" class="empty__hint-link" onclick={openGenerator}><Kbd value="G" /> generate a password</button>
+            <span><Kbd value="⌘" /><Kbd value="O" /> open another vault</span>
+          </div>
+        </div>
+      {:else if sections.length > 0}
         {#each sections as section}
           <div class="entries__section">
             {section.label}


### PR DESCRIPTION
## Summary
- add the prototype-inspired clean vault empty state with entry and generator actions
- route the empty-state generator action to the generate tab
- enforce one-line ellipsis rendering for detail field values so URLs and passwords do not wrap

## Testing
- `pnpm typecheck`
- `pnpm build`
- GitHub CI: Node Checks, Rust Checks, CodeQL, Semgrep, Secret Scan, and OSV checks passing
- Local browser preview booted without console errors

## Security Checklist
- [x] No plaintext secrets, vault entries, generated passwords, master passwords, clipboard values, or decrypted vault contents are logged or snapshotted
- [x] No cryptography, KDF parameters, vault format, or key-management behavior changed
- [x] No Tauri IPC surface or secret transport changed
- [x] No `unsafe` Rust introduced
- [x] Dependency scan/secret scan covered by GitHub checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added generator button accessible from empty vault state with dedicated messaging
  * Users can now access password generation directly when vault is empty

* **Style**
  * Improved text truncation for field values with ellipsis overflow handling
  * Enhanced empty state layout and visual design for better clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
