### PR TITLE
feat: persist paper ink theme names

### DIFF
--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -83,7 +83,7 @@ impl Default for Settings {
         Self {
             auto_lock_timeout_minutes: Some(15),
             clipboard_clear_seconds: Some(30),
-            theme: Theme::Terminal,
+            theme: Theme::Paper,
             font_size: 13,
         }
     }
@@ -92,6 +92,50 @@ impl Default for Settings {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum Theme {
-    Terminal,
-    Amber,
+    #[serde(alias = "terminal")]
+    Paper,
+    #[serde(alias = "amber")]
+    Ink,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Settings, Theme};
+
+    #[test]
+    fn settings_serialize_v2_theme_names() {
+        let settings = Settings {
+            theme: Theme::Ink,
+            ..Settings::default()
+        };
+
+        let json = serde_json::to_value(settings).expect("settings should serialize");
+
+        assert_eq!(json["theme"], "ink");
+    }
+
+    #[test]
+    fn settings_deserialize_legacy_theme_names() {
+        let terminal: Settings = serde_json::from_str(
+            r#"{
+                "autoLockTimeoutMinutes": 15,
+                "clipboardClearSeconds": 30,
+                "theme": "terminal",
+                "fontSize": 13
+            }"#,
+        )
+        .expect("legacy terminal theme should deserialize");
+        let amber: Settings = serde_json::from_str(
+            r#"{
+                "autoLockTimeoutMinutes": 15,
+                "clipboardClearSeconds": 30,
+                "theme": "amber",
+                "fontSize": 13
+            }"#,
+        )
+        .expect("legacy amber theme should deserialize");
+
+        assert_eq!(terminal.theme, Theme::Paper);
+        assert_eq!(amber.theme, Theme::Ink);
+    }
 }

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -1,6 +1,8 @@
 import { invoke } from '@tauri-apps/api/core';
 
-export type Theme = 'terminal' | 'amber';
+export type Theme = 'paper' | 'ink';
+export type LegacyTheme = 'terminal' | 'amber';
+export type SettingsTheme = Theme | LegacyTheme;
 export type GeneratorMode = 'random' | 'passphrase';
 
 export interface VaultInfo {
@@ -68,7 +70,7 @@ export interface PathSuggestion {
 export interface Settings {
   autoLockTimeoutMinutes?: number | null;
   clipboardClearSeconds?: number | null;
-  theme: Theme;
+  theme: SettingsTheme;
   fontSize: number;
 }
 

--- a/apps/desktop/src/lib/stores/settings.svelte.ts
+++ b/apps/desktop/src/lib/stores/settings.svelte.ts
@@ -8,7 +8,7 @@ const DEFAULT_FONT_SIZE = 13;
 export const DEFAULT_SETTINGS: Settings = {
   autoLockTimeoutMinutes: DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES,
   clipboardClearSeconds: DEFAULT_CLIPBOARD_CLEAR_SECONDS,
-  theme: 'terminal',
+  theme: 'paper',
   fontSize: DEFAULT_FONT_SIZE,
 };
 
@@ -39,11 +39,11 @@ export function applyRuntimeSettings(settings: Settings) {
 }
 
 export function themeForUi(theme: ThemeName): Settings['theme'] {
-  return theme === 'ink' ? 'amber' : 'terminal';
+  return theme;
 }
 
 export function uiThemeFor(theme: Settings['theme']): ThemeName {
-  return theme === 'amber' ? 'ink' : 'paper';
+  return theme === 'ink' || theme === 'amber' ? 'ink' : 'paper';
 }
 
 function normalizeSettings(settings: Settings): Settings {
@@ -61,7 +61,7 @@ function normalizeSettings(settings: Settings): Settings {
       300,
       5,
     ),
-    theme: settings.theme === 'amber' ? 'amber' : 'terminal',
+    theme: themeForUi(uiThemeFor(settings.theme)),
     fontSize: normalizeFontSize(settings.fontSize),
   };
 }


### PR DESCRIPTION
## Summary
- switch Tauri settings defaults and serialization to the v0.2 paper/ink theme names
- keep legacy terminal/amber settings values deserializable for compatibility
- normalize frontend runtime settings to save paper/ink going forward

## Verification
- pnpm typecheck
- pnpm build
- cargo fmt --all --check
- cargo test --workspace (passed on rerun after one transient path suggestion test failure)
- cargo clippy --workspace --all-targets -- -D warnings
- local browser preview loaded with no console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the theme system with new theme options: "Paper" and "Ink"
  * Updated the default application theme to "Paper"
  * Existing user theme preferences are automatically migrated and remain fully compatible

<!-- end of auto-generated comment: release notes by coderabbit.ai -->