### PR TITLE
fix: keep generator toggles aligned

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2533,14 +2533,22 @@ body {
 }
 .gen__ctrl {
   display: grid;
-  grid-template-columns: 150px 1fr auto;
+  grid-template-columns: minmax(130px, 180px) minmax(0, 1fr) auto;
   align-items: center;
   gap: 18px;
   padding: 14px 18px;
   border-bottom: 1px dashed var(--rule-dashed);
 }
+.gen__ctrl .slider {
+  grid-column: 2 / 4;
+}
+.gen__ctrl .switch {
+  grid-column: 3;
+  justify-self: end;
+}
 .gen__ctrl:last-child { border-bottom: none; }
 .gen__ctrl-k {
+  grid-column: 1;
   font-family: var(--font-mono);
   font-size: calc(11px * var(--arca-font-scale, 1));
   letter-spacing: 0.04em;
@@ -2905,7 +2913,6 @@ body {
   }
   .audit__score,
   .audit__stats,
-  .gen__ctrl,
   .set-row {
     grid-template-columns: 1fr;
   }
@@ -2932,6 +2939,21 @@ body {
   }
   .audit__stats {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .gen__ctrl {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px 12px;
+  }
+  .gen__ctrl .slider {
+    grid-column: 1 / -1;
+  }
+  .gen__ctrl .switch {
+    grid-column: 2;
+    grid-row: 1;
+  }
+  .gen__ctrl-k,
+  .gen__ctrl-k--wide {
+    grid-column: 1;
   }
   .gen__pw {
     font-size: calc(20px * var(--arca-font-scale, 1));

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -245,7 +245,6 @@
 
       <div class="gen__ctrl">
         <div class="gen__ctrl-k">uppercase<small>A–Z</small></div>
-        <div></div>
         <Toggle
           label="Uppercase letters"
           checked={uppercase}
@@ -258,7 +257,6 @@
 
       <div class="gen__ctrl">
         <div class="gen__ctrl-k">lowercase<small>a–z</small></div>
-        <div></div>
         <Toggle
           label="Lowercase letters"
           checked={lowercase}
@@ -271,7 +269,6 @@
 
       <div class="gen__ctrl">
         <div class="gen__ctrl-k">numbers<small>0–9</small></div>
-        <div></div>
         <Toggle
           label="Numbers"
           checked={digits}
@@ -296,7 +293,6 @@
 
       <div class="gen__ctrl">
         <div class="gen__ctrl-k">exclude ambiguous<small>e.g. 0 O 1 l I</small></div>
-        <div></div>
         <Toggle
           label="Exclude ambiguous characters"
           checked={excludeAmbiguous}


### PR DESCRIPTION
## Summary
- keep generator option rows in a three-column layout through desktop/tablet widths
- pin toggle controls to the right until the narrow mobile breakpoint
- remove empty spacer markup now that CSS places sliders and toggles explicitly

## Validation
- pnpm typecheck
- pnpm build
- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved generator control layouts for clearer alignment and spacing on desktop and smaller screens.
  * Updated responsive behavior to keep controls accessible at medium and narrow widths.
  * Sliders now span the available control area, while switches remain consistently right-aligned.
  * Removed unnecessary spacing elements without changing generator behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->