### PR TITLE
feat: polish entry detail fields

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2824,15 +2824,23 @@ body {
   gap: 12px;
   padding: 12px 16px;
   border-bottom: 1px dashed var(--rule-dashed);
+  min-width: 0;
 }
 .field:last-child { border-bottom: none; }
 .field--focus { background: var(--accent-soft); }
+.field--empty .field__v { color: var(--text-4); }
+.field--secret-revealed { background: rgba(200, 85, 61, 0.16); }
 .field__k {
   font-family: var(--font-mono);
   font-size: calc(10px * var(--arca-font-scale, 1));
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--text-3);
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
 }
 .field__v {
   font-family: var(--font-mono);
@@ -2845,9 +2853,18 @@ body {
   white-space: nowrap;
 }
 .field__v--mask { letter-spacing: 0.20em; color: var(--text-2); }
+.field__v--secret {
+  letter-spacing: 0.04em;
+  color: var(--text);
+}
 .field__v--url { color: var(--accent); text-decoration: underline; text-decoration-color: var(--accent-soft); text-underline-offset: 3px; cursor: pointer; }
 .field__v--ok  { color: var(--vault); }
-.field__actions { display: flex; gap: 6px; }
+.field__actions {
+  display: flex;
+  gap: 6px;
+  flex: 0 0 auto;
+  justify-content: flex-end;
+}
 
 /* Compact stat strip */
 .strip {

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -39,7 +39,7 @@
 
   onMount(() => {
     function handleKeydown(event: KeyboardEvent) {
-      if (event.metaKey || event.ctrlKey || event.altKey || isEditableTarget(event.target)) {
+      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey || isEditableTarget(event.target)) {
         return;
       }
 
@@ -121,11 +121,17 @@
       return false;
     }
 
-    return Boolean(target.closest('input, textarea, select, [contenteditable="true"]'));
+    return (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLSelectElement ||
+      target.isContentEditable
+    );
   }
 
   $effect(() => {
     entry.id;
+    password;
     passwordRevealed = false;
     copied = null;
     clearRevealTimer();

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import type { EntryDto } from '../../ipc';
   import { writeConfiguredClipboardText } from '../../clipboard';
   import { Icon } from '../icons';
@@ -11,10 +11,15 @@
     entry: EntryDto;
   }>();
 
+  type CopyKind = 'url' | 'username' | 'password';
+
   const passwordMask = '●●●●●●●●●●●●●●●●●●●●●●●●';
-  let copied = $state<'username' | 'password' | null>(null);
+  const passwordRevealMs = 10_000;
+
+  let copied = $state<CopyKind | null>(null);
   let passwordRevealed = $state(false);
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
+  let revealTimer: ReturnType<typeof setTimeout> | null = null;
 
   const url = $derived(entry.url?.trim() || 'not_set');
   const username = $derived(entry.username.trim() || 'not_set');
@@ -27,9 +32,39 @@
     if (copyTimer) {
       clearTimeout(copyTimer);
     }
+
+    clearRevealTimer();
   });
 
-  async function copyValue(kind: 'username' | 'password', value: string) {
+  onMount(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.metaKey || event.ctrlKey || event.altKey || isEditableTarget(event.target)) {
+        return;
+      }
+
+      if (event.key.toLowerCase() === 'u' && entry.username.trim()) {
+        event.preventDefault();
+        void copyValue('username', entry.username);
+        return;
+      }
+
+      if (event.key.toLowerCase() === 'c' && password) {
+        event.preventDefault();
+        void copyValue('password', password);
+        return;
+      }
+
+      if (event.key.toLowerCase() === 'r' && password) {
+        event.preventDefault();
+        togglePasswordReveal();
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  });
+
+  async function copyValue(kind: CopyKind, value: string) {
     if (!value) {
       return;
     }
@@ -56,26 +91,67 @@
     }
 
     passwordRevealed = !passwordRevealed;
+
+    if (passwordRevealed) {
+      schedulePasswordHide();
+    } else {
+      clearRevealTimer();
+    }
+  }
+
+  function schedulePasswordHide() {
+    clearRevealTimer();
+
+    revealTimer = setTimeout(() => {
+      passwordRevealed = false;
+      revealTimer = null;
+    }, passwordRevealMs);
+  }
+
+  function clearRevealTimer() {
+    if (revealTimer) {
+      clearTimeout(revealTimer);
+      revealTimer = null;
+    }
+  }
+
+  function isEditableTarget(target: EventTarget | null) {
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+
+    return Boolean(target.closest('input, textarea, select, [contenteditable="true"]'));
   }
 
   $effect(() => {
     entry.id;
     passwordRevealed = false;
+    copied = null;
+    clearRevealTimer();
   });
 </script>
 
 <div class="fields">
-  <div class="field">
+  <div class={entry.url ? 'field' : 'field field--empty'}>
     <div class="field__k">url</div>
     <div class={entry.url ? 'field__v field__v--url' : 'field__v'}>{url}</div>
     <div class="field__actions">
-      <IconButton label={`Open ${entry.title} URL`} disabled={!entry.url}>
-        <Icon name="external" size={13} />
+      <IconButton
+        label={copied === 'url' ? 'URL copied' : `Copy ${entry.title} URL`}
+        variant={copied === 'url' ? 'accent' : 'default'}
+        disabled={!entry.url}
+        onclick={() => entry.url && copyValue('url', entry.url)}
+      >
+        {#if copied === 'url'}
+          ✓
+        {:else}
+          <Icon name="copy" size={13} />
+        {/if}
       </IconButton>
     </div>
   </div>
 
-  <div class="field">
+  <div class={entry.username.trim() ? 'field' : 'field field--empty'}>
     <div class="field__k">user <Kbd value="U" /></div>
     <div class="field__v">{username}</div>
     <div class="field__actions">
@@ -94,8 +170,8 @@
     </div>
   </div>
 
-  <div class="field field--focus">
-    <div class="field__k">password <Kbd value="C" /></div>
+  <div class={passwordRevealed ? 'field field--focus field--secret-revealed' : 'field field--focus'}>
+    <div class="field__k">password <Kbd value="C" /><Kbd value="R" /></div>
     <div class={passwordRevealed ? 'field__v field__v--secret' : 'field__v field__v--mask'}>{displayedPassword}</div>
     <div class="field__actions">
       <IconButton

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -21,9 +21,10 @@
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
   let revealTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const url = $derived(entry.url?.trim() || 'not_set');
+  const normalizedUrl = $derived(entry.url?.trim() || '');
+  const url = $derived(normalizedUrl || 'not_set');
   const username = $derived(entry.username.trim() || 'not_set');
-  const password = $derived(entry.password?.trim() || '');
+  const password = $derived(entry.password ?? '');
   const displayedPassword = $derived(passwordRevealed ? password : passwordMask);
   const entropyBits = $derived(Math.max(72, Math.min(112, entry.title.length * 6 + entry.username.length * 4 + 48)));
   const entropyFilled = $derived(Math.max(10, Math.min(16, Math.round(entropyBits / 7))));
@@ -132,15 +133,15 @@
 </script>
 
 <div class="fields">
-  <div class={entry.url ? 'field' : 'field field--empty'}>
+  <div class={normalizedUrl ? 'field' : 'field field--empty'}>
     <div class="field__k">url</div>
-    <div class={entry.url ? 'field__v field__v--url' : 'field__v'}>{url}</div>
+    <div class={normalizedUrl ? 'field__v field__v--url' : 'field__v'}>{url}</div>
     <div class="field__actions">
       <IconButton
         label={copied === 'url' ? 'URL copied' : `Copy ${entry.title} URL`}
         variant={copied === 'url' ? 'accent' : 'default'}
-        disabled={!entry.url}
-        onclick={() => entry.url && copyValue('url', entry.url)}
+        disabled={!normalizedUrl}
+        onclick={() => normalizedUrl && copyValue('url', normalizedUrl)}
       >
         {#if copied === 'url'}
           ✓

--- a/apps/desktop/src/lib/components/vault/SearchBar.svelte
+++ b/apps/desktop/src/lib/components/vault/SearchBar.svelte
@@ -41,7 +41,9 @@
   {...rest}
   class={classes}
   onclick={(event) => {
-    if ((event.target as HTMLElement).closest('button')) {
+    const target = event.target;
+
+    if (target instanceof Element && target.closest('button')) {
       return;
     }
 

--- a/apps/desktop/src/lib/components/vault/SearchBar.svelte
+++ b/apps/desktop/src/lib/components/vault/SearchBar.svelte
@@ -37,7 +37,17 @@
   });
 </script>
 
-<div {...rest} class={classes}>
+<div
+  {...rest}
+  class={classes}
+  onclick={(event) => {
+    if ((event.target as HTMLElement).closest('button')) {
+      return;
+    }
+
+    inputElement?.focus();
+  }}
+>
   <span class="search__prompt">&gt;</span>
   <input
     bind:this={inputElement}
@@ -52,7 +62,17 @@
     onblur={onblur}
   />
   {#if query.trim()}
-    <button type="button" class="search__clear" onclick={() => onclear?.()} aria-label="Clear query">clear</button>
+    <button
+      type="button"
+      class="search__clear"
+      onclick={(event) => {
+        event.stopPropagation();
+        onclear?.();
+      }}
+      aria-label="Clear query"
+    >
+      clear
+    </button>
   {/if}
   <span class="search__hint">⌘F</span>
 </div>


### PR DESCRIPTION
## Summary
- make entry detail URL, username, and password copy actions share one configured clipboard path
- add detail keyboard shortcuts for username copy, password copy, and password reveal when focus is not in a form field
- auto-hide revealed entry passwords after a short user-driven reveal window and tighten field row layout

## Testing
- `pnpm typecheck`
- `pnpm build`
- local browser preview loaded with no console errors

## Security Checklist
- [x] No plaintext secrets, vault entries, generated passwords, master passwords, clipboard values, or decrypted vault contents are logged or snapshotted
- [x] No cryptography, KDF parameters, vault format, or key-management behavior changed
- [x] No Tauri IPC surface or secret transport changed
- [x] No `unsafe` Rust introduced
- [x] Password reveal remains explicit, user-driven, and time-limited
- [x] Clipboard copying continues through the configured clipboard helper

## Agent-Assisted Changes
- [x] Changes were prepared with Codex assistance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for quick actions: U copies username, C copies password, R reveals password.
  * Password reveal now auto-hides after a short delay.
  * URL field now copies to clipboard with clear visual feedback.
* **UI Improvements**
  * Updated field layout and states (empty/secret-revealed) for more consistent alignment.
  * Search bar adds a conditional clear button, improved click-to-focus behavior, and updated keyboard hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
