### PR TITLE
security: patch nanoid advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,10 @@
     "test": "pnpm --filter @arca/desktop test",
     "tauri": "pnpm --filter @arca/desktop tauri"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "pnpm": {
+    "overrides": {
+      "nanoid": "3.3.18"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nanoid: 3.3.18
+
 importers:
 
   .: {}
@@ -468,8 +471,8 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -985,7 +988,7 @@ snapshots:
 
   mri@1.2.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   obug@2.1.3: {}
 
@@ -997,7 +1000,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary
- add a root pnpm override for nanoid 3.3.18
- regenerate pnpm-lock.yaml so postcss resolves the patched nanoid version
- address Dependabot alert #10 / GHSA-2v37-7h3g-55p8

## Validation
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm why nanoid --recursive shows nanoid 3.3.18 on all paths

## Notes
This is a frontend tooling/build-chain transitive dependency through Vite/PostCSS. Arca does not use nanoid directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the `nanoid` package to version 3.3.18 for consistent package resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->