### PR TITLE
chore: define release settings baseline

### DIFF
--- a/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { Settings } from '../../ipc';
+  import {
+    RELEASE_AUTO_LOCK_OPTIONS,
+    RELEASE_CLIPBOARD_CLEAR_OPTIONS,
+    RELEASE_THEME_OPTIONS,
+    SETTINGS_LIMITS,
+  } from '../../settings';
   import { lockCurrentVault } from '../../session';
   import {
     loadRuntimeSettings,
@@ -12,38 +18,17 @@
   import { vaultState } from '../../stores/vault.svelte';
   import { Button, Segmented, Slider, Toggle } from '../primitives';
 
-  const themeOptions = [
-    { value: 'paper', label: 'paper' },
-    { value: 'ink', label: 'ink' },
-  ] as const;
-  const autoLockOptions = [
-    { value: '1', label: '1 min' },
-    { value: '5', label: '5 min' },
-    { value: '15', label: '15 min' },
-    { value: '60', label: '60 min' },
-    { value: 'never', label: 'never' },
-  ];
-  const clipboardOptions = [
-    { value: '15', label: '15s' },
-    { value: '30', label: '30s' },
-    { value: '60', label: '60s' },
-    { value: '120', label: '120s' },
-  ];
-
   let autoLockEnabled = $state(true);
-  let autoLockMinutes = $state(15);
+  let autoLockMinutes = $state<number>(SETTINGS_LIMITS.autoLockTimeoutMinutes.defaultValue);
   let clipboardEnabled = $state(true);
-  let clipboardSeconds = $state(30);
-  let fontSize = $state(13);
+  let clipboardSeconds = $state<number>(SETTINGS_LIMITS.clipboardClearSeconds.defaultValue);
+  let fontSize = $state<number>(SETTINGS_LIMITS.fontSize.defaultValue);
   let busy = $state(false);
   let loaded = $state(false);
   let errorMessage = $state('');
 
   const autoLockValue = $derived(autoLockEnabled ? String(autoLockMinutes) : 'never');
   const clipboardValue = $derived(String(clipboardSeconds));
-  const clipboardDurationOptions = $derived(
-    clipboardOptions.map((option) => ({ ...option, disabled: !clipboardEnabled })),
-  );
 
   onMount(() => {
     if (runtimeSettings.loaded) {
@@ -149,24 +134,33 @@
       const nextAutoLock = autoLockEnabled ? Number(autoLockMinutes) : null;
       if (
         nextAutoLock !== null &&
-        (!Number.isInteger(nextAutoLock) || nextAutoLock < 1 || nextAutoLock > 240)
+        (!Number.isInteger(nextAutoLock) ||
+          nextAutoLock < SETTINGS_LIMITS.autoLockTimeoutMinutes.min ||
+          nextAutoLock > SETTINGS_LIMITS.autoLockTimeoutMinutes.max)
       ) {
-        errorMessage = 'Auto-lock timeout must be an integer between 1 and 240 minutes';
+        errorMessage = `Auto-lock timeout must be an integer between ${SETTINGS_LIMITS.autoLockTimeoutMinutes.min} and ${SETTINGS_LIMITS.autoLockTimeoutMinutes.max} minutes`;
         return false;
       }
 
       const nextClipboard = clipboardEnabled ? Number(clipboardSeconds) : null;
       if (
         nextClipboard !== null &&
-        (!Number.isInteger(nextClipboard) || nextClipboard < 5 || nextClipboard > 300 || nextClipboard % 5 !== 0)
+        (!Number.isInteger(nextClipboard) ||
+          nextClipboard < SETTINGS_LIMITS.clipboardClearSeconds.min ||
+          nextClipboard > SETTINGS_LIMITS.clipboardClearSeconds.max ||
+          nextClipboard % SETTINGS_LIMITS.clipboardClearSeconds.step !== 0)
       ) {
-        errorMessage = 'Clipboard clear timeout must be a multiple of 5 between 5 and 300 seconds';
+        errorMessage = `Clipboard clear timeout must be a multiple of ${SETTINGS_LIMITS.clipboardClearSeconds.step} between ${SETTINGS_LIMITS.clipboardClearSeconds.min} and ${SETTINGS_LIMITS.clipboardClearSeconds.max} seconds`;
         return false;
       }
 
       const nextFontSize = Number(fontSize);
-      if (!Number.isInteger(nextFontSize) || nextFontSize < 11 || nextFontSize > 16) {
-        errorMessage = 'Font size must be an integer between 11 and 16';
+      if (
+        !Number.isInteger(nextFontSize) ||
+        nextFontSize < SETTINGS_LIMITS.fontSize.min ||
+        nextFontSize > SETTINGS_LIMITS.fontSize.max
+      ) {
+        errorMessage = `Font size must be an integer between ${SETTINGS_LIMITS.fontSize.min} and ${SETTINGS_LIMITS.fontSize.max}`;
         return false;
       }
 
@@ -187,10 +181,28 @@
 
   function applySettings(settings: Settings) {
     autoLockEnabled = settings.autoLockTimeoutMinutes !== null && settings.autoLockTimeoutMinutes !== undefined;
-    autoLockMinutes = normalizeInteger(settings.autoLockTimeoutMinutes ?? 15, 15, 1, 240);
+    autoLockMinutes = normalizeInteger(
+      settings.autoLockTimeoutMinutes ?? SETTINGS_LIMITS.autoLockTimeoutMinutes.defaultValue,
+      SETTINGS_LIMITS.autoLockTimeoutMinutes.defaultValue,
+      SETTINGS_LIMITS.autoLockTimeoutMinutes.min,
+      SETTINGS_LIMITS.autoLockTimeoutMinutes.max,
+      SETTINGS_LIMITS.autoLockTimeoutMinutes.step,
+    );
     clipboardEnabled = settings.clipboardClearSeconds !== null && settings.clipboardClearSeconds !== undefined;
-    clipboardSeconds = normalizeInteger(settings.clipboardClearSeconds ?? 30, 30, 5, 300, 5);
-    fontSize = normalizeInteger(settings.fontSize, 13, 11, 16);
+    clipboardSeconds = normalizeInteger(
+      settings.clipboardClearSeconds ?? SETTINGS_LIMITS.clipboardClearSeconds.defaultValue,
+      SETTINGS_LIMITS.clipboardClearSeconds.defaultValue,
+      SETTINGS_LIMITS.clipboardClearSeconds.min,
+      SETTINGS_LIMITS.clipboardClearSeconds.max,
+      SETTINGS_LIMITS.clipboardClearSeconds.step,
+    );
+    fontSize = normalizeInteger(
+      settings.fontSize,
+      SETTINGS_LIMITS.fontSize.defaultValue,
+      SETTINGS_LIMITS.fontSize.min,
+      SETTINGS_LIMITS.fontSize.max,
+      SETTINGS_LIMITS.fontSize.step,
+    );
   }
 
   function normalizeInteger(value: unknown, fallback: number, min: number, max: number, multiple = 1): number {
@@ -227,7 +239,7 @@
           <Segmented
             ariaLabel="Theme"
             value={uiState.theme}
-            options={[...themeOptions]}
+            options={[...RELEASE_THEME_OPTIONS]}
             onselect={setTheme}
           />
         </div>
@@ -239,9 +251,9 @@
           <Slider
             ariaLabel="Font size"
             value={fontSize}
-            min={11}
-            max={16}
-            step={1}
+            min={SETTINGS_LIMITS.fontSize.min}
+            max={SETTINGS_LIMITS.fontSize.max}
+            step={SETTINGS_LIMITS.fontSize.step}
             valueLabel={`${fontSize}px`}
             oninput={(next) => {
               fontSize = next;
@@ -258,7 +270,12 @@
       <div class="set-row">
         <div class="set-row__k">auto-lock<small>seal the vault after inactivity</small></div>
         <div class="set-row__v">
-          <Segmented ariaLabel="Auto-lock timeout" value={autoLockValue} options={autoLockOptions} onselect={setAutoLock} />
+          <Segmented
+            ariaLabel="Auto-lock timeout"
+            value={autoLockValue}
+            options={[...RELEASE_AUTO_LOCK_OPTIONS]}
+            onselect={setAutoLock}
+          />
         </div>
       </div>
 
@@ -266,13 +283,14 @@
         <div class="set-row__k">clear clipboard<small>wipe copied secrets on the configured timer</small></div>
         <div class="set-row__v">
           <Toggle label="Clear clipboard automatically" checked={clipboardEnabled} ontoggle={setClipboardEnabled} />
-          <Segmented
-            ariaLabel="Clipboard clear timeout"
-            value={clipboardValue}
-            options={clipboardDurationOptions}
-            onselect={clipboardEnabled ? setClipboardDuration : undefined}
-            class={clipboardEnabled ? '' : 'is-disabled'}
-          />
+          {#if clipboardEnabled}
+            <Segmented
+              ariaLabel="Clipboard clear timeout"
+              value={clipboardValue}
+              options={[...RELEASE_CLIPBOARD_CLEAR_OPTIONS]}
+              onselect={setClipboardDuration}
+            />
+          {/if}
         </div>
       </div>
     </div>

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -1,0 +1,113 @@
+import type { Settings } from './ipc';
+
+export const SETTINGS_LIMITS = {
+  autoLockTimeoutMinutes: {
+    defaultValue: 15,
+    min: 1,
+    max: 240,
+    step: 1,
+  },
+  clipboardClearSeconds: {
+    defaultValue: 30,
+    min: 5,
+    max: 300,
+    step: 5,
+  },
+  fontSize: {
+    defaultValue: 13,
+    min: 11,
+    max: 16,
+    step: 1,
+  },
+} as const;
+
+export const RELEASE_THEME_OPTIONS = [
+  { value: 'paper', label: 'paper' },
+  { value: 'ink', label: 'ink' },
+] as const;
+
+export const RELEASE_AUTO_LOCK_OPTIONS = [
+  { value: '1', label: '1 min' },
+  { value: '5', label: '5 min' },
+  { value: '15', label: '15 min' },
+  { value: '60', label: '60 min' },
+  { value: 'never', label: 'never' },
+] as const;
+
+export const RELEASE_CLIPBOARD_CLEAR_OPTIONS = [
+  { value: '15', label: '15s' },
+  { value: '30', label: '30s' },
+  { value: '60', label: '60s' },
+  { value: '120', label: '120s' },
+] as const;
+
+export const DEFAULT_SETTINGS: Settings = {
+  autoLockTimeoutMinutes: SETTINGS_LIMITS.autoLockTimeoutMinutes.defaultValue,
+  clipboardClearSeconds: SETTINGS_LIMITS.clipboardClearSeconds.defaultValue,
+  theme: 'paper',
+  fontSize: SETTINGS_LIMITS.fontSize.defaultValue,
+};
+
+export function normalizeSettings(settings: Settings): Settings {
+  return {
+    autoLockTimeoutMinutes: normalizeOptionalInteger(
+      settings.autoLockTimeoutMinutes,
+      SETTINGS_LIMITS.autoLockTimeoutMinutes.defaultValue,
+      SETTINGS_LIMITS.autoLockTimeoutMinutes.min,
+      SETTINGS_LIMITS.autoLockTimeoutMinutes.max,
+      SETTINGS_LIMITS.autoLockTimeoutMinutes.step,
+    ),
+    clipboardClearSeconds: normalizeOptionalInteger(
+      settings.clipboardClearSeconds,
+      SETTINGS_LIMITS.clipboardClearSeconds.defaultValue,
+      SETTINGS_LIMITS.clipboardClearSeconds.min,
+      SETTINGS_LIMITS.clipboardClearSeconds.max,
+      SETTINGS_LIMITS.clipboardClearSeconds.step,
+    ),
+    theme: themeForUi(uiThemeFor(settings.theme)),
+    fontSize: normalizeFontSize(settings.fontSize),
+  };
+}
+
+export function themeForUi(theme: 'paper' | 'ink'): Settings['theme'] {
+  return theme;
+}
+
+export function uiThemeFor(theme: Settings['theme']): 'paper' | 'ink' {
+  return theme === 'ink' || theme === 'amber' ? 'ink' : 'paper';
+}
+
+function normalizeOptionalInteger(
+  value: number | null | undefined,
+  fallback: number | null,
+  min: number,
+  max: number,
+  step = 1,
+): number | null {
+  if (value === null) {
+    return null;
+  }
+
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  const integer = Math.trunc(value);
+
+  if (integer < min || integer > max || integer % step !== 0) {
+    return fallback;
+  }
+
+  return integer;
+}
+
+function normalizeFontSize(value: number | null | undefined): number {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return SETTINGS_LIMITS.fontSize.defaultValue;
+  }
+
+  return Math.min(
+    SETTINGS_LIMITS.fontSize.max,
+    Math.max(SETTINGS_LIMITS.fontSize.min, Math.trunc(value)),
+  );
+}

--- a/apps/desktop/src/lib/stores/settings.svelte.test.ts
+++ b/apps/desktop/src/lib/stores/settings.svelte.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeSettings, uiThemeFor } from './settings.svelte';
+import {
+  RELEASE_AUTO_LOCK_OPTIONS,
+  RELEASE_CLIPBOARD_CLEAR_OPTIONS,
+  RELEASE_THEME_OPTIONS,
+  SETTINGS_LIMITS,
+  normalizeSettings,
+  uiThemeFor,
+} from '../settings';
 
 describe('normalizeSettings', () => {
   it('preserves disabled timers and canonicalizes legacy themes', () => {
@@ -41,5 +48,19 @@ describe('uiThemeFor', () => {
     expect(uiThemeFor('ink')).toBe('ink');
     expect(uiThemeFor('amber')).toBe('ink');
     expect(uiThemeFor('terminal')).toBe('paper');
+  });
+});
+
+describe('release settings surface', () => {
+  it('exposes only settings that are enforced at runtime for the first desktop release', () => {
+    expect(RELEASE_THEME_OPTIONS.map((option) => option.value)).toEqual(['paper', 'ink']);
+    expect(RELEASE_AUTO_LOCK_OPTIONS.map((option) => option.value)).toEqual(['1', '5', '15', '60', 'never']);
+    expect(RELEASE_CLIPBOARD_CLEAR_OPTIONS.map((option) => option.value)).toEqual(['15', '30', '60', '120']);
+    expect(SETTINGS_LIMITS.fontSize).toEqual({
+      defaultValue: 13,
+      min: 11,
+      max: 16,
+      step: 1,
+    });
   });
 });

--- a/apps/desktop/src/lib/stores/settings.svelte.ts
+++ b/apps/desktop/src/lib/stores/settings.svelte.ts
@@ -1,16 +1,11 @@
 import { getSettings, updateSettings, type Settings } from '../ipc';
-import { setThemePreference, type ThemeName } from './ui.svelte';
-
-const DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES = 15;
-const DEFAULT_CLIPBOARD_CLEAR_SECONDS = 30;
-const DEFAULT_FONT_SIZE = 13;
-
-export const DEFAULT_SETTINGS: Settings = {
-  autoLockTimeoutMinutes: DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES,
-  clipboardClearSeconds: DEFAULT_CLIPBOARD_CLEAR_SECONDS,
-  theme: 'paper',
-  fontSize: DEFAULT_FONT_SIZE,
-};
+import {
+  DEFAULT_SETTINGS,
+  normalizeSettings,
+  themeForUi,
+  uiThemeFor,
+} from '../settings';
+import { setThemePreference } from './ui.svelte';
 
 export const runtimeSettings = $state({
   current: { ...DEFAULT_SETTINGS },
@@ -38,62 +33,4 @@ export function applyRuntimeSettings(settings: Settings) {
   setThemePreference(uiThemeFor(runtimeSettings.current.theme));
 }
 
-export function themeForUi(theme: ThemeName): Settings['theme'] {
-  return theme;
-}
-
-export function uiThemeFor(theme: Settings['theme']): ThemeName {
-  return theme === 'ink' || theme === 'amber' ? 'ink' : 'paper';
-}
-
-export function normalizeSettings(settings: Settings): Settings {
-  return {
-    autoLockTimeoutMinutes: normalizeOptionalInteger(
-      settings.autoLockTimeoutMinutes,
-      DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES,
-      1,
-      240,
-    ),
-    clipboardClearSeconds: normalizeOptionalInteger(
-      settings.clipboardClearSeconds,
-      DEFAULT_CLIPBOARD_CLEAR_SECONDS,
-      5,
-      300,
-      5,
-    ),
-    theme: themeForUi(uiThemeFor(settings.theme)),
-    fontSize: normalizeFontSize(settings.fontSize),
-  };
-}
-
-function normalizeOptionalInteger(
-  value: number | null | undefined,
-  fallback: number | null,
-  min: number,
-  max: number,
-  step = 1,
-): number | null {
-  if (value === null) {
-    return null;
-  }
-
-  if (value === undefined || !Number.isFinite(value)) {
-    return fallback;
-  }
-
-  const integer = Math.trunc(value);
-
-  if (integer < min || integer > max || integer % step !== 0) {
-    return fallback;
-  }
-
-  return integer;
-}
-
-function normalizeFontSize(value: number | null | undefined): number {
-  if (value === null || value === undefined || !Number.isFinite(value)) {
-    return DEFAULT_FONT_SIZE;
-  }
-
-  return Math.min(16, Math.max(11, Math.trunc(value)));
-}
+export { DEFAULT_SETTINGS, normalizeSettings, themeForUi, uiThemeFor };


### PR DESCRIPTION
## Summary
- centralize the current settings defaults, limits, options, and normalization in `apps/desktop/src/lib/settings.ts`
- update the Settings panel to consume that shared baseline instead of duplicating values locally
- keep disabled clipboard clearing compact by hiding duration choices while the clear timer is off
- add focused tests that pin the settings currently supported by runtime behavior

## What this PR is
This is a preparatory cleanup for #135, not the full implementation of #135.

It does not add the new settings listed in #135. Instead, it defines the current release settings baseline so future settings are added deliberately only when runtime behavior exists.

Current baseline:
- theme: paper / ink
- font size: 11-16px
- auto-lock timeout, including disabled via `never`
- clipboard clear timeout, including disabled via the toggle
- lock now

Follow-up settings/features now have dedicated issues:
- #143 lock on app blur / focus loss
- #144 lock on system sleep / wake
- #145 explicit reduced-motion preference
- #146 keyboard shortcut reference, depends on #134
- #147 recent vault management
- #148 backup / export controls

## Validation
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm lint