### PR TITLE
feat: improve active vault filters

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -579,6 +579,25 @@ body {
   color: var(--text-3);
   opacity: 0.85;
 }
+.search__clear {
+  flex: 0 0 auto;
+  background: transparent;
+  border: 1px solid var(--rule-strong);
+  border-radius: 3px;
+  cursor: pointer;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: calc(9px * var(--arca-font-scale, 1));
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  transition: color .12s, border-color .12s, background .12s;
+}
+.search__clear:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
 .search__text--ph { color: var(--text-3); opacity: 0.85; }
 .search__hint {
   font-family: var(--font-mono);
@@ -926,18 +945,67 @@ body {
 }
 .entries__active {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
   gap: 8px;
-  padding: 4px 4px 10px;
+  padding: 6px 4px 12px;
 }
-.entries__active-item {
+.entries__active-k {
   color: var(--text-3);
-  font-size: calc(10px * var(--arca-font-scale, 1));
-  letter-spacing: 0.05em;
+  font-size: calc(9px * var(--arca-font-scale, 1));
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
 }
-.entries__active-item b {
-  color: var(--text-2);
+.entries__active-clear {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-3);
+  cursor: pointer;
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  letter-spacing: 0.06em;
+}
+.entries__active-clear:hover {
+  color: var(--accent);
+}
+.fchip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  max-width: 100%;
+  font-family: var(--font-mono);
+  font-size: calc(10px * var(--arca-font-scale, 1));
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  padding: 3px 10px;
+  cursor: pointer;
+  transition: background .12s, color .12s, border-color .12s;
+}
+.fchip b {
+  overflow: hidden;
+  max-width: 220px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-weight: 500;
+}
+.fchip span {
+  opacity: 0.7;
+}
+.fchip:hover {
+  background: var(--accent);
+  color: var(--accent-on);
+}
+.fchip--tag {
+  color: var(--vault);
+  background: var(--vault-soft);
+  border-color: var(--vault);
+}
+.fchip--tag:hover {
+  background: var(--vault);
+  color: var(--vault-on);
 }
 .entries__empty span {
   color: var(--accent);

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import type { EntryDto } from '../../ipc';
   import { uiState } from '../../stores/ui.svelte';
   import { clearEntryDraft, vaultState } from '../../stores/vault.svelte';
@@ -19,6 +20,7 @@
   let selectedFilter = $state<FilterKey>('all');
   let selectedTag = $state<string | null>(null);
   let searchFocused = $state(true);
+  let searchFocusToken = $state(0);
 
   const sortedEntries = $derived([...vaultState.entries].sort(compareByUpdatedAt));
   const recentIds = $derived(new Set(sortedEntries.slice(0, 6).map((entry) => entry.id)));
@@ -48,8 +50,28 @@
   );
   const emptyState = $derived(describeEmptyState(vaultState.entries.length));
 
+  onMount(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'f') {
+        event.preventDefault();
+        focusSearch();
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeydown);
+    };
+  });
+
   function setQuery(query: string) {
     vaultState.searchQuery = query;
+  }
+
+  function clearQuery() {
+    vaultState.searchQuery = '';
+    focusSearch();
   }
 
   function selectEntry(entry: EntryDto) {
@@ -78,6 +100,20 @@
   function clearScopedFilters() {
     selectedFilter = 'all';
     selectedTag = null;
+    vaultState.searchQuery = '';
+  }
+
+  function clearFilter() {
+    selectedFilter = 'all';
+  }
+
+  function clearTag() {
+    selectedTag = null;
+  }
+
+  function focusSearch() {
+    searchFocused = true;
+    searchFocusToken += 1;
   }
 
   function matchesQuery(entry: EntryDto): boolean {
@@ -254,7 +290,9 @@
     <SearchBar
       query={vaultState.searchQuery}
       focused={searchFocused}
+      focusToken={searchFocusToken}
       onquery={setQuery}
+      onclear={clearQuery}
       onfocus={() => (searchFocused = true)}
       onblur={() => (searchFocused = false)}
     />
@@ -283,15 +321,26 @@
     <div class="entries" role="listbox" aria-label="Vault entries">
       {#if hasScopedResults}
         <div class="entries__active">
+          <span class="entries__active-k mono">active</span>
           {#if selectedFilter !== 'all'}
-            <span class="entries__active-item mono">collection · <b>{selectedFilter}</b></span>
+            <button type="button" class="fchip" onclick={clearFilter}>
+              collection · <b>{selectedFilter}</b>
+              <span>x</span>
+            </button>
           {/if}
           {#if selectedTag}
-            <span class="entries__active-item mono">tag · <b>#{selectedTag}</b></span>
+            <button type="button" class="fchip fchip--tag" onclick={clearTag}>
+              tag · <b>#{selectedTag}</b>
+              <span>x</span>
+            </button>
           {/if}
           {#if vaultState.searchQuery.trim()}
-            <span class="entries__active-item mono">query · <b>{vaultState.searchQuery.trim()}</b></span>
+            <button type="button" class="fchip" onclick={clearQuery}>
+              query · <b>{vaultState.searchQuery.trim()}</b>
+              <span>x</span>
+            </button>
           {/if}
+          <button type="button" class="entries__active-clear mono" onclick={clearScopedFilters}>clear all</button>
         </div>
       {/if}
 

--- a/apps/desktop/src/lib/components/vault/SearchBar.svelte
+++ b/apps/desktop/src/lib/components/vault/SearchBar.svelte
@@ -2,27 +2,39 @@
   let {
     query = '',
     focused = false,
+    focusToken = 0,
     onquery,
     onfocus,
     onblur,
+    onclear,
     class: className = '',
     ...rest
   } = $props<{
     query?: string;
     focused?: boolean;
+    focusToken?: number;
     onquery?: (query: string) => void;
     onfocus?: () => void;
     onblur?: () => void;
+    onclear?: () => void;
     class?: string;
     [key: string]: unknown;
   }>();
 
+  let inputElement = $state<HTMLInputElement | null>(null);
   const classes = $derived(['search', focused ? 'search--focus' : '', className].filter(Boolean).join(' '));
+
+  $effect(() => {
+    if (focused || focusToken > 0) {
+      inputElement?.focus();
+    }
+  });
 </script>
 
-<label {...rest} class={classes}>
+<div {...rest} class={classes}>
   <span class="search__prompt">&gt;</span>
   <input
+    bind:this={inputElement}
     class="search__input"
     aria-label="query vault"
     autocomplete="off"
@@ -33,5 +45,8 @@
     onfocus={onfocus}
     onblur={onblur}
   />
+  {#if query.trim()}
+    <button type="button" class="search__clear" onclick={() => onclear?.()} aria-label="Clear query">clear</button>
+  {/if}
   <span class="search__hint">⌘F</span>
-</label>
+</div>

--- a/apps/desktop/src/lib/components/vault/SearchBar.svelte
+++ b/apps/desktop/src/lib/components/vault/SearchBar.svelte
@@ -25,7 +25,13 @@
   const classes = $derived(['search', focused ? 'search--focus' : '', className].filter(Boolean).join(' '));
 
   $effect(() => {
-    if (focused || focusToken > 0) {
+    if (focused) {
+      inputElement?.focus();
+    }
+  });
+
+  $effect(() => {
+    if (focusToken > 0) {
       inputElement?.focus();
     }
   });


### PR DESCRIPTION
## Summary
- make active vault filters removable with category/tag/query chips and clear-all
- add a query clear control to the vault search field
- wire Cmd/Ctrl+F to focus the vault search input

## Testing
- `pnpm typecheck`
- `pnpm build`
- GitHub CI: Node Checks, Rust Checks, CodeQL, Semgrep, Secret Scan, and OSV checks passing before the latest CodeRabbit fix; rerunning after push
- Local browser preview booted without console errors

## Security Checklist
- [x] No plaintext secrets, vault entries, generated passwords, master passwords, clipboard values, or decrypted vault contents are logged or snapshotted
- [x] No cryptography, KDF parameters, vault format, or key-management behavior changed
- [x] No Tauri IPC surface or secret transport changed
- [x] No `unsafe` Rust introduced
- [x] Dependency scan/secret scan covered by GitHub checks

## Agent-Assisted Changes
- [x] Changes were prepared with Codex assistance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Ctrl/⌘+F keyboard shortcut to focus the search field
  * Added dedicated clear button for search queries
  * Active filters (collections and tags) are now individually clickable to remove them

* **UI/UX Improvements**
  * Enhanced filter display styling with improved chip component appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
