### PR TITLE
feat: improve release audit UX

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -51,7 +51,9 @@
         ? 'VIEWING'
         : activeTab === 'generate'
           ? 'READY'
-          : 'AUTH',
+          : activeTab === 'settings'
+            ? 'CONFIG'
+            : 'AUTH',
   );
   const lockedStatusPill = $derived(unlockSurface === 'sealed' && uiState.sealedPromptOpen ? 'AUTH' : 'SEALED');
   const statusKind = $derived(
@@ -65,7 +67,9 @@
           ? 'slate'
           : activeTab === 'generate'
             ? 'vault'
-            : 'ink',
+            : activeTab === 'settings'
+              ? 'slate'
+              : 'ink',
   );
   const statusText = $derived(
     vaultState.locked
@@ -76,7 +80,9 @@
         ? `audit · ${auditState.flaggedEntryCount} flagged`
         : activeTab === 'generate'
           ? 'generator'
-          : `vault.local · ${vaultState.entries.length} entries`,
+          : activeTab === 'settings'
+            ? 'settings'
+            : `vault.local · ${vaultState.entries.length} entries`,
   );
   const fontSize = $derived(runtimeSettings.current.fontSize);
   const appStyle = $derived(

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -22,6 +22,7 @@
   let isFullscreen = $state(false);
 
   const auditState = $derived(getAuditState());
+  const auditFlaggedEntryCount = $derived(new Set(auditState.findings.map((finding) => finding.entry.id)).size);
   const tabItems = $derived<TabItem[]>([
     { key: 'vault', label: 'vault', count: vaultState.entries.length },
     { key: 'generate', label: 'generate' },
@@ -44,14 +45,16 @@
   const unlockSurface = $derived(
     uiState.unlockSurface === 'sealed' && vaultState.vaultPath ? 'sealed' : 'two-pane',
   );
-  const unlockedStatusPill = $derived(activeTab === 'vault' ? 'VIEWING' : 'AUTH');
+  const unlockedStatusPill = $derived(activeTab === 'audit' ? `${auditState.score}/100` : activeTab === 'vault' ? 'VIEWING' : 'AUTH');
   const lockedStatusPill = $derived(unlockSurface === 'sealed' && uiState.sealedPromptOpen ? 'AUTH' : 'SEALED');
   const statusKind = $derived(
     vaultState.locked
       ? unlockSurface === 'sealed' && uiState.sealedPromptOpen
         ? 'slate'
         : 'vault'
-      : activeTab === 'vault'
+      : activeTab === 'audit'
+        ? 'vault'
+        : activeTab === 'vault'
         ? 'slate'
         : 'ink',
   );
@@ -60,7 +63,9 @@
       ? unlockSurface === 'sealed' && !uiState.sealedPromptOpen
         ? 'tap, click, or press ↵ to unlock · argon2id'
         : 'awaiting_credentials · argon2id'
-      : `vault.local · ${vaultState.entries.length} entries`,
+      : activeTab === 'audit'
+        ? `audit · ${auditFlaggedEntryCount} flagged`
+        : `vault.local · ${vaultState.entries.length} entries`,
   );
   const fontSize = $derived(runtimeSettings.current.fontSize);
   const appStyle = $derived(

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -38,11 +38,7 @@
   );
 
   const chromePath = $derived(
-    vaultState.locked
-      ? 'vault.local · sealed'
-      : vaultState.selectedEntry
-        ? `vault.local / ${vaultState.selectedEntry.title}`
-        : 'vault.local',
+    chromePathFor(uiState.view, vaultState.locked, vaultState.selectedEntry?.title),
   );
 
   const unlockSurface = $derived(
@@ -83,6 +79,30 @@
     };
 
     uiState.view = viewByTab[key] ?? 'list';
+  }
+
+  function chromePathFor(view: ViewName, locked: boolean, entryTitle: string | undefined): string {
+    if (locked) {
+      return 'vault.local · sealed';
+    }
+
+    if (view === 'detail' && entryTitle) {
+      return `vault.local / ${entryTitle}`;
+    }
+
+    if (view === 'edit') {
+      return entryTitle ? `vault.local / ${entryTitle} / edit` : 'vault.local / new_entry';
+    }
+
+    if (view === 'generator') {
+      return 'vault.local / generate';
+    }
+
+    if (view === 'audit' || view === 'settings') {
+      return `vault.local / ${view}`;
+    }
+
+    return 'vault.local';
   }
 
   function handleGlobalKeydown(event: KeyboardEvent) {

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -46,7 +46,7 @@
   );
   const unlockedStatusPill = $derived(
     activeTab === 'audit'
-      ? `${auditState.healthyCount}/${vaultState.entries.length}`
+      ? `${auditState.healthyCount}/${auditState.entryCount}`
       : activeTab === 'vault'
         ? 'VIEWING'
         : 'AUTH',

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -49,7 +49,9 @@
       ? `${auditState.healthyCount}/${auditState.entryCount}`
       : activeTab === 'vault'
         ? 'VIEWING'
-        : 'AUTH',
+        : activeTab === 'generate'
+          ? 'READY'
+          : 'AUTH',
   );
   const lockedStatusPill = $derived(unlockSurface === 'sealed' && uiState.sealedPromptOpen ? 'AUTH' : 'SEALED');
   const statusKind = $derived(
@@ -60,8 +62,10 @@
       : activeTab === 'audit'
         ? 'vault'
         : activeTab === 'vault'
-        ? 'slate'
-        : 'ink',
+          ? 'slate'
+          : activeTab === 'generate'
+            ? 'vault'
+            : 'ink',
   );
   const statusText = $derived(
     vaultState.locked
@@ -70,7 +74,9 @@
         : 'awaiting_credentials · argon2id'
       : activeTab === 'audit'
         ? `audit · ${auditState.flaggedEntryCount} flagged`
-        : `vault.local · ${vaultState.entries.length} entries`,
+        : activeTab === 'generate'
+          ? 'generator'
+          : `vault.local · ${vaultState.entries.length} entries`,
   );
   const fontSize = $derived(runtimeSettings.current.fontSize);
   const appStyle = $derived(

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -22,7 +22,6 @@
   let isFullscreen = $state(false);
 
   const auditState = $derived(getAuditState());
-  const auditFlaggedEntryCount = $derived(new Set(auditState.findings.map((finding) => finding.entry.id)).size);
   const tabItems = $derived<TabItem[]>([
     { key: 'vault', label: 'vault', count: vaultState.entries.length },
     { key: 'generate', label: 'generate' },
@@ -45,7 +44,13 @@
   const unlockSurface = $derived(
     uiState.unlockSurface === 'sealed' && vaultState.vaultPath ? 'sealed' : 'two-pane',
   );
-  const unlockedStatusPill = $derived(activeTab === 'audit' ? `${auditState.score}/100` : activeTab === 'vault' ? 'VIEWING' : 'AUTH');
+  const unlockedStatusPill = $derived(
+    activeTab === 'audit'
+      ? `${auditState.healthyCount}/${vaultState.entries.length}`
+      : activeTab === 'vault'
+        ? 'VIEWING'
+        : 'AUTH',
+  );
   const lockedStatusPill = $derived(unlockSurface === 'sealed' && uiState.sealedPromptOpen ? 'AUTH' : 'SEALED');
   const statusKind = $derived(
     vaultState.locked
@@ -64,7 +69,7 @@
         ? 'tap, click, or press ↵ to unlock · argon2id'
         : 'awaiting_credentials · argon2id'
       : activeTab === 'audit'
-        ? `audit · ${auditFlaggedEntryCount} flagged`
+        ? `audit · ${auditState.flaggedEntryCount} flagged`
         : `vault.local · ${vaultState.entries.length} entries`,
   );
   const fontSize = $derived(runtimeSettings.current.fontSize);

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2637,9 +2637,9 @@ body {
   border-radius: 8px;
   padding: 14px 16px;
 }
-.audit__stat--high { border-color: rgba(200, 85, 61, 0.50); }
-.audit__stat--review { border-color: rgba(201, 154, 82, 0.46); }
-.audit__stat--hygiene { border-color: rgba(138, 133, 122, 0.36); }
+.audit__stat--weak { border-color: rgba(200, 85, 61, 0.52); }
+.audit__stat--reused { border-color: rgba(215, 131, 63, 0.50); }
+.audit__stat--aging { border-color: var(--rule); }
 .audit__stat--healthy { border-color: rgba(74, 93, 62, 0.40); }
 .audit__stat-n {
   font-family: var(--font-display);
@@ -2649,9 +2649,9 @@ body {
   line-height: 1;
   color: var(--text);
 }
-.audit__stat--high .audit__stat-n { color: var(--accent); }
-.audit__stat--review .audit__stat-n { color: #C99A52; }
-.audit__stat--hygiene .audit__stat-n { color: var(--text-2); }
+.audit__stat--weak .audit__stat-n { color: var(--accent); }
+.audit__stat--reused .audit__stat-n { color: #D7833F; }
+.audit__stat--aging .audit__stat-n { color: var(--text); }
 .audit__stat--healthy .audit__stat-n { color: var(--vault); }
 .audit__stat-k {
   font-family: var(--font-mono);
@@ -2689,25 +2689,38 @@ body {
   background: var(--bg-card);
   border-color: var(--rule);
 }
+.audit-row .row__main {
+  display: grid;
+  justify-items: start;
+  min-width: 0;
+}
+.audit-row .row__sub {
+  text-align: left;
+}
 .row__sev {
   width: 7px;
   height: 7px;
   border-radius: 50%;
   flex: 0 0 auto;
 }
-.row__sev--high { background: var(--accent); }
-.row__sev--medium { background: #C99A52; }
-.row__sev--low { background: var(--text-4); }
-.audit-tag--high {
+.row__sev--weak { background: var(--accent); }
+.row__sev--reused { background: #D7833F; }
+.row__sev--aging { background: var(--text-2); }
+.row__sev--review { background: var(--text-4); }
+.audit-tag--weak {
   background: transparent;
   border-color: var(--accent);
   color: var(--accent);
 }
-.audit-tag--medium {
+.audit-tag--reused {
+  background: rgba(215, 131, 63, 0.14);
+  color: #B8692E;
+}
+.audit-tag--aging {
   background: rgba(201, 154, 82, 0.16);
   color: #8D6630;
 }
-.audit-tag--low {
+.audit-tag--review {
   background: var(--slate-soft);
   color: var(--text-2);
 }

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2570,7 +2570,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 18px;
-  max-width: 960px;
+  width: 100%;
 }
 .audit__score {
   display: grid;

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -966,6 +966,14 @@ body {
   background: var(--bg-card);
   color: var(--text);
 }
+.tag-filter__count {
+  color: var(--text-4);
+}
+.tag-filter:hover .tag-filter__count,
+.tag-filter--active .tag-filter__count {
+  color: currentColor;
+  opacity: 0.65;
+}
 .tag-filter--active {
   background: var(--accent-soft);
   color: var(--accent);

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2624,7 +2624,7 @@ body {
   font-weight: 700;
   font-size: calc(30px * var(--arca-font-scale, 1));
   letter-spacing: -0.02em;
-  color: var(--text);
+  color: var(--audit-score-color, var(--text));
 }
 .audit__ring-num small {
   font-size: calc(13px * var(--arca-font-scale, 1));

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2637,9 +2637,9 @@ body {
   border-radius: 8px;
   padding: 14px 16px;
 }
-.audit__stat--weak { border-color: rgba(200, 85, 61, 0.50); }
-.audit__stat--reused { border-color: rgba(215, 131, 63, 0.46); }
-.audit__stat--aging { border-color: rgba(201, 154, 82, 0.44); }
+.audit__stat--high { border-color: rgba(200, 85, 61, 0.50); }
+.audit__stat--review { border-color: rgba(201, 154, 82, 0.46); }
+.audit__stat--hygiene { border-color: rgba(138, 133, 122, 0.36); }
 .audit__stat--healthy { border-color: rgba(74, 93, 62, 0.40); }
 .audit__stat-n {
   font-family: var(--font-display);
@@ -2649,9 +2649,9 @@ body {
   line-height: 1;
   color: var(--text);
 }
-.audit__stat--weak .audit__stat-n { color: var(--accent); }
-.audit__stat--reused .audit__stat-n { color: #D7833F; }
-.audit__stat--aging .audit__stat-n { color: #C99A52; }
+.audit__stat--high .audit__stat-n { color: var(--accent); }
+.audit__stat--review .audit__stat-n { color: #C99A52; }
+.audit__stat--hygiene .audit__stat-n { color: var(--text-2); }
 .audit__stat--healthy .audit__stat-n { color: var(--vault); }
 .audit__stat-k {
   font-family: var(--font-mono);
@@ -2695,24 +2695,19 @@ body {
   border-radius: 50%;
   flex: 0 0 auto;
 }
-.row__sev--weak { background: var(--accent); }
-.row__sev--reused { background: #D7833F; }
-.row__sev--aging { background: #C99A52; }
-.row__sev--review { background: var(--text-4); }
-.audit-tag--weak {
+.row__sev--high { background: var(--accent); }
+.row__sev--medium { background: #C99A52; }
+.row__sev--low { background: var(--text-4); }
+.audit-tag--high {
   background: transparent;
   border-color: var(--accent);
   color: var(--accent);
 }
-.audit-tag--reused {
-  background: rgba(215, 131, 63, 0.14);
-  color: #B8692E;
-}
-.audit-tag--aging {
+.audit-tag--medium {
   background: rgba(201, 154, 82, 0.16);
   color: #8D6630;
 }
-.audit-tag--review {
+.audit-tag--low {
   background: var(--slate-soft);
   color: var(--text-2);
 }

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2637,6 +2637,10 @@ body {
   border-radius: 8px;
   padding: 14px 16px;
 }
+.audit__stat--weak { border-color: rgba(200, 85, 61, 0.50); }
+.audit__stat--reused { border-color: rgba(215, 131, 63, 0.46); }
+.audit__stat--aging { border-color: rgba(201, 154, 82, 0.44); }
+.audit__stat--healthy { border-color: rgba(74, 93, 62, 0.40); }
 .audit__stat-n {
   font-family: var(--font-display);
   font-weight: 700;
@@ -2645,8 +2649,10 @@ body {
   line-height: 1;
   color: var(--text);
 }
-.audit__stat-n--warn { color: var(--accent); }
-.audit__stat-n--ok { color: var(--vault); }
+.audit__stat--weak .audit__stat-n { color: var(--accent); }
+.audit__stat--reused .audit__stat-n { color: #D7833F; }
+.audit__stat--aging .audit__stat-n { color: #C99A52; }
+.audit__stat--healthy .audit__stat-n { color: var(--vault); }
 .audit__stat-k {
   font-family: var(--font-mono);
   font-size: calc(9px * var(--arca-font-scale, 1));
@@ -2676,36 +2682,12 @@ body {
 .audit__entries > [role='listitem'] {
   width: 100%;
 }
-.audit__group-title {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-top: 4px;
-  padding: 4px 2px 0;
-  color: var(--text-3);
-  font-family: var(--font-mono);
-  font-size: calc(9px * var(--arca-font-scale, 1));
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-}
-.audit__group-title span {
-  color: var(--text-4);
-}
 .audit-row {
-  grid-template-columns: 22px minmax(0, 1fr) auto auto;
+  grid-template-columns: 22px minmax(0, 1fr) auto;
   align-items: center;
   width: 100%;
   background: var(--bg-card);
   border-color: var(--rule);
-}
-.audit-row__meta {
-  color: var(--text-3);
-  font-family: var(--font-mono);
-  font-size: calc(9px * var(--arca-font-scale, 1));
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  white-space: nowrap;
 }
 .row__sev {
   width: 7px;
@@ -2713,9 +2695,27 @@ body {
   border-radius: 50%;
   flex: 0 0 auto;
 }
-.row__sev--high { background: var(--accent); }
-.row__sev--med { background: #C99A52; }
-.row__sev--low { background: var(--text-4); }
+.row__sev--weak { background: var(--accent); }
+.row__sev--reused { background: #D7833F; }
+.row__sev--aging { background: #C99A52; }
+.row__sev--review { background: var(--text-4); }
+.audit-tag--weak {
+  background: transparent;
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.audit-tag--reused {
+  background: rgba(215, 131, 63, 0.14);
+  color: #B8692E;
+}
+.audit-tag--aging {
+  background: rgba(201, 154, 82, 0.16);
+  color: #8D6630;
+}
+.audit-tag--review {
+  background: var(--slate-soft);
+  color: var(--text-2);
+}
 
 .settings {
   max-width: 760px;

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2673,6 +2673,9 @@ body {
   overflow: visible;
   padding-left: 0;
 }
+.audit__entries > [role='listitem'] {
+  width: 100%;
+}
 .audit__group-title {
   display: flex;
   align-items: center;
@@ -2692,6 +2695,9 @@ body {
 .audit-row {
   grid-template-columns: 22px minmax(0, 1fr) auto auto;
   align-items: center;
+  width: 100%;
+  background: var(--bg-card);
+  border-color: var(--rule);
 }
 .audit-row__meta {
   color: var(--text-3);

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2686,6 +2686,11 @@ body {
   grid-template-columns: 22px minmax(0, 1fr) auto;
   align-items: center;
   width: 100%;
+  background: transparent;
+  border-color: transparent;
+}
+.audit-row:hover,
+.audit-row:focus-visible {
   background: var(--bg-card);
   border-color: var(--rule);
 }

--- a/apps/desktop/src/lib/audit.test.ts
+++ b/apps/desktop/src/lib/audit.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it, vi } from 'vitest';
-import { buildAuditFindings, scoreAudit } from './audit';
+import { AUDIT_FINDING_COPY, buildAuditFindings, scoreAudit } from './audit';
 import type { EntryDto } from './ipc';
 
 const millisecondsPerDay = 1000 * 60 * 60 * 24;
@@ -57,11 +57,39 @@ describe('buildAuditFindings', () => {
       'reused_password',
       'reused_password',
       'weak_password',
+      'duplicate_url',
+      'duplicate_url',
       'duplicate_username',
       'duplicate_username',
       'stale_entry',
       'missing_url',
       'untagged',
+    ]);
+  });
+
+  it('detects local URL and organization hygiene findings', () => {
+    const findings = buildAuditFindings([
+      entry({
+        id: 'http-a',
+        title: 'HTTP A',
+        username: 'http-a-user',
+        url: 'http://example.test/login?session=ignored',
+        collection: null,
+      }),
+      entry({
+        id: 'http-b',
+        title: 'HTTP B',
+        username: 'http-b-user',
+        url: 'http://example.test/login',
+      }),
+    ]);
+
+    expect(findings.map((finding) => finding.title)).toEqual([
+      'duplicate_url',
+      'duplicate_url',
+      'insecure_url',
+      'insecure_url',
+      'missing_collection',
     ]);
   });
 
@@ -76,6 +104,8 @@ describe('buildAuditFindings', () => {
       expect(finding.key).not.toContain(secret);
       expect(finding.title).not.toContain(secret);
       expect(finding.meta).not.toContain(secret);
+      expect(AUDIT_FINDING_COPY[finding.title].label).not.toContain(secret);
+      expect(AUDIT_FINDING_COPY[finding.title].action).not.toContain(secret);
     }
   });
 });

--- a/apps/desktop/src/lib/audit.test.ts
+++ b/apps/desktop/src/lib/audit.test.ts
@@ -108,6 +108,19 @@ describe('buildAuditFindings', () => {
       expect(AUDIT_FINDING_COPY[finding.title].action).not.toContain(secret);
     }
   });
+
+  it('treats reused passwords as high-risk findings', () => {
+    const secret = 'shared-password-with-length';
+    const findings = buildAuditFindings([
+      entry({ id: 'first', password: secret }),
+      entry({ id: 'second', password: secret }),
+    ]);
+
+    expect(findings.filter((finding) => finding.title === 'reused_password')).toEqual([
+      expect.objectContaining({ severity: 'high', meta: 'loaded_secret' }),
+      expect.objectContaining({ severity: 'high', meta: 'loaded_secret' }),
+    ]);
+  });
 });
 
 describe('scoreAudit', () => {

--- a/apps/desktop/src/lib/audit.test.ts
+++ b/apps/desktop/src/lib/audit.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it, vi } from 'vitest';
-import { AUDIT_FINDING_COPY, buildAuditFindings, scoreAudit } from './audit';
+import { AUDIT_FINDING_COPY, buildAuditFindings, filterAuditableEntries, scoreAudit } from './audit';
 import type { EntryDto } from './ipc';
 
 const millisecondsPerDay = 1000 * 60 * 60 * 24;
@@ -120,6 +120,28 @@ describe('buildAuditFindings', () => {
       expect.objectContaining({ severity: 'high', meta: 'loaded_secret' }),
       expect.objectContaining({ severity: 'high', meta: 'loaded_secret' }),
     ]);
+  });
+
+  it('excludes archived entries from audit scope', () => {
+    const entries = [
+      entry({ id: 'active', collection: 'work' }),
+      entry({ id: 'archived', collection: 'archive' }),
+      entry({ id: 'archived-spaced', collection: ' Archive ' }),
+    ];
+
+    expect(filterAuditableEntries(entries).map((auditedEntry) => auditedEntry.id)).toEqual(['active']);
+  });
+
+  it('ignores archived passwords when detecting reused active passwords', () => {
+    const secret = 'shared-password-with-length';
+    const findings = buildAuditFindings(
+      filterAuditableEntries([
+        entry({ id: 'active', password: secret }),
+        entry({ id: 'archived', password: secret, collection: 'archive' }),
+      ]),
+    );
+
+    expect(findings.some((finding) => finding.title === 'reused_password')).toBe(false);
   });
 });
 

--- a/apps/desktop/src/lib/audit.test.ts
+++ b/apps/desktop/src/lib/audit.test.ts
@@ -111,13 +111,12 @@ describe('buildAuditFindings', () => {
 });
 
 describe('scoreAudit', () => {
-  it('returns zero for empty vaults and clamps poor scores at zero', () => {
-    expect(scoreAudit(0, 0, 0)).toBe('0');
-    expect(scoreAudit(3, 50, 10)).toBe('0');
+  it('returns zero for empty vaults', () => {
+    expect(scoreAudit(0, 0)).toBe('0');
   });
 
-  it('penalizes high severity findings more heavily', () => {
-    expect(scoreAudit(5, 2, 0)).toBe('92');
-    expect(scoreAudit(5, 2, 2)).toBe('56');
+  it('scores the healthy entry ratio as a rounded percentage', () => {
+    expect(scoreAudit(6, 1)).toBe('17');
+    expect(scoreAudit(100, 82)).toBe('82');
   });
 });

--- a/apps/desktop/src/lib/audit.ts
+++ b/apps/desktop/src/lib/audit.ts
@@ -113,12 +113,20 @@ export function buildAuditFindings(entries: EntryDto[]): AuditFinding[] {
   return results.sort((a, b) => severityRank(a.severity) - severityRank(b.severity) || a.title.localeCompare(b.title));
 }
 
+export function filterAuditableEntries(entries: EntryDto[]): EntryDto[] {
+  return entries.filter(isAuditableEntry);
+}
+
 export function scoreAudit(entryCount: number, healthyEntryCount: number): string {
   if (entryCount === 0) {
     return '0';
   }
 
   return Math.round((Math.max(0, healthyEntryCount) / entryCount) * 100).toString();
+}
+
+function isAuditableEntry(entry: EntryDto): boolean {
+  return normalize(entry.collection ?? '') !== 'archive';
 }
 
 function finding(

--- a/apps/desktop/src/lib/audit.ts
+++ b/apps/desktop/src/lib/audit.ts
@@ -113,12 +113,12 @@ export function buildAuditFindings(entries: EntryDto[]): AuditFinding[] {
   return results.sort((a, b) => severityRank(a.severity) - severityRank(b.severity) || a.title.localeCompare(b.title));
 }
 
-export function scoreAudit(entryCount: number, findingCount: number, high: number): string {
+export function scoreAudit(entryCount: number, healthyEntryCount: number): string {
   if (entryCount === 0) {
     return '0';
   }
 
-  return Math.max(0, 100 - high * 18 - findingCount * 4).toString();
+  return Math.round((Math.max(0, healthyEntryCount) / entryCount) * 100).toString();
 }
 
 function finding(

--- a/apps/desktop/src/lib/audit.ts
+++ b/apps/desktop/src/lib/audit.ts
@@ -1,18 +1,73 @@
 import type { EntryDto } from './ipc';
 
 export type AuditSeverity = 'high' | 'medium' | 'low';
+export type AuditFindingTitle =
+  | 'weak_password'
+  | 'reused_password'
+  | 'insecure_url'
+  | 'duplicate_url'
+  | 'duplicate_username'
+  | 'stale_entry'
+  | 'missing_url'
+  | 'missing_collection'
+  | 'untagged';
 
 export interface AuditFinding {
   key: string;
   severity: AuditSeverity;
-  title: string;
+  title: AuditFindingTitle;
   entry: EntryDto;
   meta: string;
 }
 
+export interface AuditFindingCopy {
+  label: string;
+  action: string;
+}
+
+export const AUDIT_FINDING_COPY: Record<AuditFindingTitle, AuditFindingCopy> = {
+  weak_password: {
+    label: 'weak password',
+    action: 'Generate a stronger replacement and update this entry.',
+  },
+  reused_password: {
+    label: 'reused password',
+    action: 'Use a unique password for this account.',
+  },
+  insecure_url: {
+    label: 'HTTP URL',
+    action: 'Switch this entry to HTTPS when the service supports it.',
+  },
+  duplicate_url: {
+    label: 'duplicate URL',
+    action: 'Confirm these entries are intentionally separate accounts.',
+  },
+  duplicate_username: {
+    label: 'duplicate username',
+    action: 'Confirm this login is intentional for both entries.',
+  },
+  stale_entry: {
+    label: 'stale entry',
+    action: 'Review whether this credential still needs rotation.',
+  },
+  missing_url: {
+    label: 'missing URL',
+    action: 'Add the service URL so search and audit context stay useful.',
+  },
+  missing_collection: {
+    label: 'missing collection',
+    action: 'Assign a collection so this entry has a clear home.',
+  },
+  untagged: {
+    label: 'missing tags',
+    action: 'Add tags to make this entry easier to find later.',
+  },
+};
+
 export function buildAuditFindings(entries: EntryDto[]): AuditFinding[] {
   const results: AuditFinding[] = [];
   const usernames = groupBy(entries, (entry) => normalize(entry.username));
+  const urls = groupBy(entries, (entry) => normalizeUrl(entry.url));
   const loadedPasswords = groupBy(
     entries.filter(hasLoadedPassword),
     (entry) => entry.password,
@@ -22,6 +77,16 @@ export function buildAuditFindings(entries: EntryDto[]): AuditFinding[] {
   for (const entry of entries) {
     if (!entry.url) {
       results.push(finding('missing-url', 'low', 'missing_url', entry, 'metadata'));
+    } else if (isHttpUrl(entry.url)) {
+      results.push(finding('insecure-url', 'medium', 'insecure_url', entry, 'http'));
+    }
+
+    if (entry.url && (urls.get(normalizeUrl(entry.url))?.length ?? 0) > 1) {
+      results.push(finding('duplicate-url', 'medium', 'duplicate_url', entry, 'duplicate_detected'));
+    }
+
+    if (!entry.collection?.trim()) {
+      results.push(finding('missing-collection', 'low', 'missing_collection', entry, 'metadata'));
     }
 
     if (entry.tags.length === 0) {
@@ -59,7 +124,7 @@ export function scoreAudit(entryCount: number, findingCount: number, high: numbe
 function finding(
   type: string,
   severity: AuditSeverity,
-  title: string,
+  title: AuditFindingTitle,
   entry: EntryDto,
   meta: string,
 ): AuditFinding {
@@ -114,6 +179,29 @@ function modified(entry: EntryDto): string {
 
 function normalize(value: string): string {
   return value.trim().toLowerCase();
+}
+
+function normalizeUrl(value: string | null | undefined): string {
+  if (!value) {
+    return '';
+  }
+
+  try {
+    const url = new URL(value);
+    url.hash = '';
+    url.search = '';
+    return `${url.protocol}//${url.host}${url.pathname.replace(/\/$/, '')}`.toLowerCase();
+  } catch {
+    return normalize(value).replace(/\/$/, '');
+  }
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'http:';
+  } catch {
+    return normalize(value).startsWith('http://');
+  }
 }
 
 function hasLoadedPassword(entry: EntryDto): entry is EntryDto & { password: string } {

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -13,6 +13,7 @@
   const reusedCount = $derived(countByTitle('reused_password'));
   const agingCount = $derived(countByTitle('stale_entry'));
   const reviewCount = $derived(Math.max(0, auditState.findingCount - weakCount - agingCount));
+  const scoreColor = $derived(score >= 85 ? 'var(--vault)' : score >= 65 ? '#D7833F' : 'var(--accent)');
   const attentionSummary = $derived.by(() => {
     const parts = [
       weakCount > 0 ? `${weakCount} weak` : null,
@@ -102,7 +103,7 @@
     <div class="audit__score">
       <div
         class="audit__ring"
-        style={`background: conic-gradient(var(--vault) 0% ${score}%, var(--bg-inset) ${score}% 100%);`}
+        style={`--audit-score-color: ${scoreColor}; background: conic-gradient(var(--audit-score-color) 0% ${score}%, var(--bg-inset) ${score}% 100%);`}
         aria-hidden="true"
       >
         <div class="audit__ring-core">

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { AuditSeverity } from '../../audit';
+  import { AUDIT_FINDING_COPY, type AuditSeverity } from '../../audit';
   import { getAuditState } from '../../stores/audit.svelte';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
@@ -7,9 +7,9 @@
 
   const auditState = $derived(getAuditState());
   const score = $derived(Number(auditState.score));
-  const weakCount = $derived(countByTitle('weak_password'));
-  const reusedCount = $derived(countByTitle('reused_password'));
-  const agingCount = $derived(countByTitle('stale_entry'));
+  const highCount = $derived(countBySeverity('high'));
+  const mediumCount = $derived(countBySeverity('medium'));
+  const lowCount = $derived(countBySeverity('low'));
   const flaggedEntryCount = $derived(new Set(auditState.findings.map((finding) => finding.entry.id)).size);
   const healthyCount = $derived(Math.max(0, vaultState.entries.length - flaggedEntryCount));
   const findingGroups = $derived(
@@ -37,7 +37,7 @@
   const summary = $derived(
     vaultState.entries.length === 0
       ? 'Add entries to start measuring password health and vault hygiene.'
-      : `${healthyCount} of ${vaultState.entries.length} entries are healthy. ${auditState.findingCount} findings need attention — ${weakCount} weak, ${reusedCount} reused, ${agingCount} aging past six months.`,
+      : `${healthyCount} of ${vaultState.entries.length} entries are clear. ${auditState.findingCount} findings need attention — ${highCount} high, ${mediumCount} review, ${lowCount} hygiene.`,
   );
 
   function openEntry(entry: (typeof vaultState.entries)[number]) {
@@ -45,8 +45,8 @@
     uiState.view = 'detail';
   }
 
-  function countByTitle(title: string): number {
-    return auditState.findings.filter((finding) => finding.title === title).length;
+  function countBySeverity(severity: AuditSeverity): number {
+    return auditState.findings.filter((finding) => finding.severity === severity).length;
   }
 
   function severityVariant(severity: AuditSeverity): 'out' | 'vault' | 'slate' {
@@ -82,42 +82,12 @@
     }
   }
 
-  function findingTitle(title: string): string {
-    switch (title) {
-      case 'weak_password':
-        return 'weak password';
-      case 'reused_password':
-        return 'reused password';
-      case 'stale_entry':
-        return 'stale entry';
-      case 'duplicate_username':
-        return 'duplicate username';
-      case 'missing_url':
-        return 'missing URL';
-      case 'untagged':
-        return 'missing tags';
-      default:
-        return title.replaceAll('_', ' ');
-    }
+  function findingTitle(title: keyof typeof AUDIT_FINDING_COPY): string {
+    return AUDIT_FINDING_COPY[title].label;
   }
 
-  function findingAction(title: string): string {
-    switch (title) {
-      case 'weak_password':
-        return 'Generate a stronger replacement and update this entry.';
-      case 'reused_password':
-        return 'Use a unique password for this account.';
-      case 'stale_entry':
-        return 'Review whether this credential still needs rotation.';
-      case 'duplicate_username':
-        return 'Confirm this login is intentional for both entries.';
-      case 'missing_url':
-        return 'Add the service URL so search and audit context stay useful.';
-      case 'untagged':
-        return 'Add tags or a collection to keep this vault navigable.';
-      default:
-        return 'Review this entry.';
-    }
+  function findingAction(title: keyof typeof AUDIT_FINDING_COPY): string {
+    return AUDIT_FINDING_COPY[title].action;
   }
 
   function findingMeta(meta: string): string {
@@ -132,6 +102,7 @@
     <div class="page__meta mono">
       <span>entries · <b>{vaultState.entries.length}</b></span>
       <span>findings · <b>{auditState.findingCount}</b></span>
+      <span>scope · <b>local</b></span>
     </div>
   </div>
 
@@ -155,16 +126,16 @@
 
     <div class="audit__stats">
       <div class="audit__stat">
-        <div class="audit__stat-n audit__stat-n--warn">{weakCount}</div>
-        <div class="audit__stat-k">weak</div>
+        <div class="audit__stat-n audit__stat-n--warn">{highCount}</div>
+        <div class="audit__stat-k">high</div>
       </div>
       <div class="audit__stat">
-        <div class="audit__stat-n audit__stat-n--warn">{reusedCount}</div>
-        <div class="audit__stat-k">reused</div>
+        <div class="audit__stat-n audit__stat-n--warn">{mediumCount}</div>
+        <div class="audit__stat-k">review</div>
       </div>
       <div class="audit__stat">
-        <div class="audit__stat-n">{agingCount}</div>
-        <div class="audit__stat-k">aging</div>
+        <div class="audit__stat-n">{lowCount}</div>
+        <div class="audit__stat-k">hygiene</div>
       </div>
       <div class="audit__stat">
         <div class="audit__stat-n audit__stat-n--ok">{healthyCount}</div>

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -1,43 +1,37 @@
 <script lang="ts">
-  import { AUDIT_FINDING_COPY, type AuditSeverity } from '../../audit';
+  import { AUDIT_FINDING_COPY, type AuditFinding, type AuditFindingTitle, type AuditSeverity } from '../../audit';
   import { getAuditState } from '../../stores/audit.svelte';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
   import { Tag } from '../primitives';
 
+  type AuditBucket = 'weak' | 'reused' | 'aging' | 'review';
+
   const auditState = $derived(getAuditState());
   const score = $derived(Number(auditState.score));
-  const highCount = $derived(countBySeverity('high'));
-  const mediumCount = $derived(countBySeverity('medium'));
-  const lowCount = $derived(countBySeverity('low'));
+  const weakCount = $derived(countByTitle('weak_password'));
+  const reusedCount = $derived(countByTitle('reused_password'));
+  const agingCount = $derived(countByTitle('stale_entry'));
+  const reviewCount = $derived(Math.max(0, auditState.findingCount - weakCount - reusedCount - agingCount));
   const flaggedEntryCount = $derived(new Set(auditState.findings.map((finding) => finding.entry.id)).size);
   const healthyCount = $derived(Math.max(0, vaultState.entries.length - flaggedEntryCount));
-  const findingGroups = $derived(
-    [
-      {
-        severity: 'high' as AuditSeverity,
-        label: 'critical',
-        findings: auditState.findings.filter((finding) => finding.severity === 'high'),
-      },
-      {
-        severity: 'medium' as AuditSeverity,
-        label: 'review',
-        findings: auditState.findings.filter((finding) => finding.severity === 'medium'),
-      },
-      {
-        severity: 'low' as AuditSeverity,
-        label: 'hygiene',
-        findings: auditState.findings.filter((finding) => finding.severity === 'low'),
-      },
-    ].filter((group) => group.findings.length > 0),
-  );
+  const attentionSummary = $derived.by(() => {
+    const parts = [
+      weakCount > 0 ? `${weakCount} weak` : null,
+      reusedCount > 0 ? `${reusedCount} reused` : null,
+      agingCount > 0 ? `${agingCount} aging` : null,
+      reviewCount > 0 ? `${reviewCount} review` : null,
+    ].filter(Boolean);
+
+    return parts.join(', ');
+  });
   const headline = $derived(
     score >= 85 ? 'vault health is strong.' : score >= 65 ? 'vault health needs review.' : 'vault health needs attention.',
   );
   const summary = $derived(
     vaultState.entries.length === 0
       ? 'Add entries to start measuring password health and vault hygiene.'
-      : `${healthyCount} of ${vaultState.entries.length} entries are clear. ${auditState.findingCount} findings need attention — ${highCount} high, ${mediumCount} review, ${lowCount} hygiene.`,
+      : `${healthyCount} of ${vaultState.entries.length} entries are healthy. ${auditState.findingCount} findings need attention${attentionSummary ? ` — ${attentionSummary}.` : '.'}`,
   );
 
   function openEntry(entry: (typeof vaultState.entries)[number]) {
@@ -45,8 +39,8 @@
     uiState.view = 'detail';
   }
 
-  function countBySeverity(severity: AuditSeverity): number {
-    return auditState.findings.filter((finding) => finding.severity === severity).length;
+  function countByTitle(title: AuditFindingTitle): number {
+    return auditState.findings.filter((finding) => finding.title === title).length;
   }
 
   function severityVariant(severity: AuditSeverity): 'out' | 'vault' | 'slate' {
@@ -60,26 +54,29 @@
     }
   }
 
-  function severityLabel(severity: AuditSeverity): string {
-    switch (severity) {
-      case 'high':
-        return 'high';
-      case 'medium':
+  function findingBucket(title: AuditFindingTitle): AuditBucket {
+    switch (title) {
+      case 'weak_password':
+        return 'weak';
+      case 'reused_password':
+        return 'reused';
+      case 'stale_entry':
+        return 'aging';
+      default:
         return 'review';
-      case 'low':
-        return 'minor';
     }
   }
 
-  function severityDotClass(severity: AuditSeverity): string {
-    switch (severity) {
-      case 'high':
-        return 'row__sev row__sev--high';
-      case 'medium':
-        return 'row__sev row__sev--med';
-      case 'low':
-        return 'row__sev row__sev--low';
-    }
+  function bucketDotClass(title: AuditFindingTitle): string {
+    return `row__sev row__sev--${findingBucket(title)}`;
+  }
+
+  function bucketTagClass(title: AuditFindingTitle): string {
+    return `audit-tag audit-tag--${findingBucket(title)}`;
+  }
+
+  function bucketLabel(title: AuditFindingTitle): string {
+    return findingBucket(title);
   }
 
   function findingTitle(title: keyof typeof AUDIT_FINDING_COPY): string {
@@ -92,6 +89,10 @@
 
   function findingMeta(meta: string): string {
     return meta.replaceAll('_', ' ');
+  }
+
+  function findingDetails(finding: AuditFinding): string {
+    return `${findingTitle(finding.title)} · ${findingMeta(finding.meta)} · ${findingAction(finding.title)}`;
   }
 </script>
 
@@ -125,20 +126,20 @@
     </div>
 
     <div class="audit__stats">
-      <div class="audit__stat">
-        <div class="audit__stat-n audit__stat-n--warn">{highCount}</div>
-        <div class="audit__stat-k">high</div>
+      <div class="audit__stat audit__stat--weak">
+        <div class="audit__stat-n">{weakCount}</div>
+        <div class="audit__stat-k">weak</div>
       </div>
-      <div class="audit__stat">
-        <div class="audit__stat-n audit__stat-n--warn">{mediumCount}</div>
-        <div class="audit__stat-k">review</div>
+      <div class="audit__stat audit__stat--reused">
+        <div class="audit__stat-n">{reusedCount}</div>
+        <div class="audit__stat-k">reused</div>
       </div>
-      <div class="audit__stat">
-        <div class="audit__stat-n">{lowCount}</div>
-        <div class="audit__stat-k">hygiene</div>
+      <div class="audit__stat audit__stat--aging">
+        <div class="audit__stat-n">{agingCount}</div>
+        <div class="audit__stat-k">aging</div>
       </div>
-      <div class="audit__stat">
-        <div class="audit__stat-n audit__stat-n--ok">{healthyCount}</div>
+      <div class="audit__stat audit__stat--healthy">
+        <div class="audit__stat-n">{healthyCount}</div>
         <div class="audit__stat-k">healthy</div>
       </div>
     </div>
@@ -151,26 +152,19 @@
 
     {#if auditState.findingCount > 0}
       <div class="entries audit__entries" role="list">
-        {#each findingGroups as group (group.severity)}
-          <div class="audit__group-title">
-            {group.label}
-            <span>{group.findings.length}</span>
+        {#each auditState.findings as finding (finding.key)}
+          <div role="listitem">
+            <button type="button" class="row audit-row" onclick={() => openEntry(finding.entry)}>
+              <div class="row__bullet">
+                <span class={bucketDotClass(finding.title)}></span>
+              </div>
+              <div class="row__main">
+                <div class="row__title">{finding.entry.title}</div>
+                <div class="row__sub">{findingDetails(finding)}</div>
+              </div>
+              <Tag variant={severityVariant(finding.severity)} class={bucketTagClass(finding.title)} value={bucketLabel(finding.title)} />
+            </button>
           </div>
-          {#each group.findings as finding (finding.key)}
-            <div role="listitem">
-              <button type="button" class="row audit-row" onclick={() => openEntry(finding.entry)}>
-                <div class="row__bullet">
-                  <span class={severityDotClass(finding.severity)}></span>
-                </div>
-                <div class="row__main">
-                  <div class="row__title">{finding.entry.title}</div>
-                  <div class="row__sub">{findingTitle(finding.title)} · {findingAction(finding.title)}</div>
-                </div>
-                <div class="audit-row__meta">{findingMeta(finding.meta)}</div>
-                <Tag variant={severityVariant(finding.severity)} value={severityLabel(finding.severity)} />
-              </button>
-            </div>
-          {/each}
         {/each}
       </div>
     {:else}

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -29,7 +29,7 @@
   const summary = $derived(
     vaultState.entries.length === 0
       ? 'Add entries to start measuring password health and vault hygiene.'
-      : `${auditState.healthyCount} of ${vaultState.entries.length} entries are healthy. ${auditState.findingCount} findings need attention${attentionSummary ? ` — ${attentionSummary}.` : '.'}`,
+      : `${auditState.healthyCount} of ${vaultState.entries.length} entries are healthy. ${auditState.findingCount} findings need attention${attentionSummary ? ` - ${attentionSummary}.` : '.'}`,
   );
 
   function openEntry(entry: (typeof vaultState.entries)[number]) {

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -27,9 +27,11 @@
     score >= 85 ? 'vault health is strong.' : score >= 65 ? 'vault health needs review.' : 'vault health needs attention.',
   );
   const summary = $derived(
-    vaultState.entries.length === 0
-      ? 'Add entries to start measuring password health and vault hygiene.'
-      : `${auditState.healthyCount} of ${vaultState.entries.length} entries are healthy. ${auditState.findingCount} findings need attention${attentionSummary ? ` - ${attentionSummary}.` : '.'}`,
+    auditState.entryCount === 0
+      ? vaultState.entries.length === 0
+        ? 'Add entries to start measuring password health and vault hygiene.'
+        : 'Move entries out of archive to include them in password health and vault hygiene.'
+      : `${auditState.healthyCount} of ${auditState.entryCount} entries are healthy. ${auditState.findingCount} findings need attention${attentionSummary ? ` - ${attentionSummary}.` : '.'}`,
   );
 
   function openEntry(entry: (typeof vaultState.entries)[number]) {

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { AUDIT_FINDING_COPY, type AuditFinding, type AuditFindingTitle } from '../../audit';
+  import { AUDIT_FINDING_COPY, type AuditFinding, type AuditFindingTitle, type AuditSeverity } from '../../audit';
   import { getAuditState } from '../../stores/audit.svelte';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
@@ -9,10 +9,10 @@
 
   const auditState = $derived(getAuditState());
   const score = $derived(Number(auditState.score));
-  const weakCount = $derived(countByTitle('weak_password'));
+  const weakCount = $derived(countBySeverity('high'));
   const reusedCount = $derived(countByTitle('reused_password'));
   const agingCount = $derived(countByTitle('stale_entry'));
-  const reviewCount = $derived(Math.max(0, auditState.findingCount - weakCount - reusedCount - agingCount));
+  const reviewCount = $derived(Math.max(0, auditState.findingCount - weakCount - agingCount));
   const attentionSummary = $derived.by(() => {
     const parts = [
       weakCount > 0 ? `${weakCount} weak` : null,
@@ -39,6 +39,10 @@
 
   function countByTitle(title: AuditFindingTitle): number {
     return auditState.findings.filter((finding) => finding.title === title).length;
+  }
+
+  function countBySeverity(severity: AuditSeverity): number {
+    return auditState.findings.filter((finding) => finding.severity === severity).length;
   }
 
   function findingBucket(title: AuditFindingTitle): AuditBucket {

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -1,19 +1,35 @@
 <script lang="ts">
-  import { AUDIT_FINDING_COPY, type AuditFinding, type AuditSeverity } from '../../audit';
+  import { AUDIT_FINDING_COPY, type AuditFinding, type AuditFindingTitle } from '../../audit';
   import { getAuditState } from '../../stores/audit.svelte';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
   import { Tag } from '../primitives';
 
+  type AuditBucket = 'weak' | 'reused' | 'aging' | 'review';
+
   const auditState = $derived(getAuditState());
   const score = $derived(Number(auditState.score));
+  const weakCount = $derived(countByTitle('weak_password'));
+  const reusedCount = $derived(countByTitle('reused_password'));
+  const agingCount = $derived(countByTitle('stale_entry'));
+  const reviewCount = $derived(Math.max(0, auditState.findingCount - weakCount - reusedCount - agingCount));
+  const attentionSummary = $derived.by(() => {
+    const parts = [
+      weakCount > 0 ? `${weakCount} weak` : null,
+      reusedCount > 0 ? `${reusedCount} reused` : null,
+      agingCount > 0 ? `${agingCount} aging` : null,
+      reviewCount > 0 ? `${reviewCount} review` : null,
+    ].filter(Boolean);
+
+    return parts.join(', ');
+  });
   const headline = $derived(
     score >= 85 ? 'vault health is strong.' : score >= 65 ? 'vault health needs review.' : 'vault health needs attention.',
   );
   const summary = $derived(
     vaultState.entries.length === 0
       ? 'Add entries to start measuring password health and vault hygiene.'
-      : `${auditState.healthyCount} of ${vaultState.entries.length} entries are healthy. ${auditState.findingCount} findings need attention — ${auditState.highCount} high, ${auditState.mediumCount} review, ${auditState.lowCount} hygiene.`,
+      : `${auditState.healthyCount} of ${vaultState.entries.length} entries are healthy. ${auditState.findingCount} findings need attention${attentionSummary ? ` — ${attentionSummary}.` : '.'}`,
   );
 
   function openEntry(entry: (typeof vaultState.entries)[number]) {
@@ -21,34 +37,33 @@
     uiState.view = 'detail';
   }
 
-  function severityVariant(severity: AuditSeverity): 'out' | 'vault' | 'slate' {
-    switch (severity) {
-      case 'high':
-        return 'out';
-      case 'medium':
-        return 'vault';
-      case 'low':
-        return 'slate';
-    }
+  function countByTitle(title: AuditFindingTitle): number {
+    return auditState.findings.filter((finding) => finding.title === title).length;
   }
 
-  function severityDotClass(severity: AuditSeverity): string {
-    return `row__sev row__sev--${severity}`;
-  }
-
-  function severityTagClass(severity: AuditSeverity): string {
-    return `audit-tag audit-tag--${severity}`;
-  }
-
-  function severityLabel(severity: AuditSeverity): string {
-    switch (severity) {
-      case 'high':
-        return 'high';
-      case 'medium':
+  function findingBucket(title: AuditFindingTitle): AuditBucket {
+    switch (title) {
+      case 'weak_password':
+        return 'weak';
+      case 'reused_password':
+        return 'reused';
+      case 'stale_entry':
+        return 'aging';
+      default:
         return 'review';
-      case 'low':
-        return 'hygiene';
     }
+  }
+
+  function bucketDotClass(title: AuditFindingTitle): string {
+    return `row__sev row__sev--${findingBucket(title)}`;
+  }
+
+  function bucketTagClass(title: AuditFindingTitle): string {
+    return `audit-tag audit-tag--${findingBucket(title)}`;
+  }
+
+  function bucketLabel(title: AuditFindingTitle): string {
+    return findingBucket(title);
   }
 
   function findingTitle(title: keyof typeof AUDIT_FINDING_COPY): string {
@@ -73,9 +88,7 @@
     <span class="page__hash mono">#</span>
     <h1 id="audit-title" class="page__title">audit<em>.</em></h1>
     <div class="page__meta mono">
-      <span>entries · <b>{vaultState.entries.length}</b></span>
-      <span>findings · <b>{auditState.findingCount}</b></span>
-      <span>scope · <b>local</b></span>
+      <span>last_scan · <b>live</b></span>
     </div>
   </div>
 
@@ -98,17 +111,17 @@
     </div>
 
     <div class="audit__stats">
-      <div class="audit__stat audit__stat--high">
-        <div class="audit__stat-n">{auditState.highCount}</div>
-        <div class="audit__stat-k">high</div>
+      <div class="audit__stat audit__stat--weak">
+        <div class="audit__stat-n">{weakCount}</div>
+        <div class="audit__stat-k">weak</div>
       </div>
-      <div class="audit__stat audit__stat--review">
-        <div class="audit__stat-n">{auditState.mediumCount}</div>
-        <div class="audit__stat-k">review</div>
+      <div class="audit__stat audit__stat--reused">
+        <div class="audit__stat-n">{reusedCount}</div>
+        <div class="audit__stat-k">reused</div>
       </div>
-      <div class="audit__stat audit__stat--hygiene">
-        <div class="audit__stat-n">{auditState.lowCount}</div>
-        <div class="audit__stat-k">hygiene</div>
+      <div class="audit__stat audit__stat--aging">
+        <div class="audit__stat-n">{agingCount}</div>
+        <div class="audit__stat-k">aging</div>
       </div>
       <div class="audit__stat audit__stat--healthy">
         <div class="audit__stat-n">{auditState.healthyCount}</div>
@@ -128,13 +141,13 @@
           <div role="listitem">
             <button type="button" class="row audit-row" onclick={() => openEntry(finding.entry)}>
               <div class="row__bullet">
-                <span class={severityDotClass(finding.severity)}></span>
+                <span class={bucketDotClass(finding.title)}></span>
               </div>
               <div class="row__main">
                 <div class="row__title">{finding.entry.title}</div>
                 <div class="row__sub">{findingDetails(finding)}</div>
               </div>
-              <Tag variant={severityVariant(finding.severity)} class={severityTagClass(finding.severity)} value={severityLabel(finding.severity)} />
+              <Tag class={bucketTagClass(finding.title)} value={bucketLabel(finding.title)} />
             </button>
           </div>
         {/each}

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -1,46 +1,24 @@
 <script lang="ts">
-  import { AUDIT_FINDING_COPY, type AuditFinding, type AuditFindingTitle, type AuditSeverity } from '../../audit';
+  import { AUDIT_FINDING_COPY, type AuditFinding, type AuditSeverity } from '../../audit';
   import { getAuditState } from '../../stores/audit.svelte';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
   import { Tag } from '../primitives';
 
-  type AuditBucket = 'weak' | 'reused' | 'aging' | 'review';
-
   const auditState = $derived(getAuditState());
   const score = $derived(Number(auditState.score));
-  const weakCount = $derived(countByTitle('weak_password'));
-  const reusedCount = $derived(countByTitle('reused_password'));
-  const agingCount = $derived(countByTitle('stale_entry'));
-  const reviewCount = $derived(Math.max(0, auditState.findingCount - weakCount - reusedCount - agingCount));
-  const flaggedEntryCount = $derived(new Set(auditState.findings.map((finding) => finding.entry.id)).size);
-  const healthyCount = $derived(Math.max(0, vaultState.entries.length - flaggedEntryCount));
-  const attentionSummary = $derived.by(() => {
-    const parts = [
-      weakCount > 0 ? `${weakCount} weak` : null,
-      reusedCount > 0 ? `${reusedCount} reused` : null,
-      agingCount > 0 ? `${agingCount} aging` : null,
-      reviewCount > 0 ? `${reviewCount} review` : null,
-    ].filter(Boolean);
-
-    return parts.join(', ');
-  });
   const headline = $derived(
     score >= 85 ? 'vault health is strong.' : score >= 65 ? 'vault health needs review.' : 'vault health needs attention.',
   );
   const summary = $derived(
     vaultState.entries.length === 0
       ? 'Add entries to start measuring password health and vault hygiene.'
-      : `${healthyCount} of ${vaultState.entries.length} entries are healthy. ${auditState.findingCount} findings need attention${attentionSummary ? ` — ${attentionSummary}.` : '.'}`,
+      : `${auditState.healthyCount} of ${vaultState.entries.length} entries are healthy. ${auditState.findingCount} findings need attention — ${auditState.highCount} high, ${auditState.mediumCount} review, ${auditState.lowCount} hygiene.`,
   );
 
   function openEntry(entry: (typeof vaultState.entries)[number]) {
     vaultState.selectedEntry = entry;
     uiState.view = 'detail';
-  }
-
-  function countByTitle(title: AuditFindingTitle): number {
-    return auditState.findings.filter((finding) => finding.title === title).length;
   }
 
   function severityVariant(severity: AuditSeverity): 'out' | 'vault' | 'slate' {
@@ -54,29 +32,23 @@
     }
   }
 
-  function findingBucket(title: AuditFindingTitle): AuditBucket {
-    switch (title) {
-      case 'weak_password':
-        return 'weak';
-      case 'reused_password':
-        return 'reused';
-      case 'stale_entry':
-        return 'aging';
-      default:
+  function severityDotClass(severity: AuditSeverity): string {
+    return `row__sev row__sev--${severity}`;
+  }
+
+  function severityTagClass(severity: AuditSeverity): string {
+    return `audit-tag audit-tag--${severity}`;
+  }
+
+  function severityLabel(severity: AuditSeverity): string {
+    switch (severity) {
+      case 'high':
+        return 'high';
+      case 'medium':
         return 'review';
+      case 'low':
+        return 'hygiene';
     }
-  }
-
-  function bucketDotClass(title: AuditFindingTitle): string {
-    return `row__sev row__sev--${findingBucket(title)}`;
-  }
-
-  function bucketTagClass(title: AuditFindingTitle): string {
-    return `audit-tag audit-tag--${findingBucket(title)}`;
-  }
-
-  function bucketLabel(title: AuditFindingTitle): string {
-    return findingBucket(title);
   }
 
   function findingTitle(title: keyof typeof AUDIT_FINDING_COPY): string {
@@ -126,20 +98,20 @@
     </div>
 
     <div class="audit__stats">
-      <div class="audit__stat audit__stat--weak">
-        <div class="audit__stat-n">{weakCount}</div>
-        <div class="audit__stat-k">weak</div>
+      <div class="audit__stat audit__stat--high">
+        <div class="audit__stat-n">{auditState.highCount}</div>
+        <div class="audit__stat-k">high</div>
       </div>
-      <div class="audit__stat audit__stat--reused">
-        <div class="audit__stat-n">{reusedCount}</div>
-        <div class="audit__stat-k">reused</div>
+      <div class="audit__stat audit__stat--review">
+        <div class="audit__stat-n">{auditState.mediumCount}</div>
+        <div class="audit__stat-k">review</div>
       </div>
-      <div class="audit__stat audit__stat--aging">
-        <div class="audit__stat-n">{agingCount}</div>
-        <div class="audit__stat-k">aging</div>
+      <div class="audit__stat audit__stat--hygiene">
+        <div class="audit__stat-n">{auditState.lowCount}</div>
+        <div class="audit__stat-k">hygiene</div>
       </div>
       <div class="audit__stat audit__stat--healthy">
-        <div class="audit__stat-n">{healthyCount}</div>
+        <div class="audit__stat-n">{auditState.healthyCount}</div>
         <div class="audit__stat-k">healthy</div>
       </div>
     </div>
@@ -156,13 +128,13 @@
           <div role="listitem">
             <button type="button" class="row audit-row" onclick={() => openEntry(finding.entry)}>
               <div class="row__bullet">
-                <span class={bucketDotClass(finding.title)}></span>
+                <span class={severityDotClass(finding.severity)}></span>
               </div>
               <div class="row__main">
                 <div class="row__title">{finding.entry.title}</div>
                 <div class="row__sub">{findingDetails(finding)}</div>
               </div>
-              <Tag variant={severityVariant(finding.severity)} class={bucketTagClass(finding.title)} value={bucketLabel(finding.title)} />
+              <Tag variant={severityVariant(finding.severity)} class={severityTagClass(finding.severity)} value={severityLabel(finding.severity)} />
             </button>
           </div>
         {/each}

--- a/apps/desktop/src/lib/components/vault/FilterSidebar.svelte
+++ b/apps/desktop/src/lib/components/vault/FilterSidebar.svelte
@@ -63,7 +63,10 @@
           aria-pressed={activeTag === tag.value}
           onclick={() => ontagselect?.(tag.value)}
         >
-          <span class="tag-filter__label"># {tag.value} {tag.count}</span>
+          <span class="tag-filter__label">
+            # {tag.value}
+            <span class="tag-filter__count">{tag.count}</span>
+          </span>
         </button>
       {/each}
     {:else}

--- a/apps/desktop/src/lib/stores/audit.svelte.ts
+++ b/apps/desktop/src/lib/stores/audit.svelte.ts
@@ -7,6 +7,8 @@ export interface AuditStateSnapshot {
   highCount: number;
   mediumCount: number;
   lowCount: number;
+  flaggedEntryCount: number;
+  healthyCount: number;
   score: string;
 }
 
@@ -15,6 +17,8 @@ const auditState = $derived.by((): AuditStateSnapshot => {
   const highCount = findings.filter((finding) => finding.severity === 'high').length;
   const mediumCount = findings.filter((finding) => finding.severity === 'medium').length;
   const lowCount = findings.filter((finding) => finding.severity === 'low').length;
+  const flaggedEntryCount = new Set(findings.map((finding) => finding.entry.id)).size;
+  const healthyCount = Math.max(0, vaultState.entries.length - flaggedEntryCount);
 
   return {
     findings,
@@ -22,7 +26,9 @@ const auditState = $derived.by((): AuditStateSnapshot => {
     highCount,
     mediumCount,
     lowCount,
-    score: scoreAudit(vaultState.entries.length, findings.length, highCount),
+    flaggedEntryCount,
+    healthyCount,
+    score: scoreAudit(vaultState.entries.length, healthyCount),
   };
 });
 

--- a/apps/desktop/src/lib/stores/audit.svelte.ts
+++ b/apps/desktop/src/lib/stores/audit.svelte.ts
@@ -1,7 +1,8 @@
-import { buildAuditFindings, scoreAudit, type AuditFinding } from '../audit';
+import { buildAuditFindings, filterAuditableEntries, scoreAudit, type AuditFinding } from '../audit';
 import { vaultState } from './vault.svelte';
 
 export interface AuditStateSnapshot {
+  entryCount: number;
   findings: AuditFinding[];
   findingCount: number;
   highCount: number;
@@ -13,14 +14,16 @@ export interface AuditStateSnapshot {
 }
 
 const auditState = $derived.by((): AuditStateSnapshot => {
-  const findings = buildAuditFindings(vaultState.entries);
+  const entries = filterAuditableEntries(vaultState.entries);
+  const findings = buildAuditFindings(entries);
   const highCount = findings.filter((finding) => finding.severity === 'high').length;
   const mediumCount = findings.filter((finding) => finding.severity === 'medium').length;
   const lowCount = findings.filter((finding) => finding.severity === 'low').length;
   const flaggedEntryCount = new Set(findings.map((finding) => finding.entry.id)).size;
-  const healthyCount = Math.max(0, vaultState.entries.length - flaggedEntryCount);
+  const healthyCount = Math.max(0, entries.length - flaggedEntryCount);
 
   return {
+    entryCount: entries.length,
     findings,
     findingCount: findings.length,
     highCount,
@@ -28,7 +31,7 @@ const auditState = $derived.by((): AuditStateSnapshot => {
     lowCount,
     flaggedEntryCount,
     healthyCount,
-    score: scoreAudit(vaultState.entries.length, healthyCount),
+    score: scoreAudit(entries.length, healthyCount),
   };
 });
 


### PR DESCRIPTION
## Summary
- add first-release local audit checks for HTTP URLs, duplicate URLs, and missing collections
- centralize audit finding labels and recommended actions beside the audit model
- summarize audit findings by severity groups: high, review, hygiene, healthy
- mark audit scope as local so the UI does not imply breach/network checks are running
- extend tests for the new local checks and plaintext-safe finding copy

## First-release audit scope
This PR keeps audit local-only and privacy-preserving. It covers:
- weak loaded passwords
- reused loaded passwords
- stale entries
- duplicate usernames
- missing URLs
- HTTP URLs
- duplicate URLs
- missing collections
- missing tags

Advanced checks that need explicit privacy/product design are deferred to #149.

Closes #136.

## Validation
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit checks for insecure HTTP links, duplicate URLs, and missing collections.
  * Improved URL matching to recognize equivalent links more accurately.
  * Audit findings now appear in a unified list with clearer labels, details, severity indicators, and recommended actions.
  * Added audit scores, flagged-entry counts, and a local-scope indicator.
  * Updated status displays to distinguish audit, vault, generator, and settings views.

* **Bug Fixes**
  * Improved audit messaging to avoid displaying plaintext passwords in passive findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->