### PR TITLE
chore: allow boost software license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,7 @@ confidence-threshold = 0.8
 allow = [
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
+  "BSL-1.0",
   "BSD-2-Clause",
   "BSD-3-Clause",
   "ISC",


### PR DESCRIPTION
## Summary

- Add BSL-1.0 to the cargo-deny license allowlist.
- Keep the clipboard implementation PR focused by landing the license policy update separately.

## Why

PR #151 introduces the official Tauri clipboard plugin. Its transitive Windows clipboard path pulls crates licensed under BSL-1.0, which cargo-deny rejected because that permissive license was not explicitly allowed yet.

## Validation

- cargo deny check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the BSL-1.0 license to the project’s approved license list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->