### PR TITLE
fix: desktop QA mockup drift polish

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -1725,6 +1725,9 @@ body {
   white-space: nowrap;
 }
 .audit-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
   color: var(--text-3);
   font-family: var(--font-mono);
   font-size: calc(12px * var(--arca-font-scale, 1));

--- a/apps/desktop/src/lib/components/VaultShell.svelte
+++ b/apps/desktop/src/lib/components/VaultShell.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { lockCurrentVault } from '../session';
   import { uiState } from '../stores/ui.svelte';
   import { AuditPanel } from './audit';
   import { EntryDetail, EntryForm } from './detail';
@@ -7,37 +6,6 @@
   import { SettingsPanel } from './settings';
   import { SharedPanel } from './shared';
   import { EntryList } from './vault';
-
-  let busy = $state(false);
-  let errorMessage = $state('');
-
-  async function lock() {
-    busy = true;
-    errorMessage = '';
-
-    try {
-      await lockCurrentVault();
-    } catch (error) {
-      errorMessage = messageFromError(error);
-    } finally {
-      busy = false;
-    }
-  }
-
-  function messageFromError(error: unknown): string {
-    if (typeof error === 'object' && error !== null && 'message' in error) {
-      return String(error.message);
-    }
-
-    return 'Unable to lock vault';
-  }
-  const placeholderTitle = $derived(
-    uiState.view === 'generator'
-      ? 'generate'
-      : uiState.view === 'audit' || uiState.view === 'shared' || uiState.view === 'settings'
-        ? uiState.view
-        : '',
-  );
 </script>
 
 {#if uiState.view === 'detail'}
@@ -55,13 +23,5 @@
 {:else if uiState.view === 'shared'}
   <SharedPanel />
 {:else}
-  <section class="vault-placeholder" aria-labelledby="vault-placeholder-title">
-    <p class="vault-placeholder__eyebrow">placeholder</p>
-    <h1 id="vault-placeholder-title">{placeholderTitle}</h1>
-    <p>screen_port_pending</p>
-    <button class="btn btn--ghost" type="button" onclick={lock} disabled={busy}>lock_vault</button>
-    {#if errorMessage}
-      <div class="error" role="alert">{errorMessage}</div>
-    {/if}
-  </section>
+  <EntryList />
 {/if}

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -133,9 +133,9 @@
         {/each}
       </div>
     {:else}
-      <div class="shared-empty">
-        <b>no findings</b>
-        <small>Your loaded vault is in good shape. Add more entries or rescan after updates to spot regressions.</small>
+      <div class="audit-empty">
+        <span>no findings</span>
+        <small>vault health checks are clear</small>
       </div>
     {/if}
   </div>

--- a/apps/desktop/src/lib/components/detail/EntryDetail.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryDetail.svelte
@@ -22,6 +22,10 @@
     uiState.view = 'edit';
   }
 
+  function openShared() {
+    uiState.view = 'shared';
+  }
+
   function requestDelete() {
     confirmDeleteOpen = true;
     deleteError = '';
@@ -94,7 +98,7 @@
           <Icon name="edit" size={12} />
           edit
         </Button>
-        <Button variant="ghost" size="sm">
+        <Button variant="ghost" size="sm" onclick={openShared}>
           <Icon name="share" size={12} />
           share
         </Button>

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -21,6 +21,8 @@
   let selectedTag = $state<string | null>(null);
   let searchFocused = $state(true);
   let searchFocusToken = $state(0);
+  let syncAcknowledged = $state(false);
+  let syncAckTimer: ReturnType<typeof setTimeout> | null = null;
 
   const sortedEntries = $derived([...vaultState.entries].sort(compareByUpdatedAt));
   const recentIds = $derived(new Set(sortedEntries.slice(0, 6).map((entry) => entry.id)));
@@ -62,6 +64,7 @@
 
     return () => {
       window.removeEventListener('keydown', handleKeydown);
+      clearSyncAckTimer();
     };
   });
 
@@ -89,6 +92,15 @@
     uiState.view = 'generator';
   }
 
+  function acknowledgeLocalSync() {
+    syncAcknowledged = true;
+    clearSyncAckTimer();
+    syncAckTimer = setTimeout(() => {
+      syncAcknowledged = false;
+      syncAckTimer = null;
+    }, 1400);
+  }
+
   function selectFilter(key: string) {
     selectedFilter = key as FilterKey;
   }
@@ -101,6 +113,13 @@
     selectedFilter = 'all';
     selectedTag = null;
     vaultState.searchQuery = '';
+  }
+
+  function clearSyncAckTimer() {
+    if (syncAckTimer) {
+      clearTimeout(syncAckTimer);
+      syncAckTimer = null;
+    }
   }
 
   function clearFilter() {
@@ -301,9 +320,9 @@
       new_entry
       <Kbd value="N" />
     </Button>
-    <Button variant="ghost">
+    <Button variant={syncAcknowledged ? 'vault' : 'ghost'} onclick={acknowledgeLocalSync}>
       <Icon name="refresh" size={11} sw={2} />
-      sync
+      {syncAcknowledged ? 'local_only' : 'sync'}
     </Button>
   </div>
 


### PR DESCRIPTION
## Summary

- Align the audit empty state with the current audit styling and stack its helper copy.
- Remove the stale unlocked placeholder route and fall back to the vault list for unexpected unlocked view state.
- Make detail share route to the deferred shared surface instead of rendering as a dead action.
- Make the vault toolbar sync affordance acknowledge the local-only build instead of doing nothing.

## Why

This is the first phase of the post-mockup drift pass: small, connected UX cleanup that keeps the current paper UI intact while removing stale placeholders and no-op controls.

## Validation

- pnpm typecheck
- pnpm build
- Browser preview at http://127.0.0.1:5173/ for the cold-start unlock screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vault fallback view to display entry list instead of placeholder
  * Improved audit panel empty-state messaging for clarity

* **New Features**
  * Added temporary visual feedback indicator for local sync actions

* **Style**
  * Updated empty audit panel layout and spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->