### PR TITLE
fix: decide password clearing semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # arca
 Open-source, local-first password vault with a terminal-inspired UI.
+
+## Current Entry Semantics
+
+Entries require a non-empty password. Editing an entry may omit the password to
+keep the existing value, or provide a non-empty replacement. Passwordless entries
+and password clearing are not supported in this release; see
+[#74](https://github.com/akei9/arca/issues/74).

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -172,6 +172,7 @@ pub fn create_entry(
 ) -> Result<EntryDto, ArcaError> {
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
+    validate_entry_password(&data.password)?;
 
     let mut entry = core_entry::create_entry(&data.title, &data.username, &data.password);
     entry.collection = data.collection;
@@ -193,6 +194,7 @@ pub fn update_entry(
 ) -> Result<EntryDto, ArcaError> {
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
+    validate_optional_entry_password(data.password.as_deref())?;
 
     let entry = session
         .entries
@@ -336,6 +338,24 @@ fn ensure_unlocked(session: &crate::state::SessionState) -> Result<(), ArcaError
         Ok(())
     } else {
         Err(ArcaError::locked())
+    }
+}
+
+fn validate_optional_entry_password(password: Option<&str>) -> Result<(), ArcaError> {
+    if let Some(password) = password {
+        validate_entry_password(password)?;
+    }
+
+    Ok(())
+}
+
+fn validate_entry_password(password: &str) -> Result<(), ArcaError> {
+    if password.is_empty() {
+        Err(ArcaError::invalid_input(
+            "Entry passwords cannot be empty; passwordless entries are unsupported",
+        ))
+    } else {
+        Ok(())
     }
 }
 
@@ -498,10 +518,14 @@ fn home_dir() -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{suggest_paths_for, CreateEntryDto, EntryDto, GeneratorConfigDto};
+    use super::{
+        suggest_paths_for, validate_entry_password, validate_optional_entry_password,
+        CreateEntryDto, EntryDto, GeneratorConfigDto, UpdateEntryDto,
+    };
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
     use vault_core::entry::create_entry;
+    use vault_core::entry::EntryPatch;
 
     #[test]
     fn entry_dto_masks_password_for_list_views() {
@@ -533,6 +557,34 @@ mod tests {
 
         assert!(dto.collection.is_none());
         assert!(dto.tags.is_empty());
+    }
+
+    #[test]
+    fn entry_password_policy_rejects_empty_create_passwords() {
+        let error = validate_entry_password("").expect_err("empty passwords should be rejected");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(validate_entry_password("secret").is_ok());
+    }
+
+    #[test]
+    fn update_entry_dto_omitted_password_means_unchanged() {
+        let dto: UpdateEntryDto =
+            serde_json::from_str(r#"{"title":"GitHub"}"#).expect("update dto should deserialize");
+        let patch: EntryPatch = dto.into();
+
+        assert!(patch.password.is_none());
+        assert!(validate_optional_entry_password(patch.password.as_deref()).is_ok());
+    }
+
+    #[test]
+    fn entry_password_policy_rejects_empty_update_passwords() {
+        let dto: UpdateEntryDto =
+            serde_json::from_str(r#"{"password":""}"#).expect("update dto should deserialize");
+        let error = validate_optional_entry_password(dto.password.as_deref())
+            .expect_err("empty update passwords should be rejected");
+
+        assert_eq!(error.code, "invalid_input");
     }
 
     #[test]

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -485,6 +485,8 @@
               required={passwordRequired}
               type={revealPassword ? 'text' : 'password'}
               placeholder="type or generate"
+              aria-invalid={passwordClearBlocked}
+              aria-describedby={passwordClearBlocked ? 'password-clear-hint' : undefined}
             />
             <IconButton
               label={revealPassword ? 'Hide entry password' : 'Reveal entry password'}
@@ -504,7 +506,9 @@
               <Entropy filled={entropyFilled} bits={entropyBits} strength={entropyStrength} />
             </div>
           {:else if passwordClearBlocked}
-            <div class="form-hint form-hint--warn mono">password clearing is not supported yet</div>
+            <div id="password-clear-hint" class="form-hint form-hint--warn mono">
+              passwordless entries are unsupported · type or generate a replacement
+            </div>
           {/if}
         </div>
       </div>

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -38,6 +38,10 @@ export interface CreateEntryDto {
 export interface UpdateEntryDto {
   title?: string;
   username?: string;
+  /**
+   * Omit to keep the existing password. Passwordless entries are unsupported in
+   * this release, so callers must send a non-empty replacement when changing it.
+   */
   password?: string;
   collection?: string | null;
   url?: string | null;

--- a/packages/vault-core/src/entry.rs
+++ b/packages/vault-core/src/entry.rs
@@ -162,6 +162,26 @@ mod tests {
     }
 
     #[test]
+    fn update_entry_keeps_password_when_patch_omits_password() {
+        let mut entry = create_entry("GitHub", "arca", "secret");
+        let original_updated_at = entry.updated_at.clone();
+        thread::sleep(Duration::from_millis(1));
+
+        update_entry(
+            &mut entry,
+            EntryPatch {
+                title: Some("GitHub Enterprise".to_string()),
+                password: None,
+                ..EntryPatch::default()
+            },
+        );
+
+        assert_eq!(entry.title, "GitHub Enterprise");
+        assert_eq!(entry.password, "secret");
+        assert_ne!(entry.updated_at, original_updated_at);
+    }
+
+    #[test]
     fn search_entries_matches_title_username_url_and_tags_by_relevance() {
         let title_match = create_entry("GitHub", "admin", "secret");
         let mut username_match = create_entry("Admin Console", "github_user", "secret");


### PR DESCRIPTION
## Summary

- Documents the current product decision: entries require non-empty passwords, and password clearing/passwordless entries are unsupported for this release.
- Clarifies the edit-entry UI when a user clears an existing password field.
- Enforces the decision at the Tauri command boundary by rejecting empty create/update passwords while preserving the existing omitted-password-means-unchanged behavior.
- Adds Rust tests for omitted update passwords, rejected empty passwords, and vault-core unchanged-password patch behavior.

## Why

Issue #74 called out that supporting clearing needs explicit clear-vs-unchanged semantics through frontend IPC, Tauri DTOs, and vault-core. This PR chooses the conservative v0.2 behavior: no passwordless entries yet, and no accidental empty-password semantics.

Closes #74.

## Validation

- pnpm typecheck
- pnpm build
- cargo fmt --all --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entry password handling so empty passwords are rejected when creating or updating entries.
  * Updating an entry now preserves the existing password when no new password is provided.
  * Clarified in the UI when password clearing isn’t supported, with a more specific helpful message.
  * Added clearer guidance in the app documentation about password requirements and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->