### PR TITLE
feat: complete keyboard navigation model

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -92,7 +92,7 @@
       : activeTab === 'audit'
         ? `audit · ${auditState.flaggedEntryCount} flagged`
         : activeTab === 'generate'
-          ? 'generator'
+          ? 'generator · R generate · V reveal · C copy · U use'
           : activeTab === 'settings'
             ? `settings · ${lockShortcut} lock now`
             : uiState.view === 'detail'

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -158,9 +158,7 @@
     if (
       modKey &&
       !event.shiftKey &&
-      key in tabShortcutMap &&
-      uiState.view !== 'list' &&
-      uiState.view !== 'audit'
+      key in tabShortcutMap
     ) {
       event.preventDefault();
       uiState.view = tabShortcutMap[key];

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -34,6 +34,7 @@
 
   const modLabel = $derived(primaryModifierLabel());
   const lockShortcut = $derived(shortcutLabel(modLabel, 'Shift', 'L'));
+  const saveShortcut = $derived(shortcutLabel(modLabel, '↵'));
   const auditState = $derived(getAuditState());
   const tabItems = $derived<TabItem[]>([
     { key: 'vault', label: 'vault', count: vaultState.entries.length },
@@ -97,7 +98,9 @@
             ? `settings · ${lockShortcut} lock now`
             : uiState.view === 'detail'
               ? 'Esc back · E edit · U user · C password · R reveal · D delete'
-              : `vault.local · ${vaultState.entries.length} entries`,
+              : uiState.view === 'edit'
+                ? `${vaultState.selectedEntry ? 'edit_entry' : 'new_entry'} · Esc cancel · ${saveShortcut} save`
+                : `vault.local · ${vaultState.entries.length} entries · ${shortcutLabel(modLabel, 'F')} search · N new · G generate · ↑↓ select · ↵ open`,
   );
   const fontSize = $derived(runtimeSettings.current.fontSize);
   const appStyle = $derived(

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -96,7 +96,7 @@
           : activeTab === 'settings'
             ? `settings · ${lockShortcut} lock now`
             : uiState.view === 'detail'
-              ? detailStatusText(vaultState.selectedEntry?.title ?? vaultState.entries[0]?.title)
+              ? 'Esc back · E edit · U user · C password · R reveal · D delete'
               : `vault.local · ${vaultState.entries.length} entries`,
   );
   const fontSize = $derived(runtimeSettings.current.fontSize);
@@ -140,10 +140,6 @@
     }
 
     return 'vault.local';
-  }
-
-  function detailStatusText(entryTitle: string | undefined): string {
-    return `${entryTitle?.trim() || 'entry'} · password`;
   }
 
   function handleGlobalKeydown(event: KeyboardEvent) {

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -5,6 +5,7 @@
   import UnlockScreen from './lib/components/UnlockScreen.svelte';
   import VaultShell from './lib/components/VaultShell.svelte';
   import { StatusBar, Tabs, WindowChrome, type TabItem } from './lib/components/chrome';
+  import { isEditableTarget, isMacPlatform, primaryModifierPressed } from './lib/keyboard';
   import { lockCurrentVault } from './lib/session';
   import { getAuditState } from './lib/stores/audit.svelte';
   import { loadRuntimeSettings, runtimeSettings } from './lib/stores/settings.svelte';
@@ -13,9 +14,13 @@
 
   const BASE_FONT_SIZE = 13;
   const ACTIVITY_EVENTS = ['pointerdown', 'keydown', 'wheel', 'touchstart'] as const;
-  const isMacWindow =
-    typeof navigator !== 'undefined' &&
-    (navigator.platform.includes('Mac') || navigator.userAgent.includes('Macintosh'));
+  const isMacWindow = isMacPlatform();
+  const tabShortcutMap: Record<string, ViewName> = {
+    '1': 'list',
+    '2': 'generator',
+    '3': 'audit',
+    '4': 'settings',
+  };
 
   let lastActivityAt = $state(Date.now());
   let autoLockTimer: ReturnType<typeof setTimeout> | null = null;
@@ -129,22 +134,52 @@
 
   function handleGlobalKeydown(event: KeyboardEvent) {
     const key = event.key.toLowerCase();
-    const modKey = isMacWindow ? event.metaKey : event.ctrlKey;
+    const modKey = primaryModifierPressed(event);
 
-    if (!vaultState.locked && !event.repeat && modKey && event.shiftKey && key === 'l') {
+    if (
+      vaultState.locked ||
+      event.repeat ||
+      event.altKey ||
+      isEditableTarget(event.target)
+    ) {
+      return;
+    }
+
+    if (uiState.view === 'edit') {
+      return;
+    }
+
+    if (modKey && event.shiftKey && key === 'l') {
       event.preventDefault();
       void lockFromUserAction();
       return;
     }
 
-    if (
-      vaultState.locked ||
-      event.repeat ||
-      event.metaKey ||
-      event.ctrlKey ||
-      event.altKey ||
-      isEditableTarget(event.target)
-    ) {
+    if (modKey && !event.shiftKey && key in tabShortcutMap) {
+      event.preventDefault();
+      uiState.view = tabShortcutMap[key];
+      return;
+    }
+
+    if (modKey && !event.shiftKey && key === ',') {
+      event.preventDefault();
+      uiState.view = 'settings';
+      return;
+    }
+
+    if (modKey && !event.shiftKey && key === 'o') {
+      event.preventDefault();
+      void openAnotherVault();
+      return;
+    }
+
+    if (event.metaKey || event.ctrlKey) {
+      return;
+    }
+
+    if ((uiState.view === 'generator' || uiState.view === 'audit' || uiState.view === 'settings') && key === 'escape') {
+      event.preventDefault();
+      uiState.view = 'list';
       return;
     }
 
@@ -194,6 +229,19 @@
     }
   }
 
+  async function openAnotherVault() {
+    try {
+      await lockCurrentVault();
+      uiState.unlockSurface = 'two-pane';
+      uiState.sealedPromptOpen = false;
+    } catch {
+      uiState.notification = {
+        kind: 'error',
+        message: 'Unable to open another vault',
+      };
+    }
+  }
+
   function clearAutoLockTimer() {
     if (autoLockTimer) {
       clearTimeout(autoLockTimer);
@@ -228,19 +276,6 @@
     } catch {
       return null;
     }
-  }
-
-  function isEditableTarget(target: EventTarget | null) {
-    if (!(target instanceof HTMLElement)) {
-      return false;
-    }
-
-    return (
-      target instanceof HTMLInputElement ||
-      target instanceof HTMLTextAreaElement ||
-      target instanceof HTMLSelectElement ||
-      target.isContentEditable
-    );
   }
 
   onMount(() => {

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -155,7 +155,13 @@
       return;
     }
 
-    if (modKey && !event.shiftKey && key in tabShortcutMap) {
+    if (
+      modKey &&
+      !event.shiftKey &&
+      key in tabShortcutMap &&
+      uiState.view !== 'list' &&
+      uiState.view !== 'audit'
+    ) {
       event.preventDefault();
       uiState.view = tabShortcutMap[key];
       return;

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -5,7 +5,13 @@
   import UnlockScreen from './lib/components/UnlockScreen.svelte';
   import VaultShell from './lib/components/VaultShell.svelte';
   import { StatusBar, Tabs, WindowChrome, type TabItem } from './lib/components/chrome';
-  import { isEditableTarget, isMacPlatform, primaryModifierPressed } from './lib/keyboard';
+  import {
+    isEditableTarget,
+    isMacPlatform,
+    primaryModifierLabel,
+    primaryModifierPressed,
+    shortcutLabel,
+  } from './lib/keyboard';
   import { lockCurrentVault } from './lib/session';
   import { getAuditState } from './lib/stores/audit.svelte';
   import { loadRuntimeSettings, runtimeSettings } from './lib/stores/settings.svelte';
@@ -26,6 +32,8 @@
   let autoLockTimer: ReturnType<typeof setTimeout> | null = null;
   let isFullscreen = $state(false);
 
+  const modLabel = $derived(primaryModifierLabel());
+  const lockShortcut = $derived(shortcutLabel(modLabel, 'Shift', 'L'));
   const auditState = $derived(getAuditState());
   const tabItems = $derived<TabItem[]>([
     { key: 'vault', label: 'vault', count: vaultState.entries.length },
@@ -86,7 +94,7 @@
         : activeTab === 'generate'
           ? 'generator'
           : activeTab === 'settings'
-            ? 'settings'
+            ? `settings · ${lockShortcut} lock now`
             : uiState.view === 'detail'
               ? detailStatusText(vaultState.selectedEntry?.title ?? vaultState.entries[0]?.title)
               : `vault.local · ${vaultState.entries.length} entries`,

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -88,7 +88,7 @@
           : activeTab === 'settings'
             ? 'settings'
             : uiState.view === 'detail'
-              ? 'Esc back · E edit · U user · C password · R reveal · D delete'
+              ? detailStatusText(vaultState.selectedEntry?.title ?? vaultState.entries[0]?.title)
               : `vault.local · ${vaultState.entries.length} entries`,
   );
   const fontSize = $derived(runtimeSettings.current.fontSize);
@@ -132,6 +132,10 @@
     }
 
     return 'vault.local';
+  }
+
+  function detailStatusText(entryTitle: string | undefined): string {
+    return `${entryTitle?.trim() || 'entry'} · password`;
   }
 
   function handleGlobalKeydown(event: KeyboardEvent) {

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -145,13 +145,13 @@
       return;
     }
 
-    if (uiState.view === 'edit') {
-      return;
-    }
-
     if (modKey && event.shiftKey && key === 'l') {
       event.preventDefault();
       void lockFromUserAction();
+      return;
+    }
+
+    if (uiState.view === 'edit') {
       return;
     }
 

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -87,7 +87,9 @@
           ? 'generator'
           : activeTab === 'settings'
             ? 'settings'
-            : `vault.local · ${vaultState.entries.length} entries`,
+            : uiState.view === 'detail'
+              ? 'Esc back · E edit · U user · C password · R reveal · D delete'
+              : `vault.local · ${vaultState.entries.length} entries`,
   );
   const fontSize = $derived(runtimeSettings.current.fontSize);
   const appStyle = $derived(

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2815,6 +2815,53 @@ body {
   display: flex;
   gap: 8px;
 }
+.shortcut-ref {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px dashed var(--rule-dashed);
+}
+.shortcut-ref__group {
+  min-width: 0;
+  padding: 14px 18px 16px;
+}
+.shortcut-ref__group:nth-child(2n) {
+  border-left: 1px dashed var(--rule-dashed);
+}
+.shortcut-ref__group:nth-child(n + 3) {
+  border-top: 1px dashed var(--rule-dashed);
+}
+.shortcut-ref__title {
+  font-family: var(--font-mono);
+  font-size: calc(9px * var(--arca-font-scale, 1));
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  margin-bottom: 10px;
+}
+.shortcut-ref__items {
+  display: grid;
+  gap: 8px;
+}
+.shortcut-ref__item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-width: 0;
+  font-size: calc(11px * var(--arca-font-scale, 1));
+  color: var(--text-2);
+}
+.shortcut-ref__item > span:first-child {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.shortcut-ref__keys {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  white-space: nowrap;
+}
 .settings-error {
   color: var(--accent);
   font-size: calc(10px * var(--arca-font-scale, 1));
@@ -2944,8 +2991,15 @@ body {
   }
   .audit__score,
   .audit__stats,
+  .shortcut-ref,
   .set-row {
     grid-template-columns: 1fr;
+  }
+  .shortcut-ref__group:nth-child(2n) {
+    border-left: 0;
+  }
+  .shortcut-ref__group:nth-child(n + 2) {
+    border-top: 1px dashed var(--rule-dashed);
   }
   .set-row__v {
     justify-content: flex-start;

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -2722,6 +2722,14 @@ body {
 .audit-row .row__sub {
   text-align: left;
 }
+.audit-row__tags {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+  white-space: nowrap;
+}
 .row__sev {
   width: 7px;
   height: 7px;
@@ -2811,10 +2819,6 @@ body {
   min-width: min(260px, 100%);
   flex-wrap: nowrap;
 }
-.settings__actions {
-  display: flex;
-  gap: 8px;
-}
 .shortcut-ref {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2822,7 +2826,7 @@ body {
 }
 .shortcut-ref__group {
   min-width: 0;
-  padding: 14px 18px 16px;
+  padding: 12px 18px 14px;
 }
 .shortcut-ref__group:nth-child(2n) {
   border-left: 1px dashed var(--rule-dashed);
@@ -2836,19 +2840,19 @@ body {
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--text-3);
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 }
 .shortcut-ref__items {
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 .shortcut-ref__item {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 12px;
+  gap: 10px;
   align-items: center;
   min-width: 0;
-  font-size: calc(11px * var(--arca-font-scale, 1));
+  font-size: calc(10px * var(--arca-font-scale, 1));
   color: var(--text-2);
 }
 .shortcut-ref__item > span:first-child {

--- a/apps/desktop/src/lib/components/UnlockScreen.svelte
+++ b/apps/desktop/src/lib/components/UnlockScreen.svelte
@@ -51,20 +51,23 @@
         return;
       }
 
+      if (event.key === 'Escape' && uiState.sealedPromptOpen) {
+        event.preventDefault();
+        closeSealedPrompt();
+        return;
+      }
+
       if (isEditableTarget(event.target)) {
         return;
       }
 
       if (primaryModifierPressed(event) && !event.shiftKey && event.key.toLowerCase() === 'o') {
         event.preventDefault();
-        uiState.unlockSurface = 'two-pane';
-        uiState.sealedPromptOpen = false;
-        return;
-      }
-
-      if (event.key === 'Escape' && uiState.sealedPromptOpen) {
-        event.preventDefault();
+        if (busy) {
+          return;
+        }
         closeSealedPrompt();
+        uiState.unlockSurface = 'two-pane';
         return;
       }
 

--- a/apps/desktop/src/lib/components/UnlockScreen.svelte
+++ b/apps/desktop/src/lib/components/UnlockScreen.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { createVault, listEntries, suggestPaths, unlockVault, type EntryDto, type PathSuggestion } from '../ipc';
+  import { primaryModifierLabel, primaryModifierPressed } from '../keyboard';
   import { vaultState } from '../stores/vault.svelte';
   import { uiState } from '../stores/ui.svelte';
   import { Lockup } from './brand';
@@ -42,10 +43,18 @@
   const isSealed = $derived(variant === 'sealed');
   const sealedOpen = $derived(isSealed && uiState.sealedPromptOpen);
   const showPathSuggestions = $derived(pathFocused && pathSuggestions.length > 0);
+  const modLabel = $derived(primaryModifierLabel());
 
   onMount(() => {
     function handleKeydown(event: KeyboardEvent) {
       if (!isSealed || !vaultState.locked) {
+        return;
+      }
+
+      if (primaryModifierPressed(event) && !event.shiftKey && event.key.toLowerCase() === 'o') {
+        event.preventDefault();
+        uiState.unlockSurface = 'two-pane';
+        uiState.sealedPromptOpen = false;
         return;
       }
 
@@ -354,8 +363,7 @@
 
           <div class="unlock__hints mono">
             <span><Kbd value="↵" /> <b>unlock</b></span>
-            <span><Kbd value="⌘" />+<Kbd value="," /> settings</span>
-            <span><Kbd value="⌘" />+<Kbd value="O" /> other vault</span>
+            <span><Kbd value={modLabel} />+<Kbd value="O" /> other vault</span>
           </div>
 
           <div class="ds-hr"></div>
@@ -517,8 +525,6 @@
 
         <div class="unlock__hints mono">
           <span><Kbd value="↵" /> <b>{mode === 'open' ? 'unlock' : 'create'}</b></span>
-          <span><Kbd value="⌘" />+<Kbd value="," /> settings</span>
-          <span><Kbd value="⌘" />+<Kbd value="O" /> other vault</span>
         </div>
 
         <div class="ds-hr"></div>

--- a/apps/desktop/src/lib/components/UnlockScreen.svelte
+++ b/apps/desktop/src/lib/components/UnlockScreen.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { createVault, listEntries, suggestPaths, unlockVault, type EntryDto, type PathSuggestion } from '../ipc';
-  import { primaryModifierLabel, primaryModifierPressed } from '../keyboard';
+  import { isEditableTarget, primaryModifierLabel, primaryModifierPressed } from '../keyboard';
   import { vaultState } from '../stores/vault.svelte';
   import { uiState } from '../stores/ui.svelte';
   import { Lockup } from './brand';
@@ -48,6 +48,10 @@
   onMount(() => {
     function handleKeydown(event: KeyboardEvent) {
       if (!isSealed || !vaultState.locked) {
+        return;
+      }
+
+      if (isEditableTarget(event.target)) {
         return;
       }
 

--- a/apps/desktop/src/lib/components/UnlockScreen.svelte
+++ b/apps/desktop/src/lib/components/UnlockScreen.svelte
@@ -363,7 +363,7 @@
 
           <div class="unlock__hints mono">
             <span><Kbd value="↵" /> <b>unlock</b></span>
-            <span><Kbd value={modLabel} />+<Kbd value="O" /> other vault</span>
+            <span><Kbd value={modLabel} /> + <Kbd value="O" /> other vault</span>
           </div>
 
           <div class="ds-hr"></div>

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
+  import { onMount, tick } from 'svelte';
   import { AUDIT_FINDING_COPY, type AuditFinding, type AuditFindingTitle, type AuditSeverity } from '../../audit';
+  import { isEditableTarget } from '../../keyboard';
   import { getAuditState } from '../../stores/audit.svelte';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
   import { Tag } from '../primitives';
 
   type AuditBucket = 'weak' | 'reused' | 'aging' | 'review';
+
+  let activeFindingKey = $state('');
 
   const auditState = $derived(getAuditState());
   const score = $derived(Number(auditState.score));
@@ -14,6 +18,9 @@
   const agingCount = $derived(countByTitle('stale_entry'));
   const reviewCount = $derived(Math.max(0, auditState.findingCount - weakCount - agingCount));
   const scoreColor = $derived(score >= 85 ? 'var(--vault)' : score >= 65 ? '#D7833F' : 'var(--accent)');
+  const findingPositions = $derived(
+    new Map(auditState.findings.map((finding, index) => [finding.key, index + 1] as const)),
+  );
   const attentionSummary = $derived.by(() => {
     const parts = [
       weakCount > 0 ? `${weakCount} weak` : null,
@@ -35,9 +42,103 @@
       : `${auditState.healthyCount} of ${auditState.entryCount} entries are healthy. ${auditState.findingCount} findings need attention${attentionSummary ? ` - ${attentionSummary}.` : '.'}`,
   );
 
+  $effect(() => {
+    if (auditState.findings.length === 0) {
+      activeFindingKey = '';
+      return;
+    }
+
+    if (!auditState.findings.some((finding) => finding.key === activeFindingKey)) {
+      activeFindingKey = auditState.findings[0].key;
+    }
+  });
+
+  $effect(() => {
+    if (activeFindingKey) {
+      void scrollActiveFindingIntoView(activeFindingKey);
+    }
+  });
+
+  onMount(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      const key = event.key.toLowerCase();
+
+      if (event.repeat || event.altKey || event.metaKey || event.ctrlKey || isEditableTarget(event.target)) {
+        return;
+      }
+
+      if (key === 'arrowdown') {
+        event.preventDefault();
+        moveActiveFinding(1);
+        return;
+      }
+
+      if (key === 'arrowup') {
+        event.preventDefault();
+        moveActiveFinding(-1);
+        return;
+      }
+
+      if (key === 'home') {
+        event.preventDefault();
+        setActiveFindingAt(0);
+        return;
+      }
+
+      if (key === 'end') {
+        event.preventDefault();
+        setActiveFindingAt(auditState.findings.length - 1);
+        return;
+      }
+
+      if (key === 'enter') {
+        const active = auditState.findings.find((finding) => finding.key === activeFindingKey);
+
+        if (active) {
+          event.preventDefault();
+          openEntry(active.entry);
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  });
+
   function openEntry(entry: (typeof vaultState.entries)[number]) {
     vaultState.selectedEntry = entry;
     uiState.view = 'detail';
+  }
+
+  function moveActiveFinding(offset: number) {
+    if (auditState.findings.length === 0) {
+      return;
+    }
+
+    const currentIndex = Math.max(0, auditState.findings.findIndex((finding) => finding.key === activeFindingKey));
+    setActiveFindingAt(currentIndex + offset);
+  }
+
+  function setActiveFindingAt(index: number) {
+    const finding = auditState.findings[Math.max(0, Math.min(index, auditState.findings.length - 1))];
+
+    if (finding) {
+      activeFindingKey = finding.key;
+    }
+  }
+
+  async function scrollActiveFindingIntoView(findingKey: string) {
+    await tick();
+    const row = document.querySelector<HTMLElement>(`[data-audit-row-key="${CSS.escape(findingKey)}"]`);
+    const shouldMoveFocus =
+      document.activeElement instanceof HTMLElement &&
+      document.activeElement.closest('[data-audit-list]') !== null;
+
+    row?.scrollIntoView({ block: 'nearest' });
+
+    if (shouldMoveFocus) {
+      row?.focus({ preventScroll: true });
+    }
   }
 
   function countByTitle(title: AuditFindingTitle): number {
@@ -74,8 +175,7 @@
   }
 
   function findingMarker(finding: AuditFinding): string {
-    const index = auditState.findings.findIndex((candidate) => candidate.key === finding.key);
-    return `#${index + 1}`;
+    return `#${findingPositions.get(finding.key) ?? 0}`;
   }
 
   function findingTitle(title: keyof typeof AUDIT_FINDING_COPY): string {
@@ -148,10 +248,16 @@
     </div>
 
     {#if auditState.findingCount > 0}
-      <div class="entries audit__entries" role="list">
+      <div class="entries audit__entries" role="list" data-audit-list>
         {#each auditState.findings as finding (finding.key)}
           <div role="listitem">
-            <button type="button" class="row audit-row" onclick={() => openEntry(finding.entry)}>
+            <button
+              type="button"
+              class={activeFindingKey === finding.key ? 'row row--selected audit-row' : 'row audit-row'}
+              tabindex={activeFindingKey === finding.key ? 0 : -1}
+              data-audit-row-key={finding.key}
+              onclick={() => openEntry(finding.entry)}
+            >
               <div class="row__bullet">
                 <span class={bucketDotClass(finding.title)}></span>
               </div>

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -16,7 +16,7 @@
   const weakCount = $derived(countBySeverity('high'));
   const reusedCount = $derived(countByTitle('reused_password'));
   const agingCount = $derived(countByTitle('stale_entry'));
-  const reviewCount = $derived(Math.max(0, auditState.findingCount - weakCount - agingCount));
+  const reviewCount = $derived(Math.max(0, auditState.findingCount - weakCount - reusedCount - agingCount));
   const scoreColor = $derived(score >= 85 ? 'var(--vault)' : score >= 65 ? '#D7833F' : 'var(--accent)');
   const findingPositions = $derived(
     new Map(auditState.findings.map((finding, index) => [finding.key, index + 1] as const)),

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { AUDIT_FINDING_COPY, type AuditFinding, type AuditFindingTitle, type AuditSeverity } from '../../audit';
+  import { isEditableTarget, primaryModifierLabel, primaryModifierPressed, shortcutLabel } from '../../keyboard';
   import { getAuditState } from '../../stores/audit.svelte';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
@@ -14,6 +16,8 @@
   const agingCount = $derived(countByTitle('stale_entry'));
   const reviewCount = $derived(Math.max(0, auditState.findingCount - weakCount - agingCount));
   const scoreColor = $derived(score >= 85 ? 'var(--vault)' : score >= 65 ? '#D7833F' : 'var(--accent)');
+  const shortcutFindings = $derived(auditState.findings.slice(0, 9));
+  const modLabel = $derived(primaryModifierLabel());
   const attentionSummary = $derived.by(() => {
     const parts = [
       weakCount > 0 ? `${weakCount} weak` : null,
@@ -34,6 +38,32 @@
         : 'Move entries out of archive to include them in password health and vault hygiene.'
       : `${auditState.healthyCount} of ${auditState.entryCount} entries are healthy. ${auditState.findingCount} findings need attention${attentionSummary ? ` - ${attentionSummary}.` : '.'}`,
   );
+
+  onMount(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      const key = event.key.toLowerCase();
+
+      if (
+        event.repeat ||
+        event.altKey ||
+        isEditableTarget(event.target) ||
+        !primaryModifierPressed(event) ||
+        !/^[1-9]$/.test(key)
+      ) {
+        return;
+      }
+
+      const finding = shortcutFindings[Number(key) - 1];
+
+      if (finding) {
+        event.preventDefault();
+        openEntry(finding.entry);
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  });
 
   function openEntry(entry: (typeof vaultState.entries)[number]) {
     vaultState.selectedEntry = entry;
@@ -71,6 +101,11 @@
 
   function bucketLabel(title: AuditFindingTitle): string {
     return findingBucket(title);
+  }
+
+  function findingShortcut(finding: AuditFinding): string | undefined {
+    const index = shortcutFindings.findIndex((candidate) => candidate.key === finding.key);
+    return index === -1 ? undefined : shortcutLabel(modLabel, String(index + 1));
   }
 
   function findingTitle(title: keyof typeof AUDIT_FINDING_COPY): string {
@@ -154,6 +189,9 @@
                 <div class="row__title">{finding.entry.title}</div>
                 <div class="row__sub">{findingDetails(finding)}</div>
               </div>
+              {#if findingShortcut(finding)}
+                <Tag value={findingShortcut(finding)} />
+              {/if}
               <Tag class={bucketTagClass(finding.title)} value={bucketLabel(finding.title)} />
             </button>
           </div>

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { AUDIT_FINDING_COPY, type AuditFinding, type AuditFindingTitle, type AuditSeverity } from '../../audit';
-  import { isEditableTarget, primaryModifierLabel, primaryModifierPressed, shortcutLabel } from '../../keyboard';
   import { getAuditState } from '../../stores/audit.svelte';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
@@ -16,8 +14,6 @@
   const agingCount = $derived(countByTitle('stale_entry'));
   const reviewCount = $derived(Math.max(0, auditState.findingCount - weakCount - agingCount));
   const scoreColor = $derived(score >= 85 ? 'var(--vault)' : score >= 65 ? '#D7833F' : 'var(--accent)');
-  const shortcutFindings = $derived(auditState.findings.slice(0, 9));
-  const modLabel = $derived(primaryModifierLabel());
   const attentionSummary = $derived.by(() => {
     const parts = [
       weakCount > 0 ? `${weakCount} weak` : null,
@@ -38,32 +34,6 @@
         : 'Move entries out of archive to include them in password health and vault hygiene.'
       : `${auditState.healthyCount} of ${auditState.entryCount} entries are healthy. ${auditState.findingCount} findings need attention${attentionSummary ? ` - ${attentionSummary}.` : '.'}`,
   );
-
-  onMount(() => {
-    function handleKeydown(event: KeyboardEvent) {
-      const key = event.key.toLowerCase();
-
-      if (
-        event.repeat ||
-        event.altKey ||
-        isEditableTarget(event.target) ||
-        !primaryModifierPressed(event) ||
-        !/^[1-9]$/.test(key)
-      ) {
-        return;
-      }
-
-      const finding = shortcutFindings[Number(key) - 1];
-
-      if (finding) {
-        event.preventDefault();
-        openEntry(finding.entry);
-      }
-    }
-
-    window.addEventListener('keydown', handleKeydown);
-    return () => window.removeEventListener('keydown', handleKeydown);
-  });
 
   function openEntry(entry: (typeof vaultState.entries)[number]) {
     vaultState.selectedEntry = entry;
@@ -103,9 +73,9 @@
     return findingBucket(title);
   }
 
-  function findingShortcut(finding: AuditFinding): string | undefined {
-    const index = shortcutFindings.findIndex((candidate) => candidate.key === finding.key);
-    return index === -1 ? undefined : shortcutLabel(modLabel, String(index + 1));
+  function findingMarker(finding: AuditFinding): string {
+    const index = auditState.findings.findIndex((candidate) => candidate.key === finding.key);
+    return `#${index + 1}`;
   }
 
   function findingTitle(title: keyof typeof AUDIT_FINDING_COPY): string {
@@ -190,9 +160,7 @@
                 <div class="row__sub">{findingDetails(finding)}</div>
               </div>
               <div class="audit-row__tags">
-                {#if findingShortcut(finding)}
-                  <Tag value={findingShortcut(finding)} />
-                {/if}
+                <Tag value={findingMarker(finding)} />
                 <Tag class={bucketTagClass(finding.title)} value={bucketLabel(finding.title)} />
               </div>
             </button>

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -189,10 +189,12 @@
                 <div class="row__title">{finding.entry.title}</div>
                 <div class="row__sub">{findingDetails(finding)}</div>
               </div>
-              {#if findingShortcut(finding)}
-                <Tag value={findingShortcut(finding)} />
-              {/if}
-              <Tag class={bucketTagClass(finding.title)} value={bucketLabel(finding.title)} />
+              <div class="audit-row__tags">
+                {#if findingShortcut(finding)}
+                  <Tag value={findingShortcut(finding)} />
+                {/if}
+                <Tag class={bucketTagClass(finding.title)} value={bucketLabel(finding.title)} />
+              </div>
             </button>
           </div>
         {/each}

--- a/apps/desktop/src/lib/components/chrome/Tabs.svelte
+++ b/apps/desktop/src/lib/components/chrome/Tabs.svelte
@@ -23,13 +23,50 @@
   }>();
 
   const classes = $derived(['tabs', className].filter(Boolean).join(' '));
+
+  let tablistElement = $state<HTMLDivElement | null>(null);
+
+  function handleKeydown(event: KeyboardEvent) {
+    const enabledItems: TabItem[] = items.filter((item: TabItem) => !item.disabled);
+
+    if (enabledItems.length === 0) {
+      return;
+    }
+
+    const currentIndex = Math.max(0, enabledItems.findIndex((item) => item.key === active));
+    let nextIndex = currentIndex;
+
+    if (event.key === 'ArrowRight') {
+      nextIndex = (currentIndex + 1) % enabledItems.length;
+    } else if (event.key === 'ArrowLeft') {
+      nextIndex = (currentIndex + enabledItems.length - 1) % enabledItems.length;
+    } else if (event.key === 'Home') {
+      nextIndex = 0;
+    } else if (event.key === 'End') {
+      nextIndex = enabledItems.length - 1;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    const next = enabledItems[nextIndex];
+    onselect?.(next.key);
+    focusTab(next.key);
+  }
+
+  function focusTab(key: string) {
+    window.requestAnimationFrame(() => {
+      tablistElement?.querySelector<HTMLButtonElement>(`button[data-tab-key="${key}"]`)?.focus();
+    });
+  }
 </script>
 
-<div {...rest} class={classes} role="tablist" aria-label={label}>
+<div bind:this={tablistElement} {...rest} class={classes} role="tablist" aria-label={label} onkeydown={handleKeydown}>
   {#each items as item (item.key)}
     <button
       type="button"
       role="tab"
+      data-tab-key={item.key}
       class={active === item.key ? 'tab tab--active' : 'tab'}
       aria-selected={active === item.key}
       disabled={item.disabled}

--- a/apps/desktop/src/lib/components/detail/EntryDetail.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryDetail.svelte
@@ -168,7 +168,7 @@
     {/if}
 
     <div class="detail-body">
-      <NotePanel notes={entry.notes} tags={entry.tags} />
+      <NotePanel notes={entry.notes} tags={entry.tags} scope={entry.collection} />
       <FieldStack {entry} />
       <MetricStrip {entry} />
     </div>

--- a/apps/desktop/src/lib/components/detail/EntryDetail.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryDetail.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { deleteEntry, type EntryDto } from '../../ipc';
+  import { isEditableTarget } from '../../keyboard';
   import { uiState } from '../../stores/ui.svelte';
   import { clearEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
-  import { Button, IconButton, Tag } from '../primitives';
+  import { Button, IconButton, Kbd } from '../primitives';
   import FieldStack from './FieldStack.svelte';
   import MetricStrip from './MetricStrip.svelte';
   import NotePanel from './NotePanel.svelte';
@@ -12,6 +14,45 @@
   let confirmDeleteOpen = $state(false);
   let deleteBusy = $state(false);
   let deleteError = $state('');
+
+  onMount(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey || isEditableTarget(event.target)) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+
+      if (confirmDeleteOpen) {
+        if (key === 'escape') {
+          event.preventDefault();
+          cancelDelete();
+        }
+
+        return;
+      }
+
+      if (key === 'escape') {
+        event.preventDefault();
+        backToList();
+        return;
+      }
+
+      if (key === 'e') {
+        event.preventDefault();
+        editEntry();
+        return;
+      }
+
+      if (key === 'd') {
+        event.preventDefault();
+        requestDelete();
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  });
 
   function backToList() {
     uiState.view = 'list';
@@ -82,7 +123,10 @@
         </div>
         <h1 id="entry-detail-title" class="detail__title">{entry.title}<em>.</em></h1>
         <div class="detail__meta mono">
-          <Tag value="⌘1" />
+          <span><Kbd value="Esc" /> back</span>
+          <span><Kbd value="U" /> user</span>
+          <span><Kbd value="C" /> password</span>
+          <span><Kbd value="R" /> reveal</span>
           <span>collection · <b>{entry.collection ?? 'none'}</b></span>
           <span>id · <b>{entry.id}</b></span>
           <span>modified · <b>{modified(entry)}</b></span>
@@ -93,6 +137,7 @@
         <Button variant="ghost" size="sm" onclick={editEntry}>
           <Icon name="edit" size={12} />
           edit
+          <Kbd value="E" />
         </Button>
         <IconButton label={`Delete ${entry.title}`} onclick={requestDelete} disabled={deleteBusy}>
           <Icon name="trash" size={13} />

--- a/apps/desktop/src/lib/components/detail/EntryDetail.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryDetail.svelte
@@ -5,7 +5,7 @@
   import { uiState } from '../../stores/ui.svelte';
   import { clearEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
-  import { Button, IconButton, Kbd } from '../primitives';
+  import { Button, IconButton } from '../primitives';
   import FieldStack from './FieldStack.svelte';
   import MetricStrip from './MetricStrip.svelte';
   import NotePanel from './NotePanel.svelte';
@@ -123,10 +123,6 @@
         </div>
         <h1 id="entry-detail-title" class="detail__title">{entry.title}<em>.</em></h1>
         <div class="detail__meta mono">
-          <span><Kbd value="Esc" /> back</span>
-          <span><Kbd value="U" /> user</span>
-          <span><Kbd value="C" /> password</span>
-          <span><Kbd value="R" /> reveal</span>
           <span>collection · <b>{entry.collection ?? 'none'}</b></span>
           <span>id · <b>{entry.id}</b></span>
           <span>modified · <b>{modified(entry)}</b></span>
@@ -134,10 +130,9 @@
         </div>
       </div>
       <div class="detail__actions">
-        <Button variant="ghost" size="sm" onclick={editEntry}>
+        <Button variant="ghost" size="sm" onclick={editEntry} aria-keyshortcuts="E">
           <Icon name="edit" size={12} />
           edit
-          <Kbd value="E" />
         </Button>
         <IconButton label={`Delete ${entry.title}`} onclick={requestDelete} disabled={deleteBusy}>
           <Icon name="trash" size={13} />

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { createEntry, generatePassword, updateEntry, type EntryDto } from '../../ipc';
+  import { primaryModifierLabel, shortcutLabel } from '../../keyboard';
   import { uiState } from '../../stores/ui.svelte';
   import { clearEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
@@ -44,6 +45,7 @@
   const entropyBits = $derived(estimateEntropyBits(password));
   const entropyFilled = $derived(password ? Math.max(1, Math.min(16, Math.round(entropyBits / 8))) : 0);
   const entropyStrength = $derived(passwordStrength(password, entropyBits));
+  const saveShortcut = $derived(shortcutLabel(primaryModifierLabel(), '↵'));
 
   $effect(() => {
     const entry = editingEntry;
@@ -578,7 +580,7 @@
       <Button variant="primary" type="submit" disabled={!canSubmit}>
         <Icon name={mode === 'edit' ? 'edit' : 'plus'} size={12} />
         {busy ? 'saving' : submitText}
-        <Kbd value="⌘↵" />
+        <Kbd value={saveShortcut} />
       </Button>
     </div>
   </form>

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { createEntry, generatePassword, updateEntry, type EntryDto } from '../../ipc';
-  import { primaryModifierLabel, shortcutLabel } from '../../keyboard';
+  import { isEditableTarget, primaryModifierLabel, shortcutLabel } from '../../keyboard';
   import { uiState } from '../../stores/ui.svelte';
   import { clearEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
@@ -75,6 +75,10 @@
   onMount(() => {
     function handleKeydown(event: KeyboardEvent) {
       if (event.defaultPrevented) {
+        return;
+      }
+
+      if (isEditableTarget(event.target)) {
         return;
       }
 

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { createEntry, generatePassword, updateEntry, type EntryDto } from '../../ipc';
-  import { isEditableTarget, primaryModifierLabel, shortcutLabel } from '../../keyboard';
+  import { isEditableTarget } from '../../keyboard';
   import { uiState } from '../../stores/ui.svelte';
   import { clearEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
-  import { Button, Entropy, IconButton, Kbd } from '../primitives';
+  import { Button, Entropy, IconButton } from '../primitives';
 
   const editingEntry = $derived(vaultState.selectedEntry);
   const mode = $derived(editingEntry ? 'edit' : 'create');
@@ -45,8 +45,6 @@
   const entropyBits = $derived(estimateEntropyBits(password));
   const entropyFilled = $derived(password ? Math.max(1, Math.min(16, Math.round(entropyBits / 8))) : 0);
   const entropyStrength = $derived(passwordStrength(password, entropyBits));
-  const saveShortcut = $derived(shortcutLabel(primaryModifierLabel(), '↵'));
-
   $effect(() => {
     const entry = editingEntry;
     const draft = entry ? null : vaultState.entryDraft;
@@ -576,15 +574,13 @@
     {/if}
 
     <div class="form__actions">
-      <Button variant="bare" onclick={cancel} disabled={busy}>
+      <Button variant="bare" onclick={cancel} disabled={busy} aria-keyshortcuts="Escape">
         cancel
-        <Kbd value="esc" />
       </Button>
       <span class="form__spacer"></span>
-      <Button variant="primary" type="submit" disabled={!canSubmit}>
+      <Button variant="primary" type="submit" disabled={!canSubmit} aria-keyshortcuts="Meta+Enter Control+Enter">
         <Icon name={mode === 'edit' ? 'edit' : 'plus'} size={12} />
         {busy ? 'saving' : submitText}
-        <Kbd value={saveShortcut} />
       </Button>
     </div>
   </form>

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import { getEntry, type EntryDto } from '../../ipc';
   import { COPY_CONFIRMATION_MS, writeConfiguredClipboardText } from '../../clipboard';
+  import { isEditableTarget } from '../../keyboard';
   import { Icon } from '../icons';
   import { Entropy, IconButton } from '../primitives';
 
@@ -154,19 +155,6 @@
     }
   }
 
-  function isEditableTarget(target: EventTarget | null) {
-    if (!(target instanceof HTMLElement)) {
-      return false;
-    }
-
-    return (
-      target instanceof HTMLInputElement ||
-      target instanceof HTMLTextAreaElement ||
-      target instanceof HTMLSelectElement ||
-      target.isContentEditable
-    );
-  }
-
   function formatInlineSecret(value: string): string {
     return Array.from(value)
       .map((character) => {
@@ -223,6 +211,7 @@
         label={copied === 'username' ? 'Username copied' : `Copy ${entry.title} username`}
         variant={copied === 'username' ? 'accent' : 'default'}
         disabled={!entry.username.trim()}
+        aria-keyshortcuts="U"
         onclick={() => copyValue('username', entry.username)}
       >
         {#if copied === 'username'}
@@ -242,6 +231,7 @@
         label={passwordRevealed ? `Hide ${entry.title} password` : `Reveal ${entry.title} password`}
         variant={passwordRevealed ? 'accent' : 'default'}
         disabled={passwordBusy}
+        aria-keyshortcuts="R"
         onclick={togglePasswordReveal}
       >
         <Icon name="eye" size={13} />
@@ -250,6 +240,7 @@
         variant={copied === 'password' ? 'accent' : 'default'}
         label={copied === 'password' ? 'Password copied' : `Copy ${entry.title} password`}
         disabled={passwordBusy}
+        aria-keyshortcuts="C"
         onclick={copyPassword}
       >
         {#if copied === 'password'}

--- a/apps/desktop/src/lib/components/detail/MetricStrip.svelte
+++ b/apps/desktop/src/lib/components/detail/MetricStrip.svelte
@@ -44,7 +44,7 @@
     <div class="strip__v">{created}</div>
   </div>
   <div class="strip__cell">
-    <div class="strip__k">last_used</div>
+    <div class="strip__k">last_modified</div>
     <div class="strip__v">{updated}</div>
   </div>
   <div class="strip__cell">

--- a/apps/desktop/src/lib/components/detail/MetricStrip.svelte
+++ b/apps/desktop/src/lib/components/detail/MetricStrip.svelte
@@ -49,6 +49,6 @@
   </div>
   <div class="strip__cell">
     <div class="strip__k">revisions</div>
-    <div class="strip__v strip__v--accent">01</div>
+    <div class="strip__v">--</div>
   </div>
 </div>

--- a/apps/desktop/src/lib/components/detail/NotePanel.svelte
+++ b/apps/desktop/src/lib/components/detail/NotePanel.svelte
@@ -4,28 +4,42 @@
   let {
     notes,
     tags = [],
+    scope = 'vault',
   } = $props<{
     notes?: string | null;
     tags?: string[];
+    scope?: string | null;
   }>();
 
   const body = $derived(
     notes?.trim() ||
       'No plain_text notes are stored for this entry yet.\n\nUse edit to add recovery instructions, account context, or rotation notes.',
   );
-  const visibleTags = $derived(tags.filter((tag: string) => tag.trim().length > 0).slice(0, 4));
+  const scopeLabel = $derived(`scope · ${normalizeScope(scope)}`);
+  const visibleTags = $derived(
+    tags
+      .map((tag: string) => formatTag(tag))
+      .filter((tag: string) => tag.length > 0)
+      .slice(0, 4),
+  );
+
+  function normalizeScope(value: string | null | undefined): string {
+    return value?.trim().toLowerCase() || 'vault';
+  }
+
+  function formatTag(value: string): string {
+    const tag = value.trim().replace(/^#+/, '');
+    return tag ? `#${tag.toUpperCase()}` : '';
+  }
 </script>
 
 <div class="note-panel">
   <div class="note-panel__head">notes · plain_text</div>
   <div class="note-panel__body">{body}</div>
   <div class="note-panel__tags">
-    {#if visibleTags.length > 0}
-      {#each visibleTags as tag}
-        <Tag variant="paper" value={tag} bracketed={false} />
-      {/each}
-    {:else}
-      <Tag variant="paper" value="scope · vault" bracketed={false} />
-    {/if}
+    <Tag variant="paper" value={scopeLabel} bracketed={false} />
+    {#each visibleTags as tag}
+      <Tag variant="paper" value={tag} bracketed={false} />
+    {/each}
   </div>
 </div>

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -2,10 +2,11 @@
   import { onMount } from 'svelte';
   import { COPY_CONFIRMATION_MS, writeConfiguredClipboardText } from '../../clipboard';
   import { generatePassword, type GeneratedPassword } from '../../ipc';
+  import { isEditableTarget } from '../../keyboard';
   import { uiState } from '../../stores/ui.svelte';
   import { clearEntryDraft, setEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
-  import { Button, Entropy, IconButton, Slider, Toggle } from '../primitives';
+  import { Button, Entropy, IconButton, Kbd, Slider, Toggle } from '../primitives';
 
   let length = $state(24);
   let uppercase = $state(true);
@@ -32,7 +33,42 @@
   );
 
   onMount(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey || isEditableTarget(event.target)) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+
+      if (key === 'r' && !busy && hasCharacterSet) {
+        event.preventDefault();
+        void generate();
+        return;
+      }
+
+      if (key === 'v') {
+        event.preventDefault();
+        toggleReveal();
+        return;
+      }
+
+      if (key === 'c') {
+        event.preventDefault();
+        void copyGenerated();
+        return;
+      }
+
+      if (key === 'u') {
+        event.preventDefault();
+        useInNewEntry();
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown);
+
     return () => {
+      window.removeEventListener('keydown', handleKeydown);
+
       if (copyTimer) {
         clearTimeout(copyTimer);
       }
@@ -203,11 +239,13 @@
         <Button variant="ghost" size="sm" onclick={generate} disabled={busy || !hasCharacterSet}>
           <Icon name="refresh" size={12} />
           {busy ? 'generating' : generated ? 'regenerate' : 'generate'}
+          <Kbd value="R" />
         </Button>
         <IconButton
           label={isRevealed ? 'Hide generated password' : 'Reveal generated password'}
           onclick={toggleReveal}
           disabled={!generated?.password}
+          aria-keyshortcuts="V"
         >
           <Icon name="eye" size={13} />
         </IconButton>
@@ -217,6 +255,7 @@
           {:else}
             <Icon name="copy" size={12} />
             copy
+            <Kbd value="C" />
           {/if}
         </Button>
       </div>
@@ -309,6 +348,7 @@
       <Button variant="primary" onclick={useInNewEntry} disabled={!generated?.password}>
         <Icon name="plus" size={11} sw={2} />
         use in new entry
+        <Kbd value="U" />
       </Button>
       <Button variant="bare" onclick={openBlankEntry}>blank entry</Button>
     </div>

--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -6,7 +6,7 @@
   import { uiState } from '../../stores/ui.svelte';
   import { clearEntryDraft, setEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
-  import { Button, Entropy, IconButton, Kbd, Slider, Toggle } from '../primitives';
+  import { Button, Entropy, IconButton, Slider, Toggle } from '../primitives';
 
   let length = $state(24);
   let uppercase = $state(true);
@@ -236,10 +236,15 @@
       <div class="gen__pw-foot">
         <Entropy filled={entropyFilled} bits={entropyBits} strength={strengthLabel} />
         <span class="status__spacer"></span>
-        <Button variant="ghost" size="sm" onclick={generate} disabled={busy || !hasCharacterSet}>
+        <Button
+          variant="ghost"
+          size="sm"
+          onclick={generate}
+          disabled={busy || !hasCharacterSet}
+          aria-keyshortcuts="R"
+        >
           <Icon name="refresh" size={12} />
           {busy ? 'generating' : generated ? 'regenerate' : 'generate'}
-          <Kbd value="R" />
         </Button>
         <IconButton
           label={isRevealed ? 'Hide generated password' : 'Reveal generated password'}
@@ -249,13 +254,18 @@
         >
           <Icon name="eye" size={13} />
         </IconButton>
-        <Button variant={copied ? 'vault' : 'primary'} size="sm" onclick={copyGenerated} disabled={!generated?.password}>
+        <Button
+          variant={copied ? 'vault' : 'primary'}
+          size="sm"
+          onclick={copyGenerated}
+          disabled={!generated?.password}
+          aria-keyshortcuts="C"
+        >
           {#if copied}
             copied
           {:else}
             <Icon name="copy" size={12} />
             copy
-            <Kbd value="C" />
           {/if}
         </Button>
       </div>
@@ -345,10 +355,9 @@
     </div>
 
     <div class="gen__actions">
-      <Button variant="primary" onclick={useInNewEntry} disabled={!generated?.password}>
+      <Button variant="primary" onclick={useInNewEntry} disabled={!generated?.password} aria-keyshortcuts="U">
         <Icon name="plus" size={11} sw={2} />
         use in new entry
-        <Kbd value="U" />
       </Button>
       <Button variant="bare" onclick={openBlankEntry}>blank entry</Button>
     </div>

--- a/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { Settings } from '../../ipc';
-  import { primaryModifierLabel, shortcutLabel } from '../../keyboard';
+  import {
+    primaryModifierAriaKey,
+    primaryModifierLabel,
+    shortcutAriaLabel,
+    shortcutLabel,
+  } from '../../keyboard';
   import {
     RELEASE_AUTO_LOCK_OPTIONS,
     RELEASE_CLIPBOARD_CLEAR_OPTIONS,
@@ -31,13 +36,15 @@
   const autoLockValue = $derived(autoLockEnabled ? String(autoLockMinutes) : 'never');
   const clipboardValue = $derived(String(clipboardSeconds));
   const modLabel = $derived(primaryModifierLabel());
+  const lockShortcut = $derived(shortcutLabel(modLabel, 'Shift', 'L'));
+  const lockShortcutAria = $derived(shortcutAriaLabel(primaryModifierAriaKey(), 'Shift', 'L'));
   const shortcutGroups = $derived([
     {
       title: 'global',
       items: [
         { keys: [shortcutLabel(modLabel, '1-4')], label: 'switch tabs' },
         { keys: [shortcutLabel(modLabel, 'F')], label: 'focus search' },
-        { keys: [shortcutLabel(modLabel, 'Shift', 'L')], label: 'lock now' },
+        { keys: [lockShortcut], label: 'lock now' },
         { keys: [shortcutLabel(modLabel, 'O')], label: 'open another vault' },
         { keys: ['N'], label: 'new entry' },
         { keys: ['G'], label: 'generator' },
@@ -340,9 +347,9 @@
       <div class="set-row">
         <div class="set-row__k">lock now<small>seal the vault immediately</small></div>
         <div class="set-row__v">
-          <Button variant="ghost" onclick={lockNow} disabled={!loaded || busy} aria-keyshortcuts="Meta+Shift+L Control+Shift+L">
+          <Button variant="ghost" onclick={lockNow} disabled={!loaded || busy} aria-keyshortcuts={lockShortcutAria}>
             lock now
-            <Kbd value={shortcutLabel(modLabel, 'Shift', 'L')} />
+            <Kbd value={lockShortcut} />
           </Button>
         </div>
       </div>

--- a/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
@@ -350,7 +350,6 @@
         <div class="set-row__v">
           <Button variant="ghost" onclick={lockNow} disabled={busy} aria-keyshortcuts={lockShortcutAria}>
             lock now
-            <Kbd value={lockShortcut} />
           </Button>
         </div>
       </div>

--- a/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
@@ -54,7 +54,6 @@
     {
       title: 'vault and audit',
       items: [
-        { keys: [shortcutLabel(modLabel, '1-9')], label: 'open visible row' },
         { keys: ['↵'], label: 'open focused row' },
       ],
     },

--- a/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { Settings } from '../../ipc';
+  import { primaryModifierLabel, shortcutLabel } from '../../keyboard';
   import {
     RELEASE_AUTO_LOCK_OPTIONS,
     RELEASE_CLIPBOARD_CLEAR_OPTIONS,
@@ -16,7 +17,7 @@
   } from '../../stores/settings.svelte';
   import { uiState, type ThemeName } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
-  import { Button, Segmented, Slider, Toggle } from '../primitives';
+  import { Button, Kbd, Segmented, Slider, Toggle } from '../primitives';
 
   let autoLockEnabled = $state(true);
   let autoLockMinutes = $state<number>(SETTINGS_LIMITS.autoLockTimeoutMinutes.defaultValue);
@@ -29,6 +30,48 @@
 
   const autoLockValue = $derived(autoLockEnabled ? String(autoLockMinutes) : 'never');
   const clipboardValue = $derived(String(clipboardSeconds));
+  const modLabel = $derived(primaryModifierLabel());
+  const shortcutGroups = $derived([
+    {
+      title: 'global',
+      items: [
+        { keys: [shortcutLabel(modLabel, '1-4')], label: 'switch tabs' },
+        { keys: [shortcutLabel(modLabel, 'F')], label: 'focus search' },
+        { keys: [shortcutLabel(modLabel, 'Shift', 'L')], label: 'lock now' },
+        { keys: [shortcutLabel(modLabel, 'O')], label: 'open another vault' },
+        { keys: ['N'], label: 'new entry' },
+        { keys: ['G'], label: 'generator' },
+        { keys: ['Esc'], label: 'back to vault' },
+      ],
+    },
+    {
+      title: 'vault and audit',
+      items: [
+        { keys: [shortcutLabel(modLabel, '1-9')], label: 'open visible row' },
+        { keys: ['↵'], label: 'open focused row' },
+      ],
+    },
+    {
+      title: 'entry detail',
+      items: [
+        { keys: ['E'], label: 'edit entry' },
+        { keys: ['D'], label: 'delete entry' },
+        { keys: ['U'], label: 'copy username' },
+        { keys: ['C'], label: 'copy password' },
+        { keys: ['R'], label: 'reveal password' },
+      ],
+    },
+    {
+      title: 'forms and generator',
+      items: [
+        { keys: [shortcutLabel(modLabel, '↵')], label: 'save entry' },
+        { keys: ['R'], label: 'generate password' },
+        { keys: ['V'], label: 'reveal generated password' },
+        { keys: ['C'], label: 'copy generated password' },
+        { keys: ['U'], label: 'use in new entry' },
+      ],
+    },
+  ]);
 
   onMount(() => {
     if (runtimeSettings.loaded) {
@@ -296,7 +339,34 @@
     </div>
 
     <div class="settings__actions">
-      <Button variant="ghost" onclick={lockNow} disabled={!loaded || busy} aria-keyshortcuts="Meta+Shift+L Control+Shift+L">lock now</Button>
+      <Button variant="ghost" onclick={lockNow} disabled={!loaded || busy} aria-keyshortcuts="Meta+Shift+L Control+Shift+L">
+        lock now
+        <Kbd value={shortcutLabel(modLabel, 'Shift', 'L')} />
+      </Button>
+    </div>
+
+    <div class="set-group">
+      <div class="set-group__title">keyboard</div>
+
+      <div class="shortcut-ref">
+        {#each shortcutGroups as group}
+          <section class="shortcut-ref__group" aria-label={`${group.title} shortcuts`}>
+            <div class="shortcut-ref__title">{group.title}</div>
+            <div class="shortcut-ref__items">
+              {#each group.items as item}
+                <div class="shortcut-ref__item">
+                  <span>{item.label}</span>
+                  <span class="shortcut-ref__keys">
+                    {#each item.keys as key}
+                      <Kbd value={key} />
+                    {/each}
+                  </span>
+                </div>
+              {/each}
+            </div>
+          </section>
+        {/each}
+      </div>
     </div>
 
     {#if errorMessage}

--- a/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
@@ -54,7 +54,9 @@
     {
       title: 'vault and audit',
       items: [
-        { keys: ['↵'], label: 'open focused row' },
+        { keys: ['↑', '↓'], label: 'move active row' },
+        { keys: ['Home', 'End'], label: 'jump list edges' },
+        { keys: ['↵'], label: 'open active row' },
       ],
     },
     {
@@ -346,7 +348,7 @@
       <div class="set-row">
         <div class="set-row__k">lock now<small>seal the vault immediately</small></div>
         <div class="set-row__v">
-          <Button variant="ghost" onclick={lockNow} disabled={!loaded || busy} aria-keyshortcuts={lockShortcutAria}>
+          <Button variant="ghost" onclick={lockNow} disabled={busy} aria-keyshortcuts={lockShortcutAria}>
             lock now
             <Kbd value={lockShortcut} />
           </Button>

--- a/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
@@ -336,13 +336,16 @@
           {/if}
         </div>
       </div>
-    </div>
 
-    <div class="settings__actions">
-      <Button variant="ghost" onclick={lockNow} disabled={!loaded || busy} aria-keyshortcuts="Meta+Shift+L Control+Shift+L">
-        lock now
-        <Kbd value={shortcutLabel(modLabel, 'Shift', 'L')} />
-      </Button>
+      <div class="set-row">
+        <div class="set-row__k">lock now<small>seal the vault immediately</small></div>
+        <div class="set-row__v">
+          <Button variant="ghost" onclick={lockNow} disabled={!loaded || busy} aria-keyshortcuts="Meta+Shift+L Control+Shift+L">
+            lock now
+            <Kbd value={shortcutLabel(modLabel, 'Shift', 'L')} />
+          </Button>
+        </div>
+      </div>
     </div>
 
     <div class="set-group">

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import type { EntryDto } from '../../ipc';
   import { isEditableTarget, primaryModifierLabel, primaryModifierPressed, shortcutLabel } from '../../keyboard';
   import { uiState } from '../../stores/ui.svelte';
@@ -18,11 +18,17 @@
     entries: EntryDto[];
   }
 
+  interface EntryRowModel {
+    key: string;
+    entry: EntryDto;
+  }
+
   let selectedFilter = $state<FilterKey>('all');
   let selectedTag = $state<string | null>(null);
   let searchFocused = $state(true);
   let searchFocusToken = $state(0);
   let syncAcknowledged = $state(false);
+  let activeRowKey = $state('');
   let syncAckTimer: ReturnType<typeof setTimeout> | null = null;
 
   const sortedEntries = $derived([...vaultState.entries].sort(compareByUpdatedAt));
@@ -39,6 +45,7 @@
     vaultState.searchQuery.trim().length > 0 || selectedTag !== null || selectedFilter !== 'all',
   );
   const sections = $derived(buildSections(filteredEntries, selectedFilter, recentIds));
+  const visibleRows = $derived(flattenRows(sections));
   const shortcutEntries = $derived(entriesForShortcuts(sections, hasScopedResults).slice(0, 9));
   const modLabel = $derived(primaryModifierLabel());
   const filters = $derived<FilterItem[]>([
@@ -55,6 +62,23 @@
   const sealedAt = $derived(formatTimestamp(vaultState.lastSaved));
   const emptyState = $derived(describeEmptyState(vaultState.entries.length));
 
+  $effect(() => {
+    if (visibleRows.length === 0) {
+      activeRowKey = '';
+      return;
+    }
+
+    if (!visibleRows.some((row) => row.key === activeRowKey)) {
+      activeRowKey = visibleRows[0].key;
+    }
+  });
+
+  $effect(() => {
+    if (activeRowKey) {
+      void scrollActiveRowIntoView(activeRowKey);
+    }
+  });
+
   onMount(() => {
     function handleKeydown(event: KeyboardEvent) {
       const key = event.key.toLowerCase();
@@ -70,6 +94,42 @@
         return;
       }
 
+      if (event.metaKey || event.ctrlKey) {
+        return;
+      }
+
+      if (key === 'arrowdown') {
+        event.preventDefault();
+        moveActiveRow(1);
+        return;
+      }
+
+      if (key === 'arrowup') {
+        event.preventDefault();
+        moveActiveRow(-1);
+        return;
+      }
+
+      if (key === 'home') {
+        event.preventDefault();
+        setActiveRowAt(0);
+        return;
+      }
+
+      if (key === 'end') {
+        event.preventDefault();
+        setActiveRowAt(visibleRows.length - 1);
+        return;
+      }
+
+      if (key === 'enter') {
+        const active = visibleRows.find((row) => row.key === activeRowKey);
+
+        if (active) {
+          event.preventDefault();
+          selectEntry(active.entry);
+        }
+      }
     }
 
     window.addEventListener('keydown', handleKeydown);
@@ -147,6 +207,37 @@
     searchFocusToken += 1;
   }
 
+  function moveActiveRow(offset: number) {
+    if (visibleRows.length === 0) {
+      return;
+    }
+
+    const currentIndex = Math.max(0, visibleRows.findIndex((row) => row.key === activeRowKey));
+    setActiveRowAt(currentIndex + offset);
+  }
+
+  function setActiveRowAt(index: number) {
+    const row = visibleRows[Math.max(0, Math.min(index, visibleRows.length - 1))];
+
+    if (row) {
+      activeRowKey = row.key;
+    }
+  }
+
+  async function scrollActiveRowIntoView(rowKey: string) {
+    await tick();
+    const row = document.querySelector<HTMLElement>(`[data-entry-row-key="${CSS.escape(rowKey)}"]`);
+    const shouldMoveFocus =
+      document.activeElement instanceof HTMLElement &&
+      document.activeElement.closest('[data-entry-list]') !== null;
+
+    row?.scrollIntoView({ block: 'nearest' });
+
+    if (shouldMoveFocus) {
+      row?.focus({ preventScroll: true });
+    }
+  }
+
   function matchesQuery(entry: EntryDto): boolean {
     const query = vaultState.searchQuery.trim().toLowerCase();
 
@@ -221,6 +312,10 @@
   }
 
   function shortcutFor(section: EntrySection, index: number): string | undefined {
+    if (!hasScopedResults && section.key !== 'recent') {
+      return undefined;
+    }
+
     const shortcutIndex = shortcutEntries.findIndex((entry) => entry.id === section.entries[index]?.id);
 
     if (shortcutIndex === -1) {
@@ -228,6 +323,19 @@
     }
 
     return `#${shortcutIndex + 1}`;
+  }
+
+  function rowKey(section: EntrySection, index: number): string {
+    return `${section.key}:${section.entries[index]?.id ?? index}`;
+  }
+
+  function flattenRows(nextSections: EntrySection[]): EntryRowModel[] {
+    return nextSections.flatMap((section) =>
+      section.entries.map((entry, index) => ({
+        key: rowKey(section, index),
+        entry,
+      })),
+    );
   }
 
   function entriesForShortcuts(sections: EntrySection[], scoped: boolean): EntryDto[] {
@@ -368,7 +476,7 @@
       onclear={clearScopedFilters}
     />
 
-    <div class="entries" role="listbox" aria-label="Vault entries">
+    <div class="entries" role="listbox" aria-label="Vault entries" data-entry-list>
       {#if hasScopedResults}
         <div class="entries__active">
           <span class="entries__active-k mono">active</span>
@@ -431,9 +539,11 @@
             <span class="entries__count">{section.entries.length.toString().padStart(2, '0')}</span>
           </div>
           {#each section.entries as entry, index (entry.id)}
+            {@const currentRowKey = rowKey(section, index)}
             <EntryRow
               {entry}
-              selected={vaultState.selectedEntry?.id === entry.id}
+              rowKey={currentRowKey}
+              selected={activeRowKey === currentRowKey}
               shortcut={shortcutFor(section, index)}
               onselect={selectEntry}
             />

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { EntryDto } from '../../ipc';
+  import { isEditableTarget, primaryModifierLabel, primaryModifierPressed, shortcutLabel } from '../../keyboard';
   import { uiState } from '../../stores/ui.svelte';
   import { clearEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
@@ -34,7 +35,12 @@
         matchesQuery(entry),
     ),
   );
+  const hasScopedResults = $derived(
+    vaultState.searchQuery.trim().length > 0 || selectedTag !== null || selectedFilter !== 'all',
+  );
   const sections = $derived(buildSections(filteredEntries, selectedFilter, recentIds));
+  const shortcutEntries = $derived(entriesForShortcuts(sections, hasScopedResults).slice(0, 9));
+  const modLabel = $derived(primaryModifierLabel());
   const filters = $derived<FilterItem[]>([
     { key: 'all', label: 'all', count: vaultState.entries.length },
     { key: 'recent', label: 'recent', count: recentIds.size },
@@ -47,16 +53,30 @@
   const tags = $derived(deriveTags(vaultState.entries));
   const entropyScore = $derived(vaultState.entries.length > 0 ? '98.2%' : '0.0%');
   const sealedAt = $derived(formatTimestamp(vaultState.lastSaved));
-  const hasScopedResults = $derived(
-    vaultState.searchQuery.trim().length > 0 || selectedTag !== null || selectedFilter !== 'all',
-  );
   const emptyState = $derived(describeEmptyState(vaultState.entries.length));
 
   onMount(() => {
     function handleKeydown(event: KeyboardEvent) {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'f') {
+      const key = event.key.toLowerCase();
+      const modKey = primaryModifierPressed(event);
+
+      if (event.repeat || event.altKey || isEditableTarget(event.target)) {
+        return;
+      }
+
+      if (modKey && key === 'f') {
         event.preventDefault();
         focusSearch();
+        return;
+      }
+
+      if (modKey && /^[1-9]$/.test(key)) {
+        const entry = shortcutEntries[Number(key) - 1];
+
+        if (entry) {
+          event.preventDefault();
+          selectEntry(entry);
+        }
       }
     }
 
@@ -209,15 +229,21 @@
   }
 
   function shortcutFor(section: EntrySection, index: number): string | undefined {
-    if (index >= 9) {
+    const shortcutIndex = shortcutEntries.findIndex((entry) => entry.id === section.entries[index]?.id);
+
+    if (shortcutIndex === -1) {
       return undefined;
     }
 
-    if (hasScopedResults || section.key === 'recent') {
-      return `⌘${index + 1}`;
+    return shortcutLabel(modLabel, String(shortcutIndex + 1));
+  }
+
+  function entriesForShortcuts(sections: EntrySection[], scoped: boolean): EntryDto[] {
+    if (scoped) {
+      return sections.flatMap((section) => section.entries);
     }
 
-    return undefined;
+    return sections.find((section) => section.key === 'recent')?.entries ?? [];
   }
 
   function countByFilter(filter: FilterKey, recent: Set<string>): number {
@@ -326,6 +352,7 @@
       onclear={clearQuery}
       onfocus={() => (searchFocused = true)}
       onblur={() => (searchFocused = false)}
+      shortcut={shortcutLabel(modLabel, 'F')}
     />
     <Button variant="primary" onclick={openNewEntry}>
       <Icon name="plus" size={11} sw={2} />
@@ -401,7 +428,7 @@
           <div class="empty__hints mono">
             <span><Kbd value="N" /> new entry</span>
             <button type="button" class="empty__hint-link" onclick={openGenerator}><Kbd value="G" /> generate a password</button>
-            <span><Kbd value="⌘" /><Kbd value="O" /> open another vault</span>
+            <span><Kbd value={modLabel} /><Kbd value="O" /> open another vault</span>
           </div>
         </div>
       {:else if sections.length > 0}

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -70,14 +70,6 @@
         return;
       }
 
-      if (modKey && /^[1-9]$/.test(key)) {
-        const entry = shortcutEntries[Number(key) - 1];
-
-        if (entry) {
-          event.preventDefault();
-          selectEntry(entry);
-        }
-      }
     }
 
     window.addEventListener('keydown', handleKeydown);
@@ -235,7 +227,7 @@
       return undefined;
     }
 
-    return shortcutLabel(modLabel, String(shortcutIndex + 1));
+    return `#${shortcutIndex + 1}`;
   }
 
   function entriesForShortcuts(sections: EntrySection[], scoped: boolean): EntryDto[] {

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -121,6 +121,10 @@
       }
 
       if (key === 'enter') {
+        if (isInteractiveActionTarget(event.target)) {
+          return;
+        }
+
         const active = visibleRows.find((row) => row.key === activeRowKey);
 
         if (active) {
@@ -203,6 +207,10 @@
   function focusSearch() {
     searchFocused = true;
     searchFocusToken += 1;
+  }
+
+  function isInteractiveActionTarget(target: EventTarget | null): boolean {
+    return target instanceof HTMLElement && Boolean(target.closest('button, a, [role="button"]'));
   }
 
   function moveActiveRow(offset: number) {

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -428,7 +428,7 @@
           <div class="empty__hints mono">
             <span><Kbd value="N" /> new entry</span>
             <button type="button" class="empty__hint-link" onclick={openGenerator}><Kbd value="G" /> generate a password</button>
-            <span><Kbd value={modLabel} /><Kbd value="O" /> open another vault</span>
+            <span><Kbd value={modLabel} /> + <Kbd value="O" /> open another vault</span>
           </div>
         </div>
       {:else if sections.length > 0}

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
   import type { EntryDto } from '../../ipc';
-  import { isEditableTarget, primaryModifierLabel, primaryModifierPressed, shortcutLabel } from '../../keyboard';
+  import { isEditableTarget, primaryModifierPressed } from '../../keyboard';
   import { uiState } from '../../stores/ui.svelte';
   import { clearEntryDraft, vaultState } from '../../stores/vault.svelte';
   import { Icon } from '../icons';
-  import { Button, Kbd } from '../primitives';
+  import { Button } from '../primitives';
   import EntryRow from './EntryRow.svelte';
   import FilterSidebar, { type FilterItem } from './FilterSidebar.svelte';
   import SearchBar from './SearchBar.svelte';
@@ -46,8 +46,6 @@
   );
   const sections = $derived(buildSections(filteredEntries, selectedFilter, recentIds));
   const visibleRows = $derived(flattenRows(sections));
-  const shortcutEntries = $derived(entriesForShortcuts(sections, hasScopedResults).slice(0, 9));
-  const modLabel = $derived(primaryModifierLabel());
   const filters = $derived<FilterItem[]>([
     { key: 'all', label: 'all', count: vaultState.entries.length },
     { key: 'recent', label: 'recent', count: recentIds.size },
@@ -311,20 +309,6 @@
     return [...grouped.values()].filter((section) => section.entries.length > 0);
   }
 
-  function shortcutFor(section: EntrySection, index: number): string | undefined {
-    if (!hasScopedResults && section.key !== 'recent') {
-      return undefined;
-    }
-
-    const shortcutIndex = shortcutEntries.findIndex((entry) => entry.id === section.entries[index]?.id);
-
-    if (shortcutIndex === -1) {
-      return undefined;
-    }
-
-    return `#${shortcutIndex + 1}`;
-  }
-
   function rowKey(section: EntrySection, index: number): string {
     return `${section.key}:${section.entries[index]?.id ?? index}`;
   }
@@ -336,14 +320,6 @@
         entry,
       })),
     );
-  }
-
-  function entriesForShortcuts(sections: EntrySection[], scoped: boolean): EntryDto[] {
-    if (scoped) {
-      return sections.flatMap((section) => section.entries);
-    }
-
-    return sections.find((section) => section.key === 'recent')?.entries ?? [];
   }
 
   function countByFilter(filter: FilterKey, recent: Set<string>): number {
@@ -452,12 +428,10 @@
       onclear={clearQuery}
       onfocus={() => (searchFocused = true)}
       onblur={() => (searchFocused = false)}
-      shortcut={shortcutLabel(modLabel, 'F')}
     />
-    <Button variant="primary" onclick={openNewEntry}>
+    <Button variant="primary" onclick={openNewEntry} aria-keyshortcuts="N">
       <Icon name="plus" size={11} sw={2} />
       new_entry
-      <Kbd value="N" />
     </Button>
     <Button variant={syncAcknowledged ? 'vault' : 'ghost'} onclick={acknowledgeLocalSync}>
       <Icon name="refresh" size={11} sw={2} />
@@ -514,21 +488,14 @@
             encrypted at rest.
           </p>
           <div class="empty__cta">
-            <Button variant="primary" onclick={openNewEntry}>
+            <Button variant="primary" onclick={openNewEntry} aria-keyshortcuts="N">
               <Icon name="plus" size={11} sw={2} />
               new_entry
-              <Kbd value="N" />
             </Button>
-            <Button variant="ghost" onclick={openGenerator}>
+            <Button variant="ghost" onclick={openGenerator} aria-keyshortcuts="G">
               <Icon name="refresh" size={12} />
               generate
-              <Kbd value="G" />
             </Button>
-          </div>
-          <div class="empty__hints mono">
-            <span><Kbd value="N" /> new entry</span>
-            <button type="button" class="empty__hint-link" onclick={openGenerator}><Kbd value="G" /> generate a password</button>
-            <span><Kbd value={modLabel} /> + <Kbd value="O" /> open another vault</span>
           </div>
         </div>
       {:else if sections.length > 0}
@@ -544,7 +511,6 @@
               {entry}
               rowKey={currentRowKey}
               selected={activeRowKey === currentRowKey}
-              shortcut={shortcutFor(section, index)}
               onselect={selectEntry}
             />
           {/each}

--- a/apps/desktop/src/lib/components/vault/EntryRow.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryRow.svelte
@@ -8,11 +8,13 @@
   let {
     entry,
     selected = false,
+    rowKey,
     shortcut,
     onselect,
   } = $props<{
     entry: EntryDto;
     selected?: boolean;
+    rowKey?: string;
     shortcut?: string;
     onselect?: (entry: EntryDto) => void;
   }>();
@@ -71,6 +73,10 @@
   }
 
   function handleKeydown(event: KeyboardEvent) {
+    if (!selected) {
+      return;
+    }
+
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       onselect?.(entry);
@@ -137,8 +143,9 @@
 <div
   class={selected ? 'row row--selected' : 'row'}
   role="option"
-  tabindex="0"
+  tabindex={selected ? 0 : -1}
   aria-selected={selected}
+  data-entry-row-key={rowKey}
   onclick={() => onselect?.(entry)}
   onkeydown={handleKeydown}
 >

--- a/apps/desktop/src/lib/components/vault/EntryRow.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryRow.svelte
@@ -9,13 +9,11 @@
     entry,
     selected = false,
     rowKey,
-    shortcut,
     onselect,
   } = $props<{
     entry: EntryDto;
     selected?: boolean;
     rowKey?: string;
-    shortcut?: string;
     onselect?: (entry: EntryDto) => void;
   }>();
 
@@ -161,9 +159,6 @@
     </div>
     <div class="row__sub">{subtitle}</div>
   </div>
-  {#if shortcut}
-    <Tag value={shortcut} />
-  {/if}
   <div class="row__actions">
     <button
       class="row__action"

--- a/apps/desktop/src/lib/components/vault/SearchBar.svelte
+++ b/apps/desktop/src/lib/components/vault/SearchBar.svelte
@@ -7,6 +7,7 @@
     onfocus,
     onblur,
     onclear,
+    shortcut = 'Mod+F',
     class: className = '',
     ...rest
   } = $props<{
@@ -17,6 +18,7 @@
     onfocus?: () => void;
     onblur?: () => void;
     onclear?: () => void;
+    shortcut?: string;
     class?: string;
     [key: string]: unknown;
   }>();
@@ -76,5 +78,5 @@
       clear
     </button>
   {/if}
-  <span class="search__hint">⌘F</span>
+  <span class="search__hint">{shortcut}</span>
 </div>

--- a/apps/desktop/src/lib/components/vault/SearchBar.svelte
+++ b/apps/desktop/src/lib/components/vault/SearchBar.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+  import { primaryModifierLabel } from '../../keyboard';
+
+  const searchShortcut = primaryModifierLabel() === '⌘' ? '⌘F' : 'Ctrl+F';
+
   let {
     query = '',
     focused = false,
@@ -7,7 +11,7 @@
     onfocus,
     onblur,
     onclear,
-    shortcut = 'Mod+F',
+    shortcut = searchShortcut,
     class: className = '',
     ...rest
   } = $props<{

--- a/apps/desktop/src/lib/keyboard.ts
+++ b/apps/desktop/src/lib/keyboard.ts
@@ -15,7 +15,7 @@ export function primaryModifierPressed(event: KeyboardEvent): boolean {
 }
 
 export function shortcutLabel(...parts: string[]): string {
-  return parts.join('+');
+  return parts.join(' + ');
 }
 
 export function isEditableTarget(target: EventTarget | null): boolean {

--- a/apps/desktop/src/lib/keyboard.ts
+++ b/apps/desktop/src/lib/keyboard.ts
@@ -10,12 +10,20 @@ export function primaryModifierLabel(): string {
   return isMacPlatform() ? '⌘' : 'Ctrl';
 }
 
+export function primaryModifierAriaKey(): string {
+  return isMacPlatform() ? 'Meta' : 'Control';
+}
+
 export function primaryModifierPressed(event: KeyboardEvent): boolean {
   return isMacPlatform() ? event.metaKey : event.ctrlKey;
 }
 
 export function shortcutLabel(...parts: string[]): string {
   return parts.join(' + ');
+}
+
+export function shortcutAriaLabel(...parts: string[]): string {
+  return parts.join('+');
 }
 
 export function isEditableTarget(target: EventTarget | null): boolean {

--- a/apps/desktop/src/lib/keyboard.ts
+++ b/apps/desktop/src/lib/keyboard.ts
@@ -1,0 +1,32 @@
+export function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  return navigator.platform.includes('Mac') || navigator.userAgent.includes('Macintosh');
+}
+
+export function primaryModifierLabel(): string {
+  return isMacPlatform() ? '⌘' : 'Ctrl';
+}
+
+export function primaryModifierPressed(event: KeyboardEvent): boolean {
+  return isMacPlatform() ? event.metaKey : event.ctrlKey;
+}
+
+export function shortcutLabel(...parts: string[]): string {
+  return parts.join('+');
+}
+
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    target.isContentEditable
+  );
+}


### PR DESCRIPTION
## Summary

- add platform-aware keyboard helpers for modifier labels, ARIA shortcut labels, and editable-target guards
- implement keyboard navigation for tabs, vault rows, audit findings, entry detail actions, generator actions, lock, and open-another-vault flows
- use arrow-key roving row navigation for vault/audit lists, with Enter opening the active row
- add a compact Settings shortcut reference for the implemented keyboard model

Closes #134
Closes #146

## Security Checklist

- [x] No secrets, keys, passwords, vault contents, or generated credentials are hardcoded or logged
- [x] No new `unsafe` blocks without justification and human review
- [x] Cryptographic changes reviewed against the threat model
- [x] OSV/RustSec scan passes with no new vulnerabilities introduced
- [x] Changes touching `packages/vault-core`, Tauri IPC, or secret display/copy flows are marked for human review

## Testing

- [ ] Unit tests added/updated
- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `pnpm build`
- [x] Tested locally on target platform when UI or Tauri behavior changed

Additional validation:

- [x] `pnpm typecheck`
- [x] `pnpm lint`

## Agent-Assisted Changes

- [ ] AI-generated or AI-edited code was reviewed line by line by a human
- [x] `AGENTS.md` files remain accurate after this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation for vault entries, tabs, audit findings, and detail views.
  * Added shortcuts for editing, deleting, saving, generating, revealing, copying, locking, and switching vaults.
  * Added platform-aware shortcut labels for macOS and Windows/Linux.
  * Added a keyboard shortcut reference in Settings and responsive shortcut layouts.
  * Added visible shortcut hints and improved focus management across controls.

* **Accessibility**
  * Improved keyboard focus, selection states, scrolling, list semantics, and ARIA shortcut labels.
  * Shortcuts are suppressed while typing in editable fields.

* **Improvements**
  * Renamed the “Last used” metric to “Last modified.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->