### PR TITLE
fix: render vault tag chips as single labels

### DIFF
--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -941,29 +941,33 @@ body {
 .tag-cloud {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 6px;
   padding: 2px 0;
 }
 .tag-filter {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 0;
+  min-height: 28px;
+  padding: 5px 9px;
   border: 0;
-  background: transparent;
-  color: var(--text-3);
+  border-radius: 5px;
+  background: var(--slate-soft);
+  color: var(--text-2);
   cursor: pointer;
-}
-.tag-filter__count {
-  color: var(--text-4);
+  font-family: var(--font-mono);
   font-size: calc(9px * var(--arca-font-scale, 1));
-  letter-spacing: 0.04em;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transition: background .12s, color .12s;
 }
-.tag-filter:hover .tag--slate {
+.tag-filter:hover {
   background: var(--bg-card);
   color: var(--text);
 }
-.tag-filter--active .tag-filter__count {
+.tag-filter--active {
+  background: var(--accent-soft);
   color: var(--accent);
 }
 .sidepanel__clear {

--- a/apps/desktop/src/lib/components/vault/FilterSidebar.svelte
+++ b/apps/desktop/src/lib/components/vault/FilterSidebar.svelte
@@ -63,8 +63,7 @@
           aria-pressed={activeTag === tag.value}
           onclick={() => ontagselect?.(tag.value)}
         >
-          <Tag variant={activeTag === tag.value ? 'default' : 'slate'} value={tag.value} bracketed={false} />
-          <span class="tag-filter__count mono">{tag.count}</span>
+          <span class="tag-filter__label"># {tag.value} {tag.count}</span>
         </button>
       {/each}
     {:else}


### PR DESCRIPTION
## Summary
- render vault sidebar tags as one compact label like `# MAIL 1`
- style each tag filter as a single chip instead of composing a tag badge plus separate count
- preserve active/hover states for tag filtering

## Validation
- pnpm typecheck
- pnpm build
- pnpm test