### PR TITLE
fix: address desktop smoke-test UX issues

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -8,7 +8,7 @@
   import { lockCurrentVault } from './lib/session';
   import { getAuditState } from './lib/stores/audit.svelte';
   import { loadRuntimeSettings, runtimeSettings } from './lib/stores/settings.svelte';
-  import { vaultState } from './lib/stores/vault.svelte';
+  import { clearEntryDraft, vaultState } from './lib/stores/vault.svelte';
   import { loadThemePreference, uiState, type ViewName } from './lib/stores/ui.svelte';
 
   const BASE_FONT_SIZE = 13;
@@ -26,14 +26,13 @@
     { key: 'vault', label: 'vault', count: vaultState.entries.length },
     { key: 'generate', label: 'generate' },
     { key: 'audit', label: 'audit', count: auditState.findingCount },
-    { key: 'shared', label: 'shared' },
     { key: 'settings', label: 'settings' },
   ]);
 
   const activeTab = $derived(
     uiState.view === 'generator'
       ? 'generate'
-      : uiState.view === 'settings' || uiState.view === 'audit' || uiState.view === 'shared'
+      : uiState.view === 'settings' || uiState.view === 'audit'
         ? uiState.view
         : 'vault',
   );
@@ -80,11 +79,45 @@
       vault: 'list',
       generate: 'generator',
       audit: 'audit',
-      shared: 'shared',
       settings: 'settings',
     };
 
     uiState.view = viewByTab[key] ?? 'list';
+  }
+
+  function handleGlobalKeydown(event: KeyboardEvent) {
+    const key = event.key.toLowerCase();
+    const modKey = isMacWindow ? event.metaKey : event.ctrlKey;
+
+    if (!vaultState.locked && modKey && event.shiftKey && key === 'l') {
+      event.preventDefault();
+      void lockFromUserAction();
+      return;
+    }
+
+    if (
+      vaultState.locked ||
+      event.repeat ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      isEditableTarget(event.target)
+    ) {
+      return;
+    }
+
+    if (key === 'n') {
+      event.preventDefault();
+      clearEntryDraft();
+      vaultState.selectedEntry = null;
+      uiState.view = 'edit';
+      return;
+    }
+
+    if (key === 'g') {
+      event.preventDefault();
+      uiState.view = 'generator';
+    }
   }
 
   function recordActivity() {
@@ -104,6 +137,17 @@
       uiState.notification = {
         kind: 'error',
         message: 'Unable to auto-lock vault',
+      };
+    }
+  }
+
+  async function lockFromUserAction() {
+    try {
+      await lockCurrentVault();
+    } catch {
+      uiState.notification = {
+        kind: 'error',
+        message: 'Unable to lock vault',
       };
     }
   }
@@ -144,6 +188,19 @@
     }
   }
 
+  function isEditableTarget(target: EventTarget | null) {
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+
+    return (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLSelectElement ||
+      target.isContentEditable
+    );
+  }
+
   onMount(() => {
     let mounted = true;
     let unlistenResize: (() => void) | null = null;
@@ -173,6 +230,7 @@
     for (const eventName of ACTIVITY_EVENTS) {
       window.addEventListener(eventName, recordActivity, { passive: true });
     }
+    window.addEventListener('keydown', handleGlobalKeydown);
 
     return () => {
       mounted = false;
@@ -182,6 +240,7 @@
       for (const eventName of ACTIVITY_EVENTS) {
         window.removeEventListener(eventName, recordActivity);
       }
+      window.removeEventListener('keydown', handleGlobalKeydown);
     };
   });
 
@@ -237,5 +296,6 @@
     pill={vaultState.locked ? lockedStatusPill : unlockedStatusPill}
     pillKind={statusKind}
     leftText={statusText}
+    connectionLabel="local"
   />
 </main>

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -89,7 +89,7 @@
     const key = event.key.toLowerCase();
     const modKey = isMacWindow ? event.metaKey : event.ctrlKey;
 
-    if (!vaultState.locked && modKey && event.shiftKey && key === 'l') {
+    if (!vaultState.locked && !event.repeat && modKey && event.shiftKey && key === 'l') {
       event.preventDefault();
       void lockFromUserAction();
       return;

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2546,6 +2546,10 @@ body {
   letter-spacing: 0.04em;
   color: var(--text-2);
 }
+.gen__ctrl-k--wide {
+  grid-column: 1 / 3;
+  min-width: 0;
+}
 .gen__ctrl-k small {
   display: block;
   font-size: calc(9px * var(--arca-font-scale, 1));
@@ -2553,17 +2557,9 @@ body {
   letter-spacing: 0.10em;
   text-transform: uppercase;
   margin-top: 3px;
-  overflow-wrap: anywhere;
-}
-.gen__hint {
-  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--text-3);
-  font-family: var(--font-mono);
-  font-size: calc(9px * var(--arca-font-scale, 1));
-  letter-spacing: 0.10em;
 }
 .gen__actions {
   display: flex;

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2555,7 +2555,6 @@ body {
   font-size: calc(9px * var(--arca-font-scale, 1));
   color: var(--text-3);
   letter-spacing: 0.10em;
-  text-transform: uppercase;
   margin-top: 3px;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -1285,8 +1285,9 @@ body {
   gap: 16px;
 }
 .unlock__mode-tabs {
-  display: inline-flex;
-  align-self: flex-start;
+  display: flex;
+  align-self: stretch;
+  width: 100%;
   gap: 4px;
   padding: 3px;
   border: 1px solid var(--rule-strong);
@@ -1294,6 +1295,7 @@ body {
   background: var(--bg-card);
 }
 .unlock__mode-tab {
+  flex: 1 1 0;
   height: 26px;
   padding: 0 12px;
   border: 1px solid transparent;

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2555,6 +2555,16 @@ body {
   margin-top: 3px;
   overflow-wrap: anywhere;
 }
+.gen__hint {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: calc(9px * var(--arca-font-scale, 1));
+  letter-spacing: 0.10em;
+}
 .gen__actions {
   display: flex;
   flex-wrap: wrap;

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -919,6 +919,15 @@ body {
 }
 .row:hover .row__action { color: var(--text-2); }
 .row__action:hover { color: var(--text); background: var(--bg-card-2); }
+.row__action:disabled {
+  color: var(--text-4);
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+.row__action:disabled:hover {
+  background: transparent;
+  color: var(--text-4);
+}
 .row__action--ok { color: var(--vault); border-color: var(--vault); background: var(--vault-soft); }
 
 .vault-list {
@@ -2471,7 +2480,8 @@ body {
   font-size: calc(14px * var(--arca-font-scale, 1));
   font-weight: 600;
   color: var(--text);
-  min-width: 48px;
+  flex: 0 0 54px;
+  min-width: 54px;
   text-align: right;
 }
 
@@ -2541,6 +2551,7 @@ body {
   letter-spacing: 0.10em;
   text-transform: uppercase;
   margin-top: 3px;
+  overflow-wrap: anywhere;
 }
 .gen__actions {
   display: flex;
@@ -2655,6 +2666,34 @@ body {
   overflow: visible;
   padding-left: 0;
 }
+.audit__group-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 4px;
+  padding: 4px 2px 0;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: calc(9px * var(--arca-font-scale, 1));
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+.audit__group-title span {
+  color: var(--text-4);
+}
+.audit-row {
+  grid-template-columns: 22px minmax(0, 1fr) auto auto;
+  align-items: center;
+}
+.audit-row__meta {
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: calc(9px * var(--arca-font-scale, 1));
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
 .row__sev {
   width: 7px;
   height: 7px;
@@ -2691,7 +2730,7 @@ body {
 .set-group__title::before { content: '#'; opacity: 0.6; }
 .set-row {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 18px;
   padding: 13px 18px;
@@ -2709,6 +2748,7 @@ body {
   color: var(--text-3);
   letter-spacing: 0.02em;
   margin-top: 3px;
+  overflow-wrap: anywhere;
 }
 .set-row__v {
   display: flex;
@@ -2721,7 +2761,9 @@ body {
   color: var(--text-2);
 }
 .set-row__v--wide {
-  min-width: min(280px, 100%);
+  width: min(360px, 42vw);
+  min-width: min(260px, 100%);
+  flex-wrap: nowrap;
 }
 .settings__actions {
   display: flex;

--- a/apps/desktop/src/lib/components/VaultShell.svelte
+++ b/apps/desktop/src/lib/components/VaultShell.svelte
@@ -4,7 +4,6 @@
   import { EntryDetail, EntryForm } from './detail';
   import { GeneratorPanel } from './generator';
   import { SettingsPanel } from './settings';
-  import { SharedPanel } from './shared';
   import { EntryList } from './vault';
 </script>
 
@@ -20,8 +19,6 @@
   <AuditPanel />
 {:else if uiState.view === 'generator'}
   <GeneratorPanel />
-{:else if uiState.view === 'shared'}
-  <SharedPanel />
 {:else}
   <EntryList />
 {/if}

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -186,17 +186,19 @@
             <span>{group.findings.length}</span>
           </div>
           {#each group.findings as finding (finding.key)}
-            <button type="button" class="row audit-row" onclick={() => openEntry(finding.entry)}>
-              <div class="row__bullet">
-                <span class={severityDotClass(finding.severity)}></span>
-              </div>
-              <div class="row__main">
-                <div class="row__title">{finding.entry.title}</div>
-                <div class="row__sub">{findingTitle(finding.title)} · {findingAction(finding.title)}</div>
-              </div>
-              <div class="audit-row__meta">{findingMeta(finding.meta)}</div>
-              <Tag variant={severityVariant(finding.severity)} value={severityLabel(finding.severity)} />
-            </button>
+            <div role="listitem">
+              <button type="button" class="row audit-row" onclick={() => openEntry(finding.entry)}>
+                <div class="row__bullet">
+                  <span class={severityDotClass(finding.severity)}></span>
+                </div>
+                <div class="row__main">
+                  <div class="row__title">{finding.entry.title}</div>
+                  <div class="row__sub">{findingTitle(finding.title)} · {findingAction(finding.title)}</div>
+                </div>
+                <div class="audit-row__meta">{findingMeta(finding.meta)}</div>
+                <Tag variant={severityVariant(finding.severity)} value={severityLabel(finding.severity)} />
+              </button>
+            </div>
           {/each}
         {/each}
       </div>

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -12,6 +12,25 @@
   const agingCount = $derived(countByTitle('stale_entry'));
   const flaggedEntryCount = $derived(new Set(auditState.findings.map((finding) => finding.entry.id)).size);
   const healthyCount = $derived(Math.max(0, vaultState.entries.length - flaggedEntryCount));
+  const findingGroups = $derived(
+    [
+      {
+        severity: 'high' as AuditSeverity,
+        label: 'critical',
+        findings: auditState.findings.filter((finding) => finding.severity === 'high'),
+      },
+      {
+        severity: 'medium' as AuditSeverity,
+        label: 'review',
+        findings: auditState.findings.filter((finding) => finding.severity === 'medium'),
+      },
+      {
+        severity: 'low' as AuditSeverity,
+        label: 'hygiene',
+        findings: auditState.findings.filter((finding) => finding.severity === 'low'),
+      },
+    ].filter((group) => group.findings.length > 0),
+  );
   const headline = $derived(
     score >= 85 ? 'vault health is strong.' : score >= 65 ? 'vault health needs review.' : 'vault health needs attention.',
   );
@@ -61,6 +80,48 @@
       case 'low':
         return 'row__sev row__sev--low';
     }
+  }
+
+  function findingTitle(title: string): string {
+    switch (title) {
+      case 'weak_password':
+        return 'weak password';
+      case 'reused_password':
+        return 'reused password';
+      case 'stale_entry':
+        return 'stale entry';
+      case 'duplicate_username':
+        return 'duplicate username';
+      case 'missing_url':
+        return 'missing URL';
+      case 'untagged':
+        return 'missing tags';
+      default:
+        return title.replaceAll('_', ' ');
+    }
+  }
+
+  function findingAction(title: string): string {
+    switch (title) {
+      case 'weak_password':
+        return 'Generate a stronger replacement and update this entry.';
+      case 'reused_password':
+        return 'Use a unique password for this account.';
+      case 'stale_entry':
+        return 'Review whether this credential still needs rotation.';
+      case 'duplicate_username':
+        return 'Confirm this login is intentional for both entries.';
+      case 'missing_url':
+        return 'Add the service URL so search and audit context stay useful.';
+      case 'untagged':
+        return 'Add tags or a collection to keep this vault navigable.';
+      default:
+        return 'Review this entry.';
+    }
+  }
+
+  function findingMeta(meta: string): string {
+    return meta.replaceAll('_', ' ');
   }
 </script>
 
@@ -119,17 +180,24 @@
 
     {#if auditState.findingCount > 0}
       <div class="entries audit__entries" role="list">
-        {#each auditState.findings as finding (finding.key)}
-          <button type="button" class="row" onclick={() => openEntry(finding.entry)}>
-            <div class="row__bullet">
-              <span class={severityDotClass(finding.severity)}></span>
-            </div>
-            <div class="row__main">
-              <div class="row__title">{finding.entry.title}</div>
-              <div class="row__sub">{finding.title.replaceAll('_', ' ')} · {finding.meta}</div>
-            </div>
-            <Tag variant={severityVariant(finding.severity)} value={severityLabel(finding.severity)} />
-          </button>
+        {#each findingGroups as group (group.severity)}
+          <div class="audit__group-title">
+            {group.label}
+            <span>{group.findings.length}</span>
+          </div>
+          {#each group.findings as finding (finding.key)}
+            <button type="button" class="row audit-row" onclick={() => openEntry(finding.entry)}>
+              <div class="row__bullet">
+                <span class={severityDotClass(finding.severity)}></span>
+              </div>
+              <div class="row__main">
+                <div class="row__title">{finding.entry.title}</div>
+                <div class="row__sub">{findingTitle(finding.title)} · {findingAction(finding.title)}</div>
+              </div>
+              <div class="audit-row__meta">{findingMeta(finding.meta)}</div>
+              <Tag variant={severityVariant(finding.severity)} value={severityLabel(finding.severity)} />
+            </button>
+          {/each}
         {/each}
       </div>
     {:else}

--- a/apps/desktop/src/lib/components/detail/EntryDetail.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryDetail.svelte
@@ -22,10 +22,6 @@
     uiState.view = 'edit';
   }
 
-  function openShared() {
-    uiState.view = 'shared';
-  }
-
   function requestDelete() {
     confirmDeleteOpen = true;
     deleteError = '';
@@ -97,10 +93,6 @@
         <Button variant="ghost" size="sm" onclick={editEntry}>
           <Icon name="edit" size={12} />
           edit
-        </Button>
-        <Button variant="ghost" size="sm" onclick={openShared}>
-          <Icon name="share" size={12} />
-          share
         </Button>
         <IconButton label={`Delete ${entry.title}`} onclick={requestDelete} disabled={deleteBusy}>
           <Icon name="trash" size={13} />

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -3,7 +3,7 @@
   import type { EntryDto } from '../../ipc';
   import { COPY_CONFIRMATION_MS, writeConfiguredClipboardText } from '../../clipboard';
   import { Icon } from '../icons';
-  import { Entropy, IconButton, Kbd } from '../primitives';
+  import { Entropy, IconButton } from '../primitives';
 
   let {
     entry,
@@ -25,7 +25,7 @@
   const url = $derived(normalizedUrl || 'not_set');
   const username = $derived(entry.username.trim() || 'not_set');
   const password = $derived(entry.password ?? '');
-  const displayedPassword = $derived(passwordRevealed ? password : passwordMask);
+  const displayedPassword = $derived(passwordRevealed ? formatInlineSecret(password) : passwordMask);
   const entropyBits = $derived(Math.max(72, Math.min(112, entry.title.length * 6 + entry.username.length * 4 + 48)));
   const entropyFilled = $derived(Math.max(10, Math.min(16, Math.round(entropyBits / 7))));
 
@@ -129,6 +129,25 @@
     );
   }
 
+  function formatInlineSecret(value: string): string {
+    return Array.from(value)
+      .map((character) => {
+        switch (character) {
+          case '\r':
+            return '\\r';
+          case '\n':
+            return '\\n';
+          case '\t':
+            return '\\t';
+          default:
+            return /[\u0000-\u001F\u007F]/.test(character)
+              ? `\\u${character.charCodeAt(0).toString(16).padStart(4, '0')}`
+              : character;
+        }
+      })
+      .join('');
+  }
+
   $effect(() => {
     entry.id;
     password;
@@ -159,7 +178,7 @@
   </div>
 
   <div class={entry.username.trim() ? 'field' : 'field field--empty'}>
-    <div class="field__k">user <Kbd value="U" /></div>
+    <div class="field__k">user</div>
     <div class="field__v">{username}</div>
     <div class="field__actions">
       <IconButton
@@ -178,7 +197,7 @@
   </div>
 
   <div class={passwordRevealed ? 'field field--focus field--secret-revealed' : 'field field--focus'}>
-    <div class="field__k">password <Kbd value="C" /><Kbd value="R" /></div>
+    <div class="field__k">password</div>
     <div class={passwordRevealed ? 'field__v field__v--secret' : 'field__v field__v--mask'}>{displayedPassword}</div>
     <div class="field__actions">
       <IconButton

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
-  import type { EntryDto } from '../../ipc';
+  import { getEntry, type EntryDto } from '../../ipc';
   import { COPY_CONFIRMATION_MS, writeConfiguredClipboardText } from '../../clipboard';
   import { Icon } from '../icons';
   import { Entropy, IconButton } from '../primitives';
@@ -18,14 +18,16 @@
 
   let copied = $state<CopyKind | null>(null);
   let passwordRevealed = $state(false);
+  let revealedPassword = $state('');
+  let passwordBusy = $state(false);
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
   let revealTimer: ReturnType<typeof setTimeout> | null = null;
 
   const normalizedUrl = $derived(entry.url?.trim() || '');
   const url = $derived(normalizedUrl || 'not_set');
   const username = $derived(entry.username.trim() || 'not_set');
-  const password = $derived(entry.password ?? '');
-  const displayedPassword = $derived(passwordRevealed ? formatInlineSecret(password) : passwordMask);
+  const activePassword = $derived(entry.password ?? revealedPassword);
+  const displayedPassword = $derived(passwordRevealed ? formatInlineSecret(activePassword) : passwordMask);
   const entropyBits = $derived(Math.max(72, Math.min(112, entry.title.length * 6 + entry.username.length * 4 + 48)));
   const entropyFilled = $derived(Math.max(10, Math.min(16, Math.round(entropyBits / 7))));
 
@@ -49,15 +51,15 @@
         return;
       }
 
-      if (event.key.toLowerCase() === 'c' && password) {
+      if (event.key.toLowerCase() === 'c') {
         event.preventDefault();
-        void copyValue('password', password);
+        void copyPassword();
         return;
       }
 
-      if (event.key.toLowerCase() === 'r' && password) {
+      if (event.key.toLowerCase() === 'r') {
         event.preventDefault();
-        togglePasswordReveal();
+        void togglePasswordReveal();
       }
     }
 
@@ -86,17 +88,52 @@
     }, COPY_CONFIRMATION_MS);
   }
 
-  function togglePasswordReveal() {
+  async function copyPassword() {
+    const password = await loadPassword();
+
     if (!password) {
       return;
     }
 
-    passwordRevealed = !passwordRevealed;
+    await copyValue('password', password);
+  }
 
+  async function togglePasswordReveal() {
     if (passwordRevealed) {
-      schedulePasswordHide();
-    } else {
+      passwordRevealed = false;
+      revealedPassword = '';
       clearRevealTimer();
+      return;
+    }
+
+    const password = await loadPassword();
+
+    if (!password) {
+      return;
+    }
+
+    revealedPassword = password;
+    passwordRevealed = true;
+    schedulePasswordHide();
+  }
+
+  async function loadPassword(): Promise<string> {
+    if (activePassword) {
+      return activePassword;
+    }
+
+    if (passwordBusy) {
+      return '';
+    }
+
+    passwordBusy = true;
+
+    try {
+      return (await getEntry(entry.id)).password ?? '';
+    } catch {
+      return '';
+    } finally {
+      passwordBusy = false;
     }
   }
 
@@ -105,6 +142,7 @@
 
     revealTimer = setTimeout(() => {
       passwordRevealed = false;
+      revealedPassword = '';
       revealTimer = null;
     }, passwordRevealMs);
   }
@@ -150,8 +188,8 @@
 
   $effect(() => {
     entry.id;
-    password;
     passwordRevealed = false;
+    revealedPassword = '';
     copied = null;
     clearRevealTimer();
   });
@@ -203,7 +241,7 @@
       <IconButton
         label={passwordRevealed ? `Hide ${entry.title} password` : `Reveal ${entry.title} password`}
         variant={passwordRevealed ? 'accent' : 'default'}
-        disabled={!password}
+        disabled={passwordBusy}
         onclick={togglePasswordReveal}
       >
         <Icon name="eye" size={13} />
@@ -211,8 +249,8 @@
       <IconButton
         variant={copied === 'password' ? 'accent' : 'default'}
         label={copied === 'password' ? 'Password copied' : `Copy ${entry.title} password`}
-        disabled={!password}
-        onclick={() => copyValue('password', password)}
+        disabled={passwordBusy}
+        onclick={copyPassword}
       >
         {#if copied === 'password'}
           ✓

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -140,7 +140,7 @@
           case '\t':
             return '\\t';
           default:
-            return /[\u0000-\u001F\u007F]/.test(character)
+            return /[\u0000-\u001F\u007F-\u009F]/.test(character)
               ? `\\u${character.charCodeAt(0).toString(16).padStart(4, '0')}`
               : character;
         }

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -283,8 +283,8 @@
       </div>
 
       <div class="gen__ctrl">
-        <div class="gen__ctrl-k">symbols<small>{symbolHint}</small></div>
-        <div></div>
+        <div class="gen__ctrl-k">symbols</div>
+        <small class="gen__hint">{symbolHint}</small>
         <Toggle
           label="Symbols"
           checked={symbols}

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -21,6 +21,7 @@
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
   let generationCounter = 0;
 
+  const symbolHint = '! @ # $ % ^ & * ( ) - _ = + [ ] { } : ; , . ?';
   const hasCharacterSet = $derived(uppercase || lowercase || digits || symbols);
   const entropyBits = $derived(generated ? Math.round(generated.entropyBits) : 0);
   const strengthLabel = $derived(strengthFromEntropy(entropyBits));
@@ -69,7 +70,7 @@
       }
 
       generated = nextGenerated;
-      isRevealed = true;
+      isRevealed = false;
     } catch (error) {
       if (currentGeneration !== generationCounter) {
         return;
@@ -282,7 +283,7 @@
       </div>
 
       <div class="gen__ctrl">
-        <div class="gen__ctrl-k">symbols<small>!@#$</small></div>
+        <div class="gen__ctrl-k">symbols<small>{symbolHint}</small></div>
         <div></div>
         <Toggle
           label="Symbols"

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -283,8 +283,8 @@
       </div>
 
       <div class="gen__ctrl">
-        <div class="gen__ctrl-k">symbols</div>
-        <small class="gen__hint">{symbolHint}</small>
+        <div class="gen__ctrl-k gen__ctrl-k--wide">symbols<small>{symbolHint}</small></div>
+        <div></div>
         <Toggle
           label="Symbols"
           checked={symbols}
@@ -296,7 +296,7 @@
       </div>
 
       <div class="gen__ctrl">
-        <div class="gen__ctrl-k">exclude ambiguous<small>0 O 1 l I</small></div>
+        <div class="gen__ctrl-k">exclude ambiguous<small>e.g. 0 O 1 l I</small></div>
         <div></div>
         <Toggle
           label="Exclude ambiguous characters"

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -284,7 +284,6 @@
 
       <div class="gen__ctrl">
         <div class="gen__ctrl-k gen__ctrl-k--wide">symbols<small>{symbolHint}</small></div>
-        <div></div>
         <Toggle
           label="Symbols"
           checked={symbols}

--- a/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
@@ -277,27 +277,8 @@
       </div>
     </div>
 
-    <div class="set-group">
-      <div class="set-group__title">vault</div>
-
-      <div class="set-row">
-        <div class="set-row__k">location<small>{vaultState.vaultPath || '~/.arca/vault.local'}</small></div>
-        <div class="set-row__v">local</div>
-      </div>
-
-      <div class="set-row">
-        <div class="set-row__k">kdf<small>argon2id · aes-512</small></div>
-        <div class="set-row__v">tuned</div>
-      </div>
-
-      <div class="set-row">
-        <div class="set-row__k">networking<small>local-first desktop build · no remote transport configured</small></div>
-        <div class="set-row__v">offline by design</div>
-      </div>
-    </div>
-
     <div class="settings__actions">
-      <Button variant="ghost" onclick={lockNow} disabled={!loaded || busy}>lock now</Button>
+      <Button variant="ghost" onclick={lockNow} disabled={!loaded || busy} aria-keyshortcuts="Meta+Shift+L Control+Shift+L">lock now</Button>
     </div>
 
     {#if errorMessage}

--- a/apps/desktop/src/lib/components/vault/EntryRow.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryRow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
-  import type { EntryDto } from '../../ipc';
+  import { getEntry, type EntryDto } from '../../ipc';
   import { COPY_CONFIRMATION_MS, writeConfiguredClipboardText } from '../../clipboard';
   import { Icon, type IconName } from '../icons';
   import { Tag } from '../primitives';
@@ -22,8 +22,8 @@
   const subtitle = $derived(entry.username || entry.url || entry.id);
   type CopyKind = 'username' | 'password';
 
-  const password = $derived(entry.password ?? '');
   let copied = $state<CopyKind | null>(null);
+  let copyBusy = $state(false);
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
 
   onDestroy(() => {
@@ -88,6 +88,34 @@
       return;
     }
 
+    scheduleCopied(kind);
+  }
+
+  async function handlePasswordCopy(event: MouseEvent) {
+    event.stopPropagation();
+
+    if (copyBusy) {
+      return;
+    }
+
+    copyBusy = true;
+
+    try {
+      const password = entry.password ?? (await getEntry(entry.id)).password ?? '';
+
+      if (!password || !(await writeConfiguredClipboardText(password))) {
+        return;
+      }
+
+      scheduleCopied('password');
+    } catch {
+      return;
+    } finally {
+      copyBusy = false;
+    }
+  }
+
+  function scheduleCopied(kind: CopyKind) {
     copied = kind;
 
     if (copyTimer) {
@@ -155,8 +183,8 @@
       class={copied === 'password' ? 'row__action row__action--ok' : 'row__action'}
       type="button"
       aria-label={copied === 'password' ? `${entry.title} password copied` : `Copy ${entry.title} password`}
-      disabled={!password}
-      onclick={(event) => handleCopy(event, 'password', password)}
+      disabled={copyBusy}
+      onclick={handlePasswordCopy}
     >
       {#if copied === 'password'}
         ✓

--- a/apps/desktop/src/lib/components/vault/EntryRow.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryRow.svelte
@@ -20,8 +20,10 @@
   const iconName = $derived(iconForEntry(entry));
   const weak = $derived(Boolean(entry.tags.find((tag: string) => normalize(tag) === 'weak')));
   const subtitle = $derived(entry.username || entry.url || entry.id);
-  const copyValue = $derived(entry.username || entry.url || entry.title);
-  let copied = $state(false);
+  type CopyKind = 'username' | 'password';
+
+  const password = $derived(entry.password ?? '');
+  let copied = $state<CopyKind | null>(null);
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
 
   onDestroy(() => {
@@ -75,27 +77,32 @@
     }
   }
 
-  async function handleCopy(event: MouseEvent) {
+  async function handleCopy(event: MouseEvent, kind: CopyKind, value: string) {
     event.stopPropagation();
 
-    if (!copyValue) {
+    if (!value) {
       return;
     }
 
-    if (!(await writeConfiguredClipboardText(copyValue))) {
+    if (!(await writeConfiguredClipboardText(value))) {
       return;
     }
 
-    copied = true;
+    copied = kind;
 
     if (copyTimer) {
       clearTimeout(copyTimer);
     }
 
     copyTimer = setTimeout(() => {
-      copied = false;
+      copied = null;
       copyTimer = null;
     }, COPY_CONFIRMATION_MS);
+  }
+
+  function openEntry(event: MouseEvent) {
+    event.stopPropagation();
+    onselect?.(entry);
   }
 </script>
 
@@ -126,21 +133,35 @@
     <button
       class="row__action"
       type="button"
-      aria-label={`Reveal ${entry.title}`}
-      onclick={(event) => event.stopPropagation()}
+      aria-label={`Open ${entry.title} details`}
+      onclick={openEntry}
     >
       <Icon name="eye" size={13} sw={1.5} />
     </button>
     <button
-      class={copied || selected ? 'row__action row__action--ok' : 'row__action'}
+      class={copied === 'username' ? 'row__action row__action--ok' : 'row__action'}
       type="button"
-      aria-label={copied ? `${entry.title} copied` : `Copy ${entry.title}`}
-      onclick={handleCopy}
+      aria-label={copied === 'username' ? `${entry.title} username copied` : `Copy ${entry.title} username`}
+      disabled={!entry.username.trim()}
+      onclick={(event) => handleCopy(event, 'username', entry.username)}
     >
-      {#if copied}
+      {#if copied === 'username'}
         ✓
       {:else}
-        <Icon name="copy" size={13} sw={1.5} />
+        <Icon name="at" size={13} sw={1.5} />
+      {/if}
+    </button>
+    <button
+      class={copied === 'password' ? 'row__action row__action--ok' : 'row__action'}
+      type="button"
+      aria-label={copied === 'password' ? `${entry.title} password copied` : `Copy ${entry.title} password`}
+      disabled={!password}
+      onclick={(event) => handleCopy(event, 'password', password)}
+    >
+      {#if copied === 'password'}
+        ✓
+      {:else}
+        <Icon name="key" size={13} sw={1.5} />
       {/if}
     </button>
   </div>

--- a/apps/desktop/src/lib/stores/ui.svelte.ts
+++ b/apps/desktop/src/lib/stores/ui.svelte.ts
@@ -5,8 +5,7 @@ export type ViewName =
   | 'edit'
   | 'settings'
   | 'generator'
-  | 'audit'
-  | 'shared';
+  | 'audit';
 export type ThemeName = 'paper' | 'ink';
 export type UnlockSurface = 'two-pane' | 'sealed';
 const THEME_STORAGE_KEY = 'arca.theme';


### PR DESCRIPTION
## Summary

- Make vault row actions explicit: open details, copy username, and copy password.
- Restore password copy/reveal from entry detail views that start from masked list entries.
- Keep generated passwords hidden by default.
- Clarify generator character hints:
  - symbols are listed under the `symbols` row
  - ambiguous examples are shown under `exclude ambiguous`
- Remove the Shared screen from primary navigation until sharing is implemented.
- Add app-wide shortcut handling for lock, new entry, and generator access.
- Replace the misleading `online` status with `local`.
- Improve audit finding grouping, action text, and list semantics.
- Tighten settings and unlock/generator layout polish found during smoke testing.

## Why

This PR addresses first desktop smoke-test findings without adding broad product scope. The goal is to make secret actions explicit, keep generated secrets masked by default, remove unavailable-feature affordances, and polish the first desktop release path.

## Security Notes

- No crypto, vault format, persistence, or Rust code changed.
- Password copy/reveal actions are explicit user actions.
- List rows still receive masked entries; password quick-copy and detail reveal/copy fetch the full entry only on explicit action.
- Clipboard writes continue to use the configured clipboard-clear helper.
- Revealed entry passwords are kept in local reveal state only and cleared on hide, timeout, or entry change.
- Control characters in displayed passwords are escaped for layout safety; copied secrets preserve the stored value.

## Follow-Up Issues

- #134 Complete keyboard-only navigation for desktop app
- #135 Review and tighten settings for first desktop release
- #136 Improve audit UX and define advanced audit checks
- #137 Add privacy-preserving website and service icons
- #138 Define long-term product roadmap after first desktop release
- #88 Define shared vault and secure sharing scope

## Validation

- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for locking, creating entries, and opening the password generator.
  * Added separate username and password copy actions with individual confirmation states.
  * Added clearer audit findings with severity groups, guidance, metadata, and counts.
  * Added supported-symbol guidance in the password generator.

* **Bug Fixes**
  * Generated passwords now remain concealed after creation.
  * Password reveal output safely displays special characters.
  * Improved disabled controls, responsive settings layouts, and long-label wrapping.

* **Updates**
  * Removed the Shared view and related navigation options.
  * Updated the connection status label to “local.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
