### PR TITLE
chore: refresh RustSec advisory review

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,10 @@ all-features = true
 [advisories]
 version = 2
 yanked = "warn"
+# Reviewed 2026-06-22. Next review: 2026-09-22.
+# Keep these only while current Tauri/wry/urlpattern transitive dependencies
+# report them. Remove ignores once cargo-deny no longer reports the advisory
+# without ignores, or upstream removes the affected dependency chain.
 ignore = [
   "RUSTSEC-2025-0075", # tracked in #35; Tauri -> urlpattern -> unic-char-range
   "RUSTSEC-2025-0080", # tracked in #35; Tauri -> urlpattern -> unic-common


### PR DESCRIPTION
## Summary

- Records the 2026-06-22 RustSec ignore review in deny.toml.
- Keeps all existing advisory ignores because the current no-ignore cargo-deny run still reports the same 16 tracked advisories.
- Documents that glib v0.18.5 is still present via the Tauri GTK stack, but cargo-deny 0.19.8 does not currently report GHSA-wrw7-89jp-8q8g / RUSTSEC-2024-0429 in this graph.
- Sets the next scheduled review to 2026-09-22.

## Validation

- cargo deny check advisories
- cargo deny check
- cargo deny check --config /private/tmp/arca-deny-no-ignore.toml advisories (expected failure; confirmed the tracked ignore set is still active)
- cargo tree --target all -i glib
- cargo fmt --all --check
