### PR TITLE
feat: clarify deferred shared state

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2688,26 +2688,77 @@ body {
   max-width: 760px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 14px;
 }
-.shared-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 18px 16px;
-  border: 1px dashed var(--rule-dashed);
+.shared-deferred {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  padding: 20px;
+  border: 1px solid var(--rule);
   border-radius: 8px;
   background: var(--bg-card);
 }
-.shared-empty b {
+.shared-deferred__mark {
+  width: 42px;
+  height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.shared-deferred__k {
+  color: var(--text);
+  font-size: calc(12px * var(--arca-font-scale, 1));
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.shared-deferred p {
+  margin: 8px 0 0;
+  max-width: 56ch;
+  color: var(--text-2);
+  line-height: 1.5;
+}
+.shared-deferred__tags {
+  grid-column: 2;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 2px;
+}
+.shared__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+.shared-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 7px;
+  min-width: 0;
+  padding: 14px;
+  border: 1px dashed var(--rule-dashed);
+  border-radius: 8px;
+  background: var(--bg-inset);
+}
+.shared-card__k {
+  color: var(--text-3);
+  font-size: calc(9px * var(--arca-font-scale, 1));
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+.shared-card b {
   color: var(--text);
   font-family: var(--font-mono);
-  font-size: calc(12px * var(--arca-font-scale, 1));
+  font-size: calc(13px * var(--arca-font-scale, 1));
   font-weight: 500;
   letter-spacing: 0.04em;
 }
-.shared-empty small,
+.shared-card small,
 .shared__note {
   color: var(--text-3);
   font-size: calc(10px * var(--arca-font-scale, 1));
@@ -2719,6 +2770,18 @@ body {
   align-items: center;
   gap: 10px 14px;
   margin-top: 6px;
+}
+
+@media (max-width: 720px) {
+  .shared-deferred,
+  .shared-deferred__tags {
+    grid-template-columns: 1fr;
+    grid-column: auto;
+  }
+
+  .shared__grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 980px) {

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2773,10 +2773,14 @@ body {
 }
 
 @media (max-width: 720px) {
-  .shared-deferred,
-  .shared-deferred__tags {
+  .shared-deferred {
     grid-template-columns: 1fr;
+  }
+
+  .shared-deferred__tags {
     grid-column: auto;
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .shared__grid {

--- a/apps/desktop/src/lib/components/shared/SharedPanel.svelte
+++ b/apps/desktop/src/lib/components/shared/SharedPanel.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import { Icon } from '../icons';
-  import { Button } from '../primitives';
-
-  const outgoingShares: [] = [];
-  const incomingShares: [] = [];
+  import { Button, Tag } from '../primitives';
 </script>
 
 <section class="page shared-panel" aria-labelledby="shared-title">
@@ -11,42 +8,57 @@
     <span class="page__hash mono">#</span>
     <h1 id="shared-title" class="page__title">shared<em>.</em></h1>
     <div class="page__meta mono">
-      <span>active · <b>{outgoingShares.length + incomingShares.length}</b></span>
-      <span>incoming · <b>{incomingShares.length}</b></span>
+      <span>scope · <b>local_only</b></span>
+      <span>status · <b>deferred</b></span>
     </div>
   </div>
 
   <div class="shared">
-    <div class="audit__list-title">shared by you <span class="entries__rule"></span></div>
-    {#if outgoingShares.length > 0}
-      {#each outgoingShares as share}
-        <div>{share}</div>
-      {/each}
-    {:else}
-      <div class="shared-empty">
-        <b>no active outgoing shares</b>
-        <small>Arca is still local-only here. Secure sharing transport has not been wired into vault-core yet.</small>
+    <div class="shared-deferred" role="status">
+      <div class="shared-deferred__mark" aria-hidden="true">
+        <Icon name="share" size={18} />
       </div>
-    {/if}
-
-    <div class="audit__list-title">shared with you <span class="entries__rule"></span></div>
-    {#if incomingShares.length > 0}
-      {#each incomingShares as share}
-        <div>{share}</div>
-      {/each}
-    {:else}
-      <div class="shared-empty">
-        <b>nothing incoming</b>
-        <small>When secure share import lands, received secrets will appear in this section.</small>
+      <div>
+        <div class="shared-deferred__k mono">sharing_unavailable</div>
+        <p>
+          shared vaults, secure send, and received secrets are outside this local-first release.
+        </p>
       </div>
-    {/if}
+      <div class="shared-deferred__tags">
+        <Tag value="local_only" />
+        <Tag value="no_transport" variant="slate" />
+        <Tag value="no_export" variant="out" />
+      </div>
+    </div>
 
-    <div class="shared__actions">
+    <div class="shared__grid" aria-label="Deferred sharing capabilities">
+      <div class="shared-card">
+        <span class="shared-card__k mono">outgoing</span>
+        <b>disabled</b>
+        <small>no send channel</small>
+      </div>
+      <div class="shared-card">
+        <span class="shared-card__k mono">incoming</span>
+        <b>disabled</b>
+        <small>no import contract</small>
+      </div>
+      <div class="shared-card">
+        <span class="shared-card__k mono">sync</span>
+        <b>offline</b>
+        <small>vault stays local</small>
+      </div>
+    </div>
+
+    <div class="shared__actions" aria-label="Unavailable sharing actions">
       <Button variant="ghost" disabled>
         <Icon name="share" size={12} />
-        new secure share
+        secure_share
       </Button>
-      <p class="shared__note mono">local-only vault · secure share transport pending</p>
+      <Button variant="ghost" disabled>
+        <Icon name="external" size={12} />
+        import_share
+      </Button>
+      <p class="shared__note mono">deferred · tracked outside vault runtime</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- replace the shared tab's pseudo-empty lists with one explicit deferred/unavailable state
- show local-only/deferred status metadata and disabled share/import actions
- keep the screen inside the existing Paper/Ink page vocabulary without adding sharing behavior

## Tracking
- https://github.com/akei9/arca/issues/88

## Verification
- pnpm typecheck
- pnpm build
- local browser preview loaded with no console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **UI Updates**
  * Redesigned the shared panel to present a “deferred” sharing experience with clearer scope/status labeling.
  * Updated the sharing content area to show sharing availability limits and disabled capabilities.
  * Refreshed spacing, typography, and card/grid styling for the shared layout.
  * Improved mobile responsiveness by collapsing the new layouts into single-column stacks on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->