### PR TITLE
feat: align copy feedback timing

### DIFF
--- a/apps/desktop/src/lib/clipboard.ts
+++ b/apps/desktop/src/lib/clipboard.ts
@@ -1,5 +1,7 @@
 import { runtimeSettings } from './stores/settings.svelte';
 
+export const COPY_CONFIRMATION_MS = 1500;
+
 let clearTimer: ReturnType<typeof setTimeout> | null = null;
 
 export async function writeConfiguredClipboardText(value: string): Promise<boolean> {

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import type { EntryDto } from '../../ipc';
-  import { writeConfiguredClipboardText } from '../../clipboard';
+  import { COPY_CONFIRMATION_MS, writeConfiguredClipboardText } from '../../clipboard';
   import { Icon } from '../icons';
   import { Entropy, IconButton, Kbd } from '../primitives';
 
@@ -83,7 +83,7 @@
     copyTimer = setTimeout(() => {
       copied = null;
       copyTimer = null;
-    }, 1500);
+    }, COPY_CONFIRMATION_MS);
   }
 
   function togglePasswordReveal() {

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { writeConfiguredClipboardText } from '../../clipboard';
+  import { COPY_CONFIRMATION_MS, writeConfiguredClipboardText } from '../../clipboard';
   import { generatePassword, type GeneratedPassword } from '../../ipc';
   import { uiState } from '../../stores/ui.svelte';
   import { clearEntryDraft, setEntryDraft, vaultState } from '../../stores/vault.svelte';
@@ -98,7 +98,7 @@
     copyTimer = setTimeout(() => {
       copied = false;
       copyTimer = null;
-    }, 1400);
+    }, COPY_CONFIRMATION_MS);
   }
 
   function resetGenerated() {

--- a/apps/desktop/src/lib/components/vault/EntryRow.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
   import type { EntryDto } from '../../ipc';
-  import { writeConfiguredClipboardText } from '../../clipboard';
+  import { COPY_CONFIRMATION_MS, writeConfiguredClipboardText } from '../../clipboard';
   import { Icon, type IconName } from '../icons';
   import { Tag } from '../primitives';
 
@@ -95,7 +95,7 @@
     copyTimer = setTimeout(() => {
       copied = false;
       copyTimer = null;
-    }, 1500);
+    }, COPY_CONFIRMATION_MS);
   }
 </script>
 


### PR DESCRIPTION
## Summary
- add a shared copy confirmation duration next to the clipboard helper
- align generator, vault row, and entry detail copy feedback to the v0.2 1500ms timing
- remove ad hoc per-component copy confirmation durations

## Verification
- `pnpm typecheck`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized copy confirmation delay timing across the application by consolidating previously hardcoded values into a shared configuration constant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->