### PR TITLE
fix: show grouped entries in all vault view

### DIFF
--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -200,12 +200,24 @@
     for (const entry of entries) {
       if (recent.has(entry.id)) {
         grouped.get('recent')?.entries.push(entry);
-      } else {
-        grouped.get(collectionFor(entry) ?? 'other')?.entries.push(entry);
       }
+
+      grouped.get(collectionFor(entry) ?? 'other')?.entries.push(entry);
     }
 
     return [...grouped.values()].filter((section) => section.entries.length > 0);
+  }
+
+  function shortcutFor(section: EntrySection, index: number): string | undefined {
+    if (index >= 9) {
+      return undefined;
+    }
+
+    if (hasScopedResults || section.key === 'recent') {
+      return `⌘${index + 1}`;
+    }
+
+    return undefined;
   }
 
   function countByFilter(filter: FilterKey, recent: Set<string>): number {
@@ -403,7 +415,7 @@
             <EntryRow
               {entry}
               selected={vaultState.selectedEntry?.id === entry.id}
-              shortcut={index < 9 ? `⌘${index + 1}` : undefined}
+              shortcut={shortcutFor(section, index)}
               onselect={selectEntry}
             />
           {/each}


### PR DESCRIPTION
## Summary
- keep the RECENT section as a preview in the all-category vault view
- also render each entry under its collection section so all selected does not collapse to recent only
- avoid duplicate command-number badges in grouped sections while preserving shortcuts for recent/scoped result lists

## Validation
- pnpm typecheck
- pnpm build
- pnpm test