### PR TITLE
feat: add bounded entry revisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4353,6 +4353,7 @@ dependencies = [
  "keepass",
  "rand",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.20",
  "uuid",

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -684,7 +684,7 @@ mod tests {
         )
         .expect_err("persisting into a missing parent directory should fail");
 
-        assert_ne!(error.code, "locked");
+        assert_eq!(error.code, "io_error");
         let session = state.session().expect("session lock should be available");
         let stored_entry = session
             .entries

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -35,6 +35,7 @@ pub struct EntryDto {
     pub tags: Vec<String>,
     pub created_at: String,
     pub updated_at: String,
+    pub revision_count: usize,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -192,6 +193,7 @@ pub fn update_entry(
     data: UpdateEntryDto,
     state: State<'_, AppState>,
 ) -> Result<EntryDto, ArcaError> {
+    let revision_limit = state.settings()?.entry_revision_limit;
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
     validate_optional_entry_password(data.password.as_deref())?;
@@ -201,7 +203,7 @@ pub fn update_entry(
         .iter_mut()
         .find(|entry| entry.id == id)
         .ok_or_else(|| ArcaError::not_found("Entry"))?;
-    core_entry::update_entry(entry, data.into());
+    core_entry::update_entry_with_revision_limit(entry, data.into(), revision_limit);
     let dto = EntryDto::from_entry(entry, true);
     persist_session(&session)?;
     session.touch();
@@ -269,7 +271,30 @@ pub fn get_settings(state: State<'_, AppState>) -> Result<Settings, ArcaError> {
 }
 
 #[tauri::command]
-pub fn update_settings(settings: Settings, state: State<'_, AppState>) -> Result<(), ArcaError> {
+pub fn update_settings(
+    mut settings: Settings,
+    state: State<'_, AppState>,
+) -> Result<(), ArcaError> {
+    settings.entry_revision_limit = settings
+        .entry_revision_limit
+        .min(core_entry::MAX_ENTRY_REVISION_LIMIT);
+
+    {
+        let mut session = state.session()?;
+        if ensure_unlocked(&session).is_ok() {
+            let mut trimmed = false;
+
+            for entry in &mut session.entries {
+                trimmed |= core_entry::trim_entry_revisions(entry, settings.entry_revision_limit);
+            }
+
+            if trimmed {
+                persist_session(&session)?;
+                session.touch();
+            }
+        }
+    }
+
     *state.settings()? = settings;
     Ok(())
 }
@@ -287,6 +312,7 @@ impl EntryDto {
             tags: entry.tags.clone(),
             created_at: entry.created_at.clone(),
             updated_at: entry.updated_at.clone(),
+            revision_count: entry.revisions.len(),
         }
     }
 }
@@ -529,13 +555,26 @@ mod tests {
 
     #[test]
     fn entry_dto_masks_password_for_list_views() {
-        let entry = create_entry("GitHub", "arca", "secret");
+        let mut entry = create_entry("GitHub", "arca", "secret");
+        entry.revisions.push(vault_core::types::EntryRevision {
+            captured_at: "2026-06-11T00:00:00+00:00".to_string(),
+            title: "GitHub".to_string(),
+            username: "arca".to_string(),
+            password: "previous-secret".to_string(),
+            collection: None,
+            url: None,
+            notes: None,
+            tags: Vec::new(),
+            updated_at: "2026-06-11T00:00:00+00:00".to_string(),
+        });
 
         let masked = EntryDto::from_entry(&entry, false);
         let revealed = EntryDto::from_entry(&entry, true);
 
         assert!(masked.password.is_none());
         assert_eq!(revealed.password.as_deref(), Some("secret"));
+        assert_eq!(masked.revision_count, 1);
+        assert_eq!(revealed.revision_count, 1);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -271,10 +271,11 @@ pub fn get_settings(state: State<'_, AppState>) -> Result<Settings, ArcaError> {
 }
 
 #[tauri::command]
-pub fn update_settings(
-    mut settings: Settings,
-    state: State<'_, AppState>,
-) -> Result<(), ArcaError> {
+pub fn update_settings(settings: Settings, state: State<'_, AppState>) -> Result<(), ArcaError> {
+    update_settings_in_state(settings, state.inner())
+}
+
+fn update_settings_in_state(mut settings: Settings, state: &AppState) -> Result<(), ArcaError> {
     settings.entry_revision_limit = settings
         .entry_revision_limit
         .min(core_entry::MAX_ENTRY_REVISION_LIMIT);
@@ -282,16 +283,17 @@ pub fn update_settings(
     {
         let mut session = state.session()?;
         if ensure_unlocked(&session).is_ok() {
-            let mut staged_entries = session.entries.clone();
+            // Atomic persistence needs a staged copy; keep it wrapped so failed saves clear copied secrets.
+            let mut staged_entries = Zeroizing::new(session.entries.clone());
             let mut trimmed = false;
 
-            for entry in &mut staged_entries {
+            for entry in staged_entries.iter_mut() {
                 trimmed |= core_entry::trim_entry_revisions(entry, settings.entry_revision_limit);
             }
 
             if trimmed {
-                persist_entries(&session, &staged_entries)?;
-                session.entries = staged_entries;
+                persist_entries(&session, staged_entries.as_slice())?;
+                session.entries = std::mem::take(staged_entries.as_mut());
                 session.touch();
             }
         }
@@ -554,13 +556,18 @@ fn home_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::{
-        suggest_paths_for, validate_entry_password, validate_optional_entry_password,
-        CreateEntryDto, EntryDto, GeneratorConfigDto, UpdateEntryDto,
+        suggest_paths_for, update_settings_in_state, validate_entry_password,
+        validate_optional_entry_password, CreateEntryDto, EntryDto, GeneratorConfigDto,
+        UpdateEntryDto,
     };
+    use crate::state::{AppState, Settings};
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
-    use vault_core::entry::create_entry;
-    use vault_core::entry::EntryPatch;
+    use vault_core::entry::{create_entry, update_entry};
+    use vault_core::entry::{EntryPatch, DEFAULT_ENTRY_REVISION_LIMIT};
+    use vault_core::types::VaultMeta;
+    use vault_core::vault as core_vault;
+    use zeroize::Zeroizing;
 
     #[test]
     fn entry_dto_masks_password_for_list_views() {
@@ -644,6 +651,109 @@ mod tests {
         assert_eq!(error.code, "invalid_input");
     }
 
+    #[test]
+    fn update_settings_persistence_failure_leaves_session_and_settings_unchanged() {
+        let state = AppState::default();
+        let password = test_credential("vault");
+        let entry = create_entry_with_revisions(3);
+        let entry_id = entry.id.clone();
+        let root = unique_temp_dir();
+        let missing_parent = root.join("missing-parent").join("vault.arca");
+        let original_settings = Settings {
+            entry_revision_limit: DEFAULT_ENTRY_REVISION_LIMIT,
+            ..Settings::default()
+        };
+
+        *state.settings().expect("settings lock should be available") = original_settings.clone();
+        state
+            .session()
+            .expect("session lock should be available")
+            .unlock(
+                missing_parent,
+                Zeroizing::new(password),
+                test_meta(),
+                vec![entry.clone()],
+            );
+
+        let error = update_settings_in_state(
+            Settings {
+                entry_revision_limit: 1,
+                ..Settings::default()
+            },
+            &state,
+        )
+        .expect_err("persisting into a missing parent directory should fail");
+
+        assert_ne!(error.code, "locked");
+        let session = state.session().expect("session lock should be available");
+        let stored_entry = session
+            .entries
+            .iter()
+            .find(|stored| stored.id == entry_id)
+            .expect("entry should remain in memory");
+        assert_eq!(stored_entry.revisions.len(), entry.revisions.len());
+        drop(session);
+        assert_eq!(
+            *state.settings().expect("settings lock should be available"),
+            original_settings
+        );
+
+        fs::remove_dir_all(root).expect("remove failed persistence fixture");
+    }
+
+    #[test]
+    fn update_settings_lowering_revision_limit_persists_trimmed_revisions() {
+        let state = AppState::default();
+        let root = unique_temp_dir();
+        let vault_path = root.join("revision-retention.arca");
+        let password = test_credential("vault");
+        let meta = core_vault::create_vault(&vault_path, &password, "Revision Retention")
+            .expect("create vault");
+        let entry = create_entry_with_revisions(4);
+
+        state
+            .session()
+            .expect("session lock should be available")
+            .unlock(
+                vault_path.clone(),
+                Zeroizing::new(password.clone()),
+                meta,
+                vec![entry],
+            );
+
+        update_settings_in_state(
+            Settings {
+                entry_revision_limit: 2,
+                ..Settings::default()
+            },
+            &state,
+        )
+        .expect("settings update should persist trimmed revisions");
+
+        assert_eq!(
+            state
+                .session()
+                .expect("session lock should be available")
+                .entries[0]
+                .revisions
+                .len(),
+            2
+        );
+        assert_eq!(
+            state
+                .settings()
+                .expect("settings lock should be available")
+                .entry_revision_limit,
+            2
+        );
+
+        let (_meta, persisted_entries) =
+            core_vault::open_vault(&vault_path, &password).expect("open persisted vault");
+        assert_eq!(persisted_entries[0].revisions.len(), 2);
+
+        fs::remove_dir_all(root).expect("remove revision retention fixture");
+    }
+
     fn test_credential(label: &str) -> String {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -651,6 +761,31 @@ mod tests {
             .as_nanos();
 
         format!("test-credential-{label}-{nanos}")
+    }
+
+    fn create_entry_with_revisions(count: usize) -> vault_core::VaultEntry {
+        let mut entry = create_entry("GitHub", "arca", &test_credential("current"));
+
+        for index in 0..count {
+            update_entry(
+                &mut entry,
+                EntryPatch {
+                    title: Some(format!("GitHub {index}")),
+                    password: Some(test_credential(&format!("revision-{index}"))),
+                    ..EntryPatch::default()
+                },
+            );
+        }
+
+        entry
+    }
+
+    fn test_meta() -> VaultMeta {
+        VaultMeta {
+            name: "Test Vault".to_string(),
+            created_at: "2026-08-19T00:00:00+00:00".to_string(),
+            modified_at: "2026-08-19T00:00:00+00:00".to_string(),
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -35,6 +35,8 @@ pub struct EntryDto {
     pub tags: Vec<String>,
     pub created_at: String,
     pub updated_at: String,
+    /// Number of retained historical revisions; the DTO exposes only the count, never the
+    /// historical values themselves.
     pub revision_count: usize,
 }
 
@@ -275,6 +277,12 @@ pub fn update_settings(settings: Settings, state: State<'_, AppState>) -> Result
     update_settings_in_state(settings, state.inner())
 }
 
+/// Validate and store `settings`, trimming retained revisions when the limit is lowered.
+///
+/// The revision limit is clamped to [`core_entry::MAX_ENTRY_REVISION_LIMIT`]. When a vault is
+/// unlocked, trimming runs against a zeroizing staged copy and is only committed to the live
+/// session after persistence succeeds, so a failed save leaves both the in-memory entries and
+/// the stored settings unchanged.
 fn update_settings_in_state(mut settings: Settings, state: &AppState) -> Result<(), ArcaError> {
     settings.entry_revision_limit = settings
         .entry_revision_limit

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -282,14 +282,16 @@ pub fn update_settings(
     {
         let mut session = state.session()?;
         if ensure_unlocked(&session).is_ok() {
+            let mut staged_entries = session.entries.clone();
             let mut trimmed = false;
 
-            for entry in &mut session.entries {
+            for entry in &mut staged_entries {
                 trimmed |= core_entry::trim_entry_revisions(entry, settings.entry_revision_limit);
             }
 
             if trimmed {
-                persist_session(&session)?;
+                persist_entries(&session, &staged_entries)?;
+                session.entries = staged_entries;
                 session.touch();
             }
         }
@@ -386,6 +388,13 @@ fn validate_entry_password(password: &str) -> Result<(), ArcaError> {
 }
 
 fn persist_session(session: &crate::state::SessionState) -> Result<(), ArcaError> {
+    persist_entries(session, &session.entries)
+}
+
+fn persist_entries(
+    session: &crate::state::SessionState,
+    entries: &[VaultEntry],
+) -> Result<(), ArcaError> {
     let path = session
         .vault_path
         .as_deref()
@@ -396,7 +405,7 @@ fn persist_session(session: &crate::state::SessionState) -> Result<(), ArcaError
         .as_ref()
         .ok_or_else(ArcaError::locked)?;
 
-    core_vault::save_vault(path, password.as_str(), meta, &session.entries)?;
+    core_vault::save_vault(path, password.as_str(), meta, entries)?;
 
     Ok(())
 }
@@ -555,12 +564,14 @@ mod tests {
 
     #[test]
     fn entry_dto_masks_password_for_list_views() {
-        let mut entry = create_entry("GitHub", "arca", "secret");
+        let credential = test_credential("current");
+        let previous_credential = test_credential("previous");
+        let mut entry = create_entry("GitHub", "arca", &credential);
         entry.revisions.push(vault_core::types::EntryRevision {
             captured_at: "2026-06-11T00:00:00+00:00".to_string(),
             title: "GitHub".to_string(),
             username: "arca".to_string(),
-            password: "previous-secret".to_string(),
+            password: previous_credential,
             collection: None,
             url: None,
             notes: None,
@@ -572,7 +583,7 @@ mod tests {
         let revealed = EntryDto::from_entry(&entry, true);
 
         assert!(masked.password.is_none());
-        assert_eq!(revealed.password.as_deref(), Some("secret"));
+        assert_eq!(revealed.password.as_deref(), Some(credential.as_str()));
         assert_eq!(masked.revision_count, 1);
         assert_eq!(revealed.revision_count, 1);
     }
@@ -590,9 +601,14 @@ mod tests {
 
     #[test]
     fn create_entry_dto_accepts_missing_tags() {
-        let json = r#"{"title":"GitHub","username":"arca","password":"secret"}"#;
+        let json = serde_json::json!({
+            "title": "GitHub",
+            "username": "arca",
+            "password": test_credential("current"),
+        })
+        .to_string();
         let dto: CreateEntryDto =
-            serde_json::from_str(json).expect("create entry dto should deserialize");
+            serde_json::from_str(&json).expect("create entry dto should deserialize");
 
         assert!(dto.collection.is_none());
         assert!(dto.tags.is_empty());
@@ -603,7 +619,7 @@ mod tests {
         let error = validate_entry_password("").expect_err("empty passwords should be rejected");
 
         assert_eq!(error.code, "invalid_input");
-        assert!(validate_entry_password("secret").is_ok());
+        assert!(validate_entry_password(&test_credential("valid")).is_ok());
     }
 
     #[test]
@@ -618,12 +634,23 @@ mod tests {
 
     #[test]
     fn entry_password_policy_rejects_empty_update_passwords() {
-        let dto: UpdateEntryDto =
-            serde_json::from_str(r#"{"password":""}"#).expect("update dto should deserialize");
+        let dto = UpdateEntryDto {
+            password: Some(String::new()),
+            ..UpdateEntryDto::default()
+        };
         let error = validate_optional_entry_password(dto.password.as_deref())
             .expect_err("empty update passwords should be rejected");
 
         assert_eq!(error.code, "invalid_input");
+    }
+
+    fn test_credential(label: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+
+        format!("test-credential-{label}-{nanos}")
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -35,8 +35,6 @@ pub struct EntryDto {
     pub tags: Vec<String>,
     pub created_at: String,
     pub updated_at: String,
-    /// Number of retained historical revisions; the DTO exposes only the count, never the
-    /// historical values themselves.
     pub revision_count: usize,
 }
 
@@ -277,12 +275,6 @@ pub fn update_settings(settings: Settings, state: State<'_, AppState>) -> Result
     update_settings_in_state(settings, state.inner())
 }
 
-/// Validate and store `settings`, trimming retained revisions when the limit is lowered.
-///
-/// The revision limit is clamped to [`core_entry::MAX_ENTRY_REVISION_LIMIT`]. When a vault is
-/// unlocked, trimming runs against a zeroizing staged copy and is only committed to the live
-/// session after persistence succeeds, so a failed save leaves both the in-memory entries and
-/// the stored settings unchanged.
 fn update_settings_in_state(mut settings: Settings, state: &AppState) -> Result<(), ArcaError> {
     settings.entry_revision_limit = settings
         .entry_revision_limit

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -75,6 +75,8 @@ impl SessionState {
 pub struct Settings {
     pub auto_lock_timeout_minutes: Option<u64>,
     pub clipboard_clear_seconds: Option<u64>,
+    /// How many historical revisions to retain per entry; defaults for older settings files
+    /// that predate the field.
     #[serde(default = "default_entry_revision_limit")]
     pub entry_revision_limit: usize,
     pub theme: Theme,
@@ -93,6 +95,7 @@ impl Default for Settings {
     }
 }
 
+/// Serde default for [`Settings::entry_revision_limit`] when loading older settings files.
 fn default_entry_revision_limit() -> usize {
     DEFAULT_ENTRY_REVISION_LIMIT
 }

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -75,8 +75,6 @@ impl SessionState {
 pub struct Settings {
     pub auto_lock_timeout_minutes: Option<u64>,
     pub clipboard_clear_seconds: Option<u64>,
-    /// How many historical revisions to retain per entry; defaults for older settings files
-    /// that predate the field.
     #[serde(default = "default_entry_revision_limit")]
     pub entry_revision_limit: usize,
     pub theme: Theme,
@@ -95,7 +93,6 @@ impl Default for Settings {
     }
 }
 
-/// Serde default for [`Settings::entry_revision_limit`] when loading older settings files.
 fn default_entry_revision_limit() -> usize {
     DEFAULT_ENTRY_REVISION_LIMIT
 }

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -3,6 +3,7 @@ use std::sync::{Mutex, MutexGuard};
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
+use vault_core::entry::DEFAULT_ENTRY_REVISION_LIMIT;
 use vault_core::{VaultEntry, VaultMeta};
 use zeroize::Zeroizing;
 
@@ -74,6 +75,8 @@ impl SessionState {
 pub struct Settings {
     pub auto_lock_timeout_minutes: Option<u64>,
     pub clipboard_clear_seconds: Option<u64>,
+    #[serde(default = "default_entry_revision_limit")]
+    pub entry_revision_limit: usize,
     pub theme: Theme,
     pub font_size: u8,
 }
@@ -83,10 +86,15 @@ impl Default for Settings {
         Self {
             auto_lock_timeout_minutes: Some(15),
             clipboard_clear_seconds: Some(30),
+            entry_revision_limit: DEFAULT_ENTRY_REVISION_LIMIT,
             theme: Theme::Paper,
             font_size: 13,
         }
     }
+}
+
+fn default_entry_revision_limit() -> usize {
+    DEFAULT_ENTRY_REVISION_LIMIT
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -137,5 +145,7 @@ mod tests {
 
         assert_eq!(terminal.theme, Theme::Paper);
         assert_eq!(amber.theme, Theme::Ink);
+        assert_eq!(terminal.entry_revision_limit, 5);
+        assert_eq!(amber.entry_revision_limit, 5);
     }
 }

--- a/apps/desktop/src/lib/audit.test.ts
+++ b/apps/desktop/src/lib/audit.test.ts
@@ -23,6 +23,7 @@ function entry(overrides: Partial<EntryDto>): EntryDto {
     tags: ['work'],
     createdAt: fresh,
     updatedAt: fresh,
+    revisionCount: 0,
     ...overrides,
   };
 }

--- a/apps/desktop/src/lib/components/detail/MetricStrip.svelte
+++ b/apps/desktop/src/lib/components/detail/MetricStrip.svelte
@@ -9,6 +9,7 @@
 
   const created = $derived(formatDate(entry.createdAt));
   const updated = $derived(formatRelative(entry.updatedAt));
+  const revisions = $derived(formatRevisionCount(entry.revisionCount));
 
   function formatDate(value: string): string {
     const time = Date.parse(value);
@@ -36,6 +37,10 @@
 
     return `${Math.round(elapsedHours / 24)}d ago`;
   }
+
+  function formatRevisionCount(value: number): string {
+    return value.toString().padStart(2, '0');
+  }
 </script>
 
 <div class="strip">
@@ -44,11 +49,11 @@
     <div class="strip__v">{created}</div>
   </div>
   <div class="strip__cell">
-    <div class="strip__k">last_used</div>
+    <div class="strip__k">last_modified</div>
     <div class="strip__v">{updated}</div>
   </div>
   <div class="strip__cell">
     <div class="strip__k">revisions</div>
-    <div class="strip__v strip__v--accent">01</div>
+    <div class="strip__v strip__v--accent">{revisions}</div>
   </div>
 </div>

--- a/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
+++ b/apps/desktop/src/lib/components/settings/SettingsPanel.svelte
@@ -4,6 +4,7 @@
   import {
     RELEASE_AUTO_LOCK_OPTIONS,
     RELEASE_CLIPBOARD_CLEAR_OPTIONS,
+    RELEASE_ENTRY_REVISION_OPTIONS,
     RELEASE_THEME_OPTIONS,
     SETTINGS_LIMITS,
   } from '../../settings';
@@ -22,6 +23,7 @@
   let autoLockMinutes = $state<number>(SETTINGS_LIMITS.autoLockTimeoutMinutes.defaultValue);
   let clipboardEnabled = $state(true);
   let clipboardSeconds = $state<number>(SETTINGS_LIMITS.clipboardClearSeconds.defaultValue);
+  let entryRevisionLimit = $state<number>(SETTINGS_LIMITS.entryRevisionLimit.defaultValue);
   let fontSize = $state<number>(SETTINGS_LIMITS.fontSize.defaultValue);
   let busy = $state(false);
   let loaded = $state(false);
@@ -29,6 +31,7 @@
 
   const autoLockValue = $derived(autoLockEnabled ? String(autoLockMinutes) : 'never');
   const clipboardValue = $derived(String(clipboardSeconds));
+  const entryRevisionValue = $derived(String(entryRevisionLimit));
 
   onMount(() => {
     if (runtimeSettings.loaded) {
@@ -92,6 +95,15 @@
     }
 
     clipboardSeconds = Number(value);
+    await saveSettings();
+  }
+
+  async function setEntryRevisionLimit(value: string) {
+    if (!loaded || busy) {
+      return;
+    }
+
+    entryRevisionLimit = Number(value);
     await saveSettings();
   }
 
@@ -164,9 +176,20 @@
         return false;
       }
 
+      const nextEntryRevisionLimit = Number(entryRevisionLimit);
+      if (
+        !Number.isInteger(nextEntryRevisionLimit) ||
+        nextEntryRevisionLimit < SETTINGS_LIMITS.entryRevisionLimit.min ||
+        nextEntryRevisionLimit > SETTINGS_LIMITS.entryRevisionLimit.max
+      ) {
+        errorMessage = `Entry revision limit must be an integer between ${SETTINGS_LIMITS.entryRevisionLimit.min} and ${SETTINGS_LIMITS.entryRevisionLimit.max}`;
+        return false;
+      }
+
       await saveRuntimeSettings({
         autoLockTimeoutMinutes: nextAutoLock,
         clipboardClearSeconds: nextClipboard,
+        entryRevisionLimit: nextEntryRevisionLimit,
         theme: themeForUi(theme),
         fontSize: nextFontSize,
       });
@@ -195,6 +218,13 @@
       SETTINGS_LIMITS.clipboardClearSeconds.min,
       SETTINGS_LIMITS.clipboardClearSeconds.max,
       SETTINGS_LIMITS.clipboardClearSeconds.step,
+    );
+    entryRevisionLimit = normalizeInteger(
+      settings.entryRevisionLimit,
+      SETTINGS_LIMITS.entryRevisionLimit.defaultValue,
+      SETTINGS_LIMITS.entryRevisionLimit.min,
+      SETTINGS_LIMITS.entryRevisionLimit.max,
+      SETTINGS_LIMITS.entryRevisionLimit.step,
     );
     fontSize = normalizeInteger(
       settings.fontSize,
@@ -259,6 +289,18 @@
               fontSize = next;
             }}
             onchange={setFontSize}
+          />
+        </div>
+      </div>
+
+      <div class="set-row">
+        <div class="set-row__k">password history<small>keep this many previous passwords per entry</small></div>
+        <div class="set-row__v">
+          <Segmented
+            ariaLabel="Password history retention"
+            value={entryRevisionValue}
+            options={[...RELEASE_ENTRY_REVISION_OPTIONS]}
+            onselect={setEntryRevisionLimit}
           />
         </div>
       </div>

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -23,6 +23,7 @@ export interface EntryDto {
   tags: string[];
   createdAt: string;
   updatedAt: string;
+  revisionCount: number;
 }
 
 export interface CreateEntryDto {
@@ -74,6 +75,7 @@ export interface PathSuggestion {
 export interface Settings {
   autoLockTimeoutMinutes?: number | null;
   clipboardClearSeconds?: number | null;
+  entryRevisionLimit?: number;
   theme: SettingsTheme;
   fontSize: number;
 }

--- a/apps/desktop/src/lib/settings.ts
+++ b/apps/desktop/src/lib/settings.ts
@@ -13,6 +13,12 @@ export const SETTINGS_LIMITS = {
     max: 300,
     step: 5,
   },
+  entryRevisionLimit: {
+    defaultValue: 5,
+    min: 0,
+    max: 25,
+    step: 1,
+  },
   fontSize: {
     defaultValue: 13,
     min: 11,
@@ -41,9 +47,19 @@ export const RELEASE_CLIPBOARD_CLEAR_OPTIONS = [
   { value: '120', label: '120s' },
 ] as const;
 
+export const RELEASE_ENTRY_REVISION_OPTIONS = [
+  { value: '0', label: 'off' },
+  { value: '1', label: '1' },
+  { value: '3', label: '3' },
+  { value: '5', label: '5' },
+  { value: '10', label: '10' },
+  { value: '25', label: '25' },
+] as const;
+
 export const DEFAULT_SETTINGS: Settings = {
   autoLockTimeoutMinutes: SETTINGS_LIMITS.autoLockTimeoutMinutes.defaultValue,
   clipboardClearSeconds: SETTINGS_LIMITS.clipboardClearSeconds.defaultValue,
+  entryRevisionLimit: SETTINGS_LIMITS.entryRevisionLimit.defaultValue,
   theme: 'paper',
   fontSize: SETTINGS_LIMITS.fontSize.defaultValue,
 };
@@ -63,6 +79,13 @@ export function normalizeSettings(settings: Settings): Settings {
       SETTINGS_LIMITS.clipboardClearSeconds.min,
       SETTINGS_LIMITS.clipboardClearSeconds.max,
       SETTINGS_LIMITS.clipboardClearSeconds.step,
+    ),
+    entryRevisionLimit: normalizeInteger(
+      settings.entryRevisionLimit,
+      SETTINGS_LIMITS.entryRevisionLimit.defaultValue,
+      SETTINGS_LIMITS.entryRevisionLimit.min,
+      SETTINGS_LIMITS.entryRevisionLimit.max,
+      SETTINGS_LIMITS.entryRevisionLimit.step,
     ),
     theme: themeForUi(uiThemeFor(settings.theme)),
     fontSize: normalizeFontSize(settings.fontSize),
@@ -89,6 +112,26 @@ function normalizeOptionalInteger(
   }
 
   if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  const integer = Math.trunc(value);
+
+  if (integer < min || integer > max || integer % step !== 0) {
+    return fallback;
+  }
+
+  return integer;
+}
+
+function normalizeInteger(
+  value: number | null | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+  step = 1,
+): number {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
     return fallback;
   }
 

--- a/apps/desktop/src/lib/stores/settings.svelte.test.ts
+++ b/apps/desktop/src/lib/stores/settings.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   RELEASE_AUTO_LOCK_OPTIONS,
   RELEASE_CLIPBOARD_CLEAR_OPTIONS,
+  RELEASE_ENTRY_REVISION_OPTIONS,
   RELEASE_THEME_OPTIONS,
   SETTINGS_LIMITS,
   normalizeSettings,
@@ -14,12 +15,14 @@ describe('normalizeSettings', () => {
       normalizeSettings({
         autoLockTimeoutMinutes: null,
         clipboardClearSeconds: null,
+        entryRevisionLimit: 10,
         theme: 'amber',
         fontSize: 14,
       }),
     ).toEqual({
       autoLockTimeoutMinutes: null,
       clipboardClearSeconds: null,
+      entryRevisionLimit: 10,
       theme: 'ink',
       fontSize: 14,
     });
@@ -30,12 +33,14 @@ describe('normalizeSettings', () => {
       normalizeSettings({
         autoLockTimeoutMinutes: 0,
         clipboardClearSeconds: 17,
+        entryRevisionLimit: 100,
         theme: 'terminal',
         fontSize: 100,
       }),
     ).toEqual({
       autoLockTimeoutMinutes: 15,
       clipboardClearSeconds: 30,
+      entryRevisionLimit: 5,
       theme: 'paper',
       fontSize: 16,
     });
@@ -56,6 +61,13 @@ describe('release settings surface', () => {
     expect(RELEASE_THEME_OPTIONS.map((option) => option.value)).toEqual(['paper', 'ink']);
     expect(RELEASE_AUTO_LOCK_OPTIONS.map((option) => option.value)).toEqual(['1', '5', '15', '60', 'never']);
     expect(RELEASE_CLIPBOARD_CLEAR_OPTIONS.map((option) => option.value)).toEqual(['15', '30', '60', '120']);
+    expect(RELEASE_ENTRY_REVISION_OPTIONS.map((option) => option.value)).toEqual(['0', '1', '3', '5', '10', '25']);
+    expect(SETTINGS_LIMITS.entryRevisionLimit).toEqual({
+      defaultValue: 5,
+      min: 0,
+      max: 25,
+      step: 1,
+    });
     expect(SETTINGS_LIMITS.fontSize).toEqual({
       defaultValue: 13,
       min: 11,

--- a/packages/vault-core/Cargo.toml
+++ b/packages/vault-core/Cargo.toml
@@ -12,6 +12,7 @@ uuid = { version = "1", features = ["v4"] }
 zeroize = { version = "1", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2"
 keepass = { version = "0.13", features = ["save_kdbx4"] }
 

--- a/packages/vault-core/src/entry.rs
+++ b/packages/vault-core/src/entry.rs
@@ -193,7 +193,7 @@ fn relevance(entry: &VaultEntry, query: &str) -> Option<u8> {
 #[cfg(test)]
 mod tests {
     use std::thread;
-    use std::time::Duration;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use super::{
         create_entry, search_entries, trim_entry_revisions, update_entry,
@@ -203,11 +203,12 @@ mod tests {
 
     #[test]
     fn create_entry_sets_defaults() {
-        let entry = create_entry("GitHub", "arca", "secret");
+        let credential = test_credential("current");
+        let entry = create_entry("GitHub", "arca", &credential);
 
         assert_eq!(entry.title, "GitHub");
         assert_eq!(entry.username, "arca");
-        assert_eq!(entry.password, "secret");
+        assert_eq!(entry.password, credential);
         assert!(entry.url.is_none());
         assert!(entry.notes.is_none());
         assert!(entry.collection.is_none());
@@ -219,7 +220,9 @@ mod tests {
 
     #[test]
     fn update_entry_applies_patch_and_updates_timestamp() {
-        let mut entry = create_entry("GitHub", "arca", "secret");
+        let credential = test_credential("current");
+        let updated_credential = test_credential("updated");
+        let mut entry = create_entry("GitHub", "arca", &credential);
         let original_created_at = entry.created_at.clone();
         let original_updated_at = entry.updated_at.clone();
         thread::sleep(Duration::from_millis(1));
@@ -229,7 +232,7 @@ mod tests {
             EntryPatch {
                 title: Some("GitLab".to_string()),
                 username: Some("akei9".to_string()),
-                password: Some("new-secret".to_string()),
+                password: Some(updated_credential.clone()),
                 collection: Some(Some("work".to_string())),
                 url: Some(Some("https://gitlab.com".to_string())),
                 notes: Some(None),
@@ -239,7 +242,7 @@ mod tests {
 
         assert_eq!(entry.title, "GitLab");
         assert_eq!(entry.username, "akei9");
-        assert_eq!(entry.password, "new-secret");
+        assert_eq!(entry.password, updated_credential);
         assert_eq!(entry.collection.as_deref(), Some("work"));
         assert_eq!(entry.url.as_deref(), Some("https://gitlab.com"));
         assert!(entry.notes.is_none());
@@ -247,14 +250,15 @@ mod tests {
         assert_eq!(entry.revisions.len(), 1);
         assert_eq!(entry.revisions[0].title, "GitHub");
         assert_eq!(entry.revisions[0].username, "arca");
-        assert_eq!(entry.revisions[0].password, "secret");
+        assert_eq!(entry.revisions[0].password, credential);
         assert_eq!(entry.created_at, original_created_at);
         assert_ne!(entry.updated_at, original_updated_at);
     }
 
     #[test]
     fn update_entry_keeps_password_when_patch_omits_password() {
-        let mut entry = create_entry("GitHub", "arca", "secret");
+        let credential = test_credential("current");
+        let mut entry = create_entry("GitHub", "arca", &credential);
         let original_updated_at = entry.updated_at.clone();
         thread::sleep(Duration::from_millis(1));
 
@@ -268,23 +272,24 @@ mod tests {
         );
 
         assert_eq!(entry.title, "GitHub Enterprise");
-        assert_eq!(entry.password, "secret");
+        assert_eq!(entry.password, credential);
         assert_eq!(entry.revisions.len(), 1);
         assert_eq!(entry.revisions[0].title, "GitHub");
-        assert_eq!(entry.revisions[0].password, "secret");
+        assert_eq!(entry.revisions[0].password, credential);
         assert_ne!(entry.updated_at, original_updated_at);
     }
 
     #[test]
     fn update_entry_does_not_capture_revision_for_noop_patch() {
-        let mut entry = create_entry("GitHub", "arca", "secret");
+        let credential = test_credential("current");
+        let mut entry = create_entry("GitHub", "arca", &credential);
 
         update_entry(
             &mut entry,
             EntryPatch {
                 title: Some("GitHub".to_string()),
                 username: Some("arca".to_string()),
-                password: Some("secret".to_string()),
+                password: Some(credential),
                 collection: Some(None),
                 url: Some(None),
                 notes: Some(None),
@@ -297,7 +302,8 @@ mod tests {
 
     #[test]
     fn update_entry_limits_revisions() {
-        let mut entry = create_entry("GitHub", "arca", "secret");
+        let credential = test_credential("current");
+        let mut entry = create_entry("GitHub", "arca", &credential);
 
         for index in 0..DEFAULT_ENTRY_REVISION_LIMIT + 2 {
             update_entry(
@@ -319,7 +325,8 @@ mod tests {
 
     #[test]
     fn update_entry_uses_configured_revision_limit() {
-        let mut entry = create_entry("GitHub", "arca", "secret");
+        let credential = test_credential("current");
+        let mut entry = create_entry("GitHub", "arca", &credential);
 
         for index in 0..4 {
             update_entry_with_revision_limit(
@@ -339,7 +346,8 @@ mod tests {
 
     #[test]
     fn update_entry_can_disable_revisions() {
-        let mut entry = create_entry("GitHub", "arca", "secret");
+        let credential = test_credential("current");
+        let mut entry = create_entry("GitHub", "arca", &credential);
 
         update_entry_with_revision_limit(
             &mut entry,
@@ -355,7 +363,8 @@ mod tests {
 
     #[test]
     fn update_entry_caps_revision_limit() {
-        let mut entry = create_entry("GitHub", "arca", "secret");
+        let credential = test_credential("current");
+        let mut entry = create_entry("GitHub", "arca", &credential);
 
         for index in 0..MAX_ENTRY_REVISION_LIMIT + 2 {
             update_entry_with_revision_limit(
@@ -373,7 +382,8 @@ mod tests {
 
     #[test]
     fn trim_entry_revisions_applies_configured_limit() {
-        let mut entry = create_entry("GitHub", "arca", "secret");
+        let credential = test_credential("current");
+        let mut entry = create_entry("GitHub", "arca", &credential);
 
         for index in 0..4 {
             update_entry(
@@ -392,13 +402,24 @@ mod tests {
         assert!(!trim_entry_revisions(&mut entry, 2));
     }
 
+    fn test_credential(label: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+
+        format!("test-credential-{label}-{nanos}")
+    }
+
     #[test]
     fn search_entries_matches_title_username_url_and_tags_by_relevance() {
-        let title_match = create_entry("GitHub", "admin", "secret");
-        let mut username_match = create_entry("Admin Console", "github_user", "secret");
-        let mut collection_match = create_entry("Ops Console", "ops", "secret");
-        let mut url_match = create_entry("Code", "dev", "secret");
-        let mut tag_match = create_entry("Deploy", "ops", "secret");
+        let title_match = create_entry("GitHub", "admin", &test_credential("title"));
+        let mut username_match =
+            create_entry("Admin Console", "github_user", &test_credential("username"));
+        let mut collection_match =
+            create_entry("Ops Console", "ops", &test_credential("collection"));
+        let mut url_match = create_entry("Code", "dev", &test_credential("url"));
+        let mut tag_match = create_entry("Deploy", "ops", &test_credential("tag"));
         collection_match.collection = Some("github".to_string());
         url_match.url = Some("https://github.com".to_string());
         tag_match.tags = vec!["github".to_string()];
@@ -422,8 +443,8 @@ mod tests {
 
     #[test]
     fn search_entries_filters_exact_tag() {
-        let mut work = create_entry("Work", "user", "secret");
-        let mut personal = create_entry("Personal", "user", "secret");
+        let mut work = create_entry("Work", "user", &test_credential("work"));
+        let mut personal = create_entry("Personal", "user", &test_credential("personal"));
         work.tags = vec!["ssh".to_string(), "work".to_string()];
         personal.tags = vec!["personal".to_string()];
         let entries = vec![work, personal];

--- a/packages/vault-core/src/entry.rs
+++ b/packages/vault-core/src/entry.rs
@@ -1,7 +1,10 @@
 use chrono::Utc;
 use uuid::Uuid;
 
-use crate::types::VaultEntry;
+use crate::types::{EntryRevision, VaultEntry};
+
+pub const DEFAULT_ENTRY_REVISION_LIMIT: usize = 5;
+pub const MAX_ENTRY_REVISION_LIMIT: usize = 25;
 
 pub fn create_entry(title: &str, username: &str, password: &str) -> VaultEntry {
     let now = Utc::now().to_rfc3339();
@@ -17,6 +20,7 @@ pub fn create_entry(title: &str, username: &str, password: &str) -> VaultEntry {
         tags: Vec::new(),
         created_at: now.clone(),
         updated_at: now,
+        revisions: Vec::new(),
     }
 }
 
@@ -32,6 +36,21 @@ pub struct EntryPatch {
 }
 
 pub fn update_entry(entry: &mut VaultEntry, patch: EntryPatch) {
+    update_entry_with_revision_limit(entry, patch, DEFAULT_ENTRY_REVISION_LIMIT);
+}
+
+pub fn update_entry_with_revision_limit(
+    entry: &mut VaultEntry,
+    patch: EntryPatch,
+    revision_limit: usize,
+) {
+    let updated_at = Utc::now().to_rfc3339();
+    let should_capture_revision = patch_changes_entry(entry, &patch);
+
+    if should_capture_revision {
+        capture_revision(entry, updated_at.clone(), revision_limit);
+    }
+
     if let Some(title) = patch.title {
         entry.title = title;
     }
@@ -54,7 +73,70 @@ pub fn update_entry(entry: &mut VaultEntry, patch: EntryPatch) {
         entry.tags = tags;
     }
 
-    entry.updated_at = Utc::now().to_rfc3339();
+    entry.updated_at = updated_at;
+}
+
+pub fn trim_entry_revisions(entry: &mut VaultEntry, revision_limit: usize) -> bool {
+    let original_len = entry.revisions.len();
+    let revision_limit = revision_limit.min(MAX_ENTRY_REVISION_LIMIT);
+
+    if revision_limit == 0 {
+        entry.revisions.clear();
+    } else {
+        entry.revisions.truncate(revision_limit);
+    }
+
+    entry.revisions.len() != original_len
+}
+
+fn patch_changes_entry(entry: &VaultEntry, patch: &EntryPatch) -> bool {
+    patch
+        .title
+        .as_ref()
+        .is_some_and(|title| title != &entry.title)
+        || patch
+            .username
+            .as_ref()
+            .is_some_and(|username| username != &entry.username)
+        || patch
+            .password
+            .as_ref()
+            .is_some_and(|password| password != &entry.password)
+        || patch
+            .collection
+            .as_ref()
+            .is_some_and(|collection| collection != &entry.collection)
+        || patch.url.as_ref().is_some_and(|url| url != &entry.url)
+        || patch
+            .notes
+            .as_ref()
+            .is_some_and(|notes| notes != &entry.notes)
+        || patch.tags.as_ref().is_some_and(|tags| tags != &entry.tags)
+}
+
+fn capture_revision(entry: &mut VaultEntry, captured_at: String, revision_limit: usize) {
+    let revision_limit = revision_limit.min(MAX_ENTRY_REVISION_LIMIT);
+
+    if revision_limit == 0 {
+        entry.revisions.clear();
+        return;
+    }
+
+    entry.revisions.insert(
+        0,
+        EntryRevision {
+            captured_at,
+            title: entry.title.clone(),
+            username: entry.username.clone(),
+            password: entry.password.clone(),
+            collection: entry.collection.clone(),
+            url: entry.url.clone(),
+            notes: entry.notes.clone(),
+            tags: entry.tags.clone(),
+            updated_at: entry.updated_at.clone(),
+        },
+    );
+    trim_entry_revisions(entry, revision_limit);
 }
 
 pub fn search_entries<'a>(entries: &'a [VaultEntry], query: &str) -> Vec<&'a VaultEntry> {
@@ -113,7 +195,11 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
-    use super::{create_entry, search_entries, update_entry, EntryPatch};
+    use super::{
+        create_entry, search_entries, trim_entry_revisions, update_entry,
+        update_entry_with_revision_limit, EntryPatch, DEFAULT_ENTRY_REVISION_LIMIT,
+        MAX_ENTRY_REVISION_LIMIT,
+    };
 
     #[test]
     fn create_entry_sets_defaults() {
@@ -126,6 +212,7 @@ mod tests {
         assert!(entry.notes.is_none());
         assert!(entry.collection.is_none());
         assert!(entry.tags.is_empty());
+        assert!(entry.revisions.is_empty());
         assert_eq!(entry.created_at, entry.updated_at);
         assert!(uuid::Uuid::parse_str(&entry.id).is_ok());
     }
@@ -157,6 +244,10 @@ mod tests {
         assert_eq!(entry.url.as_deref(), Some("https://gitlab.com"));
         assert!(entry.notes.is_none());
         assert_eq!(entry.tags, vec!["work", "ssh"]);
+        assert_eq!(entry.revisions.len(), 1);
+        assert_eq!(entry.revisions[0].title, "GitHub");
+        assert_eq!(entry.revisions[0].username, "arca");
+        assert_eq!(entry.revisions[0].password, "secret");
         assert_eq!(entry.created_at, original_created_at);
         assert_ne!(entry.updated_at, original_updated_at);
     }
@@ -178,7 +269,127 @@ mod tests {
 
         assert_eq!(entry.title, "GitHub Enterprise");
         assert_eq!(entry.password, "secret");
+        assert_eq!(entry.revisions.len(), 1);
+        assert_eq!(entry.revisions[0].title, "GitHub");
+        assert_eq!(entry.revisions[0].password, "secret");
         assert_ne!(entry.updated_at, original_updated_at);
+    }
+
+    #[test]
+    fn update_entry_does_not_capture_revision_for_noop_patch() {
+        let mut entry = create_entry("GitHub", "arca", "secret");
+
+        update_entry(
+            &mut entry,
+            EntryPatch {
+                title: Some("GitHub".to_string()),
+                username: Some("arca".to_string()),
+                password: Some("secret".to_string()),
+                collection: Some(None),
+                url: Some(None),
+                notes: Some(None),
+                tags: Some(Vec::new()),
+            },
+        );
+
+        assert!(entry.revisions.is_empty());
+    }
+
+    #[test]
+    fn update_entry_limits_revisions() {
+        let mut entry = create_entry("GitHub", "arca", "secret");
+
+        for index in 0..DEFAULT_ENTRY_REVISION_LIMIT + 2 {
+            update_entry(
+                &mut entry,
+                EntryPatch {
+                    title: Some(format!("GitHub {index}")),
+                    ..EntryPatch::default()
+                },
+            );
+        }
+
+        assert_eq!(entry.revisions.len(), DEFAULT_ENTRY_REVISION_LIMIT);
+        assert_eq!(entry.revisions[0].title, "GitHub 5");
+        assert_eq!(
+            entry.revisions[DEFAULT_ENTRY_REVISION_LIMIT - 1].title,
+            "GitHub 1"
+        );
+    }
+
+    #[test]
+    fn update_entry_uses_configured_revision_limit() {
+        let mut entry = create_entry("GitHub", "arca", "secret");
+
+        for index in 0..4 {
+            update_entry_with_revision_limit(
+                &mut entry,
+                EntryPatch {
+                    title: Some(format!("GitHub {index}")),
+                    ..EntryPatch::default()
+                },
+                2,
+            );
+        }
+
+        assert_eq!(entry.revisions.len(), 2);
+        assert_eq!(entry.revisions[0].title, "GitHub 2");
+        assert_eq!(entry.revisions[1].title, "GitHub 1");
+    }
+
+    #[test]
+    fn update_entry_can_disable_revisions() {
+        let mut entry = create_entry("GitHub", "arca", "secret");
+
+        update_entry_with_revision_limit(
+            &mut entry,
+            EntryPatch {
+                title: Some("GitHub Enterprise".to_string()),
+                ..EntryPatch::default()
+            },
+            0,
+        );
+
+        assert!(entry.revisions.is_empty());
+    }
+
+    #[test]
+    fn update_entry_caps_revision_limit() {
+        let mut entry = create_entry("GitHub", "arca", "secret");
+
+        for index in 0..MAX_ENTRY_REVISION_LIMIT + 2 {
+            update_entry_with_revision_limit(
+                &mut entry,
+                EntryPatch {
+                    title: Some(format!("GitHub {index}")),
+                    ..EntryPatch::default()
+                },
+                MAX_ENTRY_REVISION_LIMIT + 100,
+            );
+        }
+
+        assert_eq!(entry.revisions.len(), MAX_ENTRY_REVISION_LIMIT);
+    }
+
+    #[test]
+    fn trim_entry_revisions_applies_configured_limit() {
+        let mut entry = create_entry("GitHub", "arca", "secret");
+
+        for index in 0..4 {
+            update_entry(
+                &mut entry,
+                EntryPatch {
+                    title: Some(format!("GitHub {index}")),
+                    ..EntryPatch::default()
+                },
+            );
+        }
+
+        assert!(trim_entry_revisions(&mut entry, 2));
+        assert_eq!(entry.revisions.len(), 2);
+        assert_eq!(entry.revisions[0].title, "GitHub 2");
+        assert_eq!(entry.revisions[1].title, "GitHub 1");
+        assert!(!trim_entry_revisions(&mut entry, 2));
     }
 
     #[test]

--- a/packages/vault-core/src/entry.rs
+++ b/packages/vault-core/src/entry.rs
@@ -4,9 +4,14 @@ use zeroize::Zeroize;
 
 use crate::types::{EntryRevision, VaultEntry};
 
+/// Number of historical revisions retained per entry when no explicit limit is configured.
 pub const DEFAULT_ENTRY_REVISION_LIMIT: usize = 5;
+/// Hard upper bound on retained revisions; any configured limit is clamped to this value.
 pub const MAX_ENTRY_REVISION_LIMIT: usize = 25;
 
+/// Build a new [`VaultEntry`] with a fresh UUID and matching created/updated timestamps.
+///
+/// The entry starts with no revision history; snapshots are only captured on later updates.
 pub fn create_entry(title: &str, username: &str, password: &str) -> VaultEntry {
     let now = Utc::now().to_rfc3339();
 
@@ -25,6 +30,11 @@ pub fn create_entry(title: &str, username: &str, password: &str) -> VaultEntry {
     }
 }
 
+/// Partial update applied to a [`VaultEntry`].
+///
+/// A `None` field leaves the current value untouched. Fields wrapped in a nested
+/// `Option` (`collection`, `url`, `notes`) use `Some(None)` to clear the value and
+/// `Some(Some(value))` to set it.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EntryPatch {
     pub title: Option<String>,
@@ -36,10 +46,20 @@ pub struct EntryPatch {
     pub tags: Option<Vec<String>>,
 }
 
+/// Apply `patch` to `entry` using the default revision retention limit.
+///
+/// See [`update_entry_with_revision_limit`] for revision-capture semantics.
 pub fn update_entry(entry: &mut VaultEntry, patch: EntryPatch) {
     update_entry_with_revision_limit(entry, patch, DEFAULT_ENTRY_REVISION_LIMIT);
 }
 
+/// Apply `patch` to `entry`, capturing a revision snapshot when a meaningful field changes.
+///
+/// A snapshot of the pre-update values is recorded only if the patch alters at least one
+/// field, then the applied changes and a refreshed `updated_at` timestamp are written.
+/// The stored history is bounded by `revision_limit` (clamped to
+/// [`MAX_ENTRY_REVISION_LIMIT`]); a limit of `0` disables history and clears any existing
+/// revisions.
 pub fn update_entry_with_revision_limit(
     entry: &mut VaultEntry,
     patch: EntryPatch,
@@ -77,6 +97,11 @@ pub fn update_entry_with_revision_limit(
     entry.updated_at = updated_at;
 }
 
+/// Reduce `entry`'s stored revisions to at most `revision_limit` (clamped to
+/// [`MAX_ENTRY_REVISION_LIMIT`]), zeroizing every discarded revision before removal.
+///
+/// Returns `true` if any revisions were dropped, so callers can decide whether the change
+/// needs to be persisted.
 pub fn trim_entry_revisions(entry: &mut VaultEntry, revision_limit: usize) -> bool {
     let original_len = entry.revisions.len();
     let revision_limit = revision_limit.min(MAX_ENTRY_REVISION_LIMIT);
@@ -92,12 +117,16 @@ pub fn trim_entry_revisions(entry: &mut VaultEntry, revision_limit: usize) -> bo
     entry.revisions.len() != original_len
 }
 
+/// Zeroize the backing memory of each revision (including its plaintext password) before
+/// it is dropped, so discarded secrets do not linger in process memory.
 fn zeroize_revisions(revisions: &mut [EntryRevision]) {
     for revision in revisions {
         revision.zeroize();
     }
 }
 
+/// Report whether `patch` would change any field of `entry`, used to decide if a revision
+/// snapshot is warranted.
 fn patch_changes_entry(entry: &VaultEntry, patch: &EntryPatch) -> bool {
     patch
         .title
@@ -123,6 +152,8 @@ fn patch_changes_entry(entry: &VaultEntry, patch: &EntryPatch) -> bool {
         || patch.tags.as_ref().is_some_and(|tags| tags != &entry.tags)
 }
 
+/// Prepend a snapshot of `entry`'s current values as the newest revision, then trim the
+/// history to `revision_limit`. A limit of `0` records nothing and clears existing history.
 fn capture_revision(entry: &mut VaultEntry, captured_at: String, revision_limit: usize) {
     let revision_limit = revision_limit.min(MAX_ENTRY_REVISION_LIMIT);
 
@@ -148,6 +179,11 @@ fn capture_revision(entry: &mut VaultEntry, captured_at: String, revision_limit:
     trim_entry_revisions(entry, revision_limit);
 }
 
+/// Return entries matching `query`, ranked by relevance.
+///
+/// A `#tag` query filters to entries carrying that exact tag; otherwise the query is matched
+/// (case-insensitively) against title, username, collection, url, and tags in that priority
+/// order. Revision history is never searched, keeping historical secrets out of previews.
 pub fn search_entries<'a>(entries: &'a [VaultEntry], query: &str) -> Vec<&'a VaultEntry> {
     let normalized_query = query.trim().to_lowercase();
 
@@ -171,6 +207,8 @@ pub fn search_entries<'a>(entries: &'a [VaultEntry], query: &str) -> Vec<&'a Vau
     matches
 }
 
+/// Score an entry against `query`, returning a lower number for higher-priority matches
+/// (title first, tags last) or `None` when nothing matches.
 fn relevance(entry: &VaultEntry, query: &str) -> Option<u8> {
     if entry.title.to_lowercase().contains(query) {
         Some(0)

--- a/packages/vault-core/src/entry.rs
+++ b/packages/vault-core/src/entry.rs
@@ -1,5 +1,6 @@
 use chrono::Utc;
 use uuid::Uuid;
+use zeroize::Zeroize;
 
 use crate::types::{EntryRevision, VaultEntry};
 
@@ -81,12 +82,20 @@ pub fn trim_entry_revisions(entry: &mut VaultEntry, revision_limit: usize) -> bo
     let revision_limit = revision_limit.min(MAX_ENTRY_REVISION_LIMIT);
 
     if revision_limit == 0 {
+        zeroize_revisions(&mut entry.revisions);
         entry.revisions.clear();
-    } else {
+    } else if revision_limit < entry.revisions.len() {
+        zeroize_revisions(&mut entry.revisions[revision_limit..]);
         entry.revisions.truncate(revision_limit);
     }
 
     entry.revisions.len() != original_len
+}
+
+fn zeroize_revisions(revisions: &mut [EntryRevision]) {
+    for revision in revisions {
+        revision.zeroize();
+    }
 }
 
 fn patch_changes_entry(entry: &VaultEntry, patch: &EntryPatch) -> bool {
@@ -118,7 +127,7 @@ fn capture_revision(entry: &mut VaultEntry, captured_at: String, revision_limit:
     let revision_limit = revision_limit.min(MAX_ENTRY_REVISION_LIMIT);
 
     if revision_limit == 0 {
-        entry.revisions.clear();
+        trim_entry_revisions(entry, revision_limit);
         return;
     }
 

--- a/packages/vault-core/src/entry.rs
+++ b/packages/vault-core/src/entry.rs
@@ -4,14 +4,9 @@ use zeroize::Zeroize;
 
 use crate::types::{EntryRevision, VaultEntry};
 
-/// Number of historical revisions retained per entry when no explicit limit is configured.
 pub const DEFAULT_ENTRY_REVISION_LIMIT: usize = 5;
-/// Hard upper bound on retained revisions; any configured limit is clamped to this value.
 pub const MAX_ENTRY_REVISION_LIMIT: usize = 25;
 
-/// Build a new [`VaultEntry`] with a fresh UUID and matching created/updated timestamps.
-///
-/// The entry starts with no revision history; snapshots are only captured on later updates.
 pub fn create_entry(title: &str, username: &str, password: &str) -> VaultEntry {
     let now = Utc::now().to_rfc3339();
 
@@ -30,11 +25,6 @@ pub fn create_entry(title: &str, username: &str, password: &str) -> VaultEntry {
     }
 }
 
-/// Partial update applied to a [`VaultEntry`].
-///
-/// A `None` field leaves the current value untouched. Fields wrapped in a nested
-/// `Option` (`collection`, `url`, `notes`) use `Some(None)` to clear the value and
-/// `Some(Some(value))` to set it.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EntryPatch {
     pub title: Option<String>,
@@ -46,20 +36,10 @@ pub struct EntryPatch {
     pub tags: Option<Vec<String>>,
 }
 
-/// Apply `patch` to `entry` using the default revision retention limit.
-///
-/// See [`update_entry_with_revision_limit`] for revision-capture semantics.
 pub fn update_entry(entry: &mut VaultEntry, patch: EntryPatch) {
     update_entry_with_revision_limit(entry, patch, DEFAULT_ENTRY_REVISION_LIMIT);
 }
 
-/// Apply `patch` to `entry`, capturing a revision snapshot when a meaningful field changes.
-///
-/// A snapshot of the pre-update values is recorded only if the patch alters at least one
-/// field, then the applied changes and a refreshed `updated_at` timestamp are written.
-/// The stored history is bounded by `revision_limit` (clamped to
-/// [`MAX_ENTRY_REVISION_LIMIT`]); a limit of `0` disables history and clears any existing
-/// revisions.
 pub fn update_entry_with_revision_limit(
     entry: &mut VaultEntry,
     patch: EntryPatch,
@@ -97,11 +77,6 @@ pub fn update_entry_with_revision_limit(
     entry.updated_at = updated_at;
 }
 
-/// Reduce `entry`'s stored revisions to at most `revision_limit` (clamped to
-/// [`MAX_ENTRY_REVISION_LIMIT`]), zeroizing every discarded revision before removal.
-///
-/// Returns `true` if any revisions were dropped, so callers can decide whether the change
-/// needs to be persisted.
 pub fn trim_entry_revisions(entry: &mut VaultEntry, revision_limit: usize) -> bool {
     let original_len = entry.revisions.len();
     let revision_limit = revision_limit.min(MAX_ENTRY_REVISION_LIMIT);
@@ -117,16 +92,12 @@ pub fn trim_entry_revisions(entry: &mut VaultEntry, revision_limit: usize) -> bo
     entry.revisions.len() != original_len
 }
 
-/// Zeroize the backing memory of each revision (including its plaintext password) before
-/// it is dropped, so discarded secrets do not linger in process memory.
 fn zeroize_revisions(revisions: &mut [EntryRevision]) {
     for revision in revisions {
         revision.zeroize();
     }
 }
 
-/// Report whether `patch` would change any field of `entry`, used to decide if a revision
-/// snapshot is warranted.
 fn patch_changes_entry(entry: &VaultEntry, patch: &EntryPatch) -> bool {
     patch
         .title
@@ -152,8 +123,6 @@ fn patch_changes_entry(entry: &VaultEntry, patch: &EntryPatch) -> bool {
         || patch.tags.as_ref().is_some_and(|tags| tags != &entry.tags)
 }
 
-/// Prepend a snapshot of `entry`'s current values as the newest revision, then trim the
-/// history to `revision_limit`. A limit of `0` records nothing and clears existing history.
 fn capture_revision(entry: &mut VaultEntry, captured_at: String, revision_limit: usize) {
     let revision_limit = revision_limit.min(MAX_ENTRY_REVISION_LIMIT);
 
@@ -179,11 +148,6 @@ fn capture_revision(entry: &mut VaultEntry, captured_at: String, revision_limit:
     trim_entry_revisions(entry, revision_limit);
 }
 
-/// Return entries matching `query`, ranked by relevance.
-///
-/// A `#tag` query filters to entries carrying that exact tag; otherwise the query is matched
-/// (case-insensitively) against title, username, collection, url, and tags in that priority
-/// order. Revision history is never searched, keeping historical secrets out of previews.
 pub fn search_entries<'a>(entries: &'a [VaultEntry], query: &str) -> Vec<&'a VaultEntry> {
     let normalized_query = query.trim().to_lowercase();
 
@@ -207,8 +171,6 @@ pub fn search_entries<'a>(entries: &'a [VaultEntry], query: &str) -> Vec<&'a Vau
     matches
 }
 
-/// Score an entry against `query`, returning a lower number for higher-priority matches
-/// (title first, tags last) or `None` when nothing matches.
 fn relevance(entry: &VaultEntry, query: &str) -> Option<u8> {
     if entry.title.to_lowercase().contains(query) {
         Some(0)

--- a/packages/vault-core/src/types.rs
+++ b/packages/vault-core/src/types.rs
@@ -36,6 +36,21 @@ pub struct VaultEntry {
     pub tags: Vec<String>,
     pub created_at: String,
     pub updated_at: String,
+    #[serde(default)]
+    pub revisions: Vec<EntryRevision>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct EntryRevision {
+    pub captured_at: String,
+    pub title: String,
+    pub username: String,
+    pub password: String,
+    pub collection: Option<String>,
+    pub url: Option<String>,
+    pub notes: Option<String>,
+    pub tags: Vec<String>,
+    pub updated_at: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/packages/vault-core/src/types.rs
+++ b/packages/vault-core/src/types.rs
@@ -138,25 +138,25 @@ mod tests {
         let entry = entry_with_revision(&current, &historical);
 
         let sensitive = [
-            current.as_str(),
-            historical.as_str(),
-            "sentinel-title",
-            "sentinel-username",
-            "sentinel-collection",
-            "sentinel-url",
-            "sentinel-notes",
-            "sentinel-tag",
-            "sentinel-revision-title",
-            "sentinel-revision-username",
-            "sentinel-revision-collection",
-            "sentinel-revision-url",
-            "sentinel-revision-notes",
-            "sentinel-revision-tag",
+            ("current password", current.as_str()),
+            ("historical password", historical.as_str()),
+            ("entry title", "sentinel-title"),
+            ("entry username", "sentinel-username"),
+            ("entry collection", "sentinel-collection"),
+            ("entry url", "sentinel-url"),
+            ("entry notes", "sentinel-notes"),
+            ("entry tag", "sentinel-tag"),
+            ("revision title", "sentinel-revision-title"),
+            ("revision username", "sentinel-revision-username"),
+            ("revision collection", "sentinel-revision-collection"),
+            ("revision url", "sentinel-revision-url"),
+            ("revision notes", "sentinel-revision-notes"),
+            ("revision tag", "sentinel-revision-tag"),
         ];
 
         for output in [format!("{entry:?}"), format!("{entry:#?}")] {
-            for value in sensitive {
-                assert!(!output.contains(value), "Debug output leaked {value}");
+            for (label, value) in sensitive {
+                assert!(!output.contains(value), "Debug output leaked {label}");
             }
             assert!(output.contains("revision_count"));
         }

--- a/packages/vault-core/src/types.rs
+++ b/packages/vault-core/src/types.rs
@@ -3,8 +3,6 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-const REDACTED: &str = "[redacted]";
-
 /// Vault encryption key — zeroized on drop.
 #[derive(ZeroizeOnDrop)]
 pub struct VaultKey(pub [u8; 32]);
@@ -48,17 +46,8 @@ impl fmt::Debug for VaultEntry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("VaultEntry")
             .field("id", &self.id)
-            .field("title", &self.title)
-            .field("username", &self.username)
-            .field("password", &REDACTED)
-            .field("collection", &self.collection)
-            .field("url", &self.url)
-            .field("notes", &self.notes)
-            .field("tags", &self.tags)
-            .field("created_at", &self.created_at)
-            .field("updated_at", &self.updated_at)
-            .field("revisions", &self.revisions)
-            .finish()
+            .field("revision_count", &self.revisions.len())
+            .finish_non_exhaustive()
     }
 }
 
@@ -77,17 +66,7 @@ pub struct EntryRevision {
 
 impl fmt::Debug for EntryRevision {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("EntryRevision")
-            .field("captured_at", &self.captured_at)
-            .field("title", &self.title)
-            .field("username", &self.username)
-            .field("password", &REDACTED)
-            .field("collection", &self.collection)
-            .field("url", &self.url)
-            .field("notes", &self.notes)
-            .field("tags", &self.tags)
-            .field("updated_at", &self.updated_at)
-            .finish()
+        f.debug_struct("EntryRevision").finish_non_exhaustive()
     }
 }
 
@@ -118,24 +97,24 @@ mod tests {
     fn entry_with_revision(password: &str, revision_password: &str) -> VaultEntry {
         VaultEntry {
             id: "11111111-2222-4333-8444-555555555555".to_string(),
-            title: "GitHub".to_string(),
-            username: "arca".to_string(),
+            title: "sentinel-title".to_string(),
+            username: "sentinel-username".to_string(),
             password: password.to_string(),
-            collection: None,
-            url: None,
-            notes: None,
-            tags: Vec::new(),
+            collection: Some("sentinel-collection".to_string()),
+            url: Some("sentinel-url".to_string()),
+            notes: Some("sentinel-notes".to_string()),
+            tags: vec!["sentinel-tag".to_string()],
             created_at: "2026-08-19T00:00:00+00:00".to_string(),
             updated_at: "2026-08-19T00:00:00+00:00".to_string(),
             revisions: vec![EntryRevision {
                 captured_at: "2026-08-18T00:00:00+00:00".to_string(),
-                title: "GitHub".to_string(),
-                username: "arca".to_string(),
+                title: "sentinel-revision-title".to_string(),
+                username: "sentinel-revision-username".to_string(),
                 password: revision_password.to_string(),
-                collection: None,
-                url: None,
-                notes: None,
-                tags: Vec::new(),
+                collection: Some("sentinel-revision-collection".to_string()),
+                url: Some("sentinel-revision-url".to_string()),
+                notes: Some("sentinel-revision-notes".to_string()),
+                tags: vec!["sentinel-revision-tag".to_string()],
                 updated_at: "2026-08-18T00:00:00+00:00".to_string(),
             }],
         }
@@ -153,18 +132,33 @@ mod tests {
     }
 
     #[test]
-    fn debug_output_redacts_current_and_historical_passwords() {
+    fn debug_output_excludes_decrypted_vault_contents() {
         let current = test_credential("current");
         let historical = test_credential("historical");
         let entry = entry_with_revision(&current, &historical);
 
-        let rendered = format!("{entry:?}");
-        let pretty = format!("{entry:#?}");
+        let sensitive = [
+            current.as_str(),
+            historical.as_str(),
+            "sentinel-title",
+            "sentinel-username",
+            "sentinel-collection",
+            "sentinel-url",
+            "sentinel-notes",
+            "sentinel-tag",
+            "sentinel-revision-title",
+            "sentinel-revision-username",
+            "sentinel-revision-collection",
+            "sentinel-revision-url",
+            "sentinel-revision-notes",
+            "sentinel-revision-tag",
+        ];
 
-        for output in [&rendered, &pretty] {
-            assert!(!output.contains(&current));
-            assert!(!output.contains(&historical));
-            assert!(output.contains("[redacted]"));
+        for output in [format!("{entry:?}"), format!("{entry:#?}")] {
+            for value in sensitive {
+                assert!(!output.contains(value), "Debug output leaked {value}");
+            }
+            assert!(output.contains("revision_count"));
         }
     }
 

--- a/packages/vault-core/src/types.rs
+++ b/packages/vault-core/src/types.rs
@@ -1,5 +1,9 @@
+use core::fmt;
+
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
+
+const REDACTED: &str = "[redacted]";
 
 /// Vault encryption key — zeroized on drop.
 #[derive(ZeroizeOnDrop)]
@@ -24,7 +28,7 @@ impl Default for KdfConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Zeroize)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
 pub struct VaultEntry {
     pub id: String,
     pub title: String,
@@ -40,7 +44,25 @@ pub struct VaultEntry {
     pub revisions: Vec<EntryRevision>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Zeroize)]
+impl fmt::Debug for VaultEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VaultEntry")
+            .field("id", &self.id)
+            .field("title", &self.title)
+            .field("username", &self.username)
+            .field("password", &REDACTED)
+            .field("collection", &self.collection)
+            .field("url", &self.url)
+            .field("notes", &self.notes)
+            .field("tags", &self.tags)
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .field("revisions", &self.revisions)
+            .finish()
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
 pub struct EntryRevision {
     pub captured_at: String,
     pub title: String,
@@ -53,6 +75,22 @@ pub struct EntryRevision {
     pub updated_at: String,
 }
 
+impl fmt::Debug for EntryRevision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EntryRevision")
+            .field("captured_at", &self.captured_at)
+            .field("title", &self.title)
+            .field("username", &self.username)
+            .field("password", &REDACTED)
+            .field("collection", &self.collection)
+            .field("url", &self.url)
+            .field("notes", &self.notes)
+            .field("tags", &self.tags)
+            .field("updated_at", &self.updated_at)
+            .finish()
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct VaultMeta {
     pub name: String,
@@ -62,13 +100,59 @@ pub struct VaultMeta {
 
 #[cfg(test)]
 mod tests {
-    use super::{KdfConfig, VaultKey};
+    use super::{EntryRevision, KdfConfig, VaultEntry, VaultKey};
 
     fn assert_zeroize_on_drop<T: zeroize::ZeroizeOnDrop>() {}
+
+    fn entry_with_revision(password: &str, revision_password: &str) -> VaultEntry {
+        VaultEntry {
+            id: "11111111-2222-4333-8444-555555555555".to_string(),
+            title: "GitHub".to_string(),
+            username: "arca".to_string(),
+            password: password.to_string(),
+            collection: None,
+            url: None,
+            notes: None,
+            tags: Vec::new(),
+            created_at: "2026-08-19T00:00:00+00:00".to_string(),
+            updated_at: "2026-08-19T00:00:00+00:00".to_string(),
+            revisions: vec![EntryRevision {
+                captured_at: "2026-08-18T00:00:00+00:00".to_string(),
+                title: "GitHub".to_string(),
+                username: "arca".to_string(),
+                password: revision_password.to_string(),
+                collection: None,
+                url: None,
+                notes: None,
+                tags: Vec::new(),
+                updated_at: "2026-08-18T00:00:00+00:00".to_string(),
+            }],
+        }
+    }
 
     #[test]
     fn vault_key_implements_zeroize_on_drop() {
         assert_zeroize_on_drop::<VaultKey>();
+    }
+
+    #[test]
+    fn entry_secrets_implement_zeroize_on_drop() {
+        assert_zeroize_on_drop::<VaultEntry>();
+        assert_zeroize_on_drop::<EntryRevision>();
+    }
+
+    #[test]
+    fn debug_output_redacts_current_and_historical_passwords() {
+        let entry = entry_with_revision("current-secret-abc", "historical-secret-xyz");
+
+        let rendered = format!("{entry:?}");
+        let pretty = format!("{entry:#?}");
+
+        for output in [&rendered, &pretty] {
+            assert!(!output.contains("current-secret-abc"));
+            assert!(!output.contains("historical-secret-xyz"));
+            assert!(output.contains("[redacted]"));
+        }
     }
 
     #[test]

--- a/packages/vault-core/src/types.rs
+++ b/packages/vault-core/src/types.rs
@@ -100,9 +100,20 @@ pub struct VaultMeta {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use super::{EntryRevision, KdfConfig, VaultEntry, VaultKey};
 
     fn assert_zeroize_on_drop<T: zeroize::ZeroizeOnDrop>() {}
+
+    fn test_credential(label: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+
+        format!("test-credential-{label}-{nanos}")
+    }
 
     fn entry_with_revision(password: &str, revision_password: &str) -> VaultEntry {
         VaultEntry {
@@ -143,14 +154,16 @@ mod tests {
 
     #[test]
     fn debug_output_redacts_current_and_historical_passwords() {
-        let entry = entry_with_revision("current-secret-abc", "historical-secret-xyz");
+        let current = test_credential("current");
+        let historical = test_credential("historical");
+        let entry = entry_with_revision(&current, &historical);
 
         let rendered = format!("{entry:?}");
         let pretty = format!("{entry:#?}");
 
         for output in [&rendered, &pretty] {
-            assert!(!output.contains("current-secret-abc"));
-            assert!(!output.contains("historical-secret-xyz"));
+            assert!(!output.contains(&current));
+            assert!(!output.contains(&historical));
             assert!(output.contains("[redacted]"));
         }
     }

--- a/packages/vault-core/src/types.rs
+++ b/packages/vault-core/src/types.rs
@@ -24,10 +24,6 @@ impl Default for KdfConfig {
     }
 }
 
-/// A single credential stored in the vault, including any retained historical revisions.
-///
-/// Derives `Zeroize` so the plaintext password and other secret fields can be wiped from
-/// memory when a copy is discarded.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Zeroize)]
 pub struct VaultEntry {
     pub id: String,
@@ -40,16 +36,10 @@ pub struct VaultEntry {
     pub tags: Vec<String>,
     pub created_at: String,
     pub updated_at: String,
-    /// Newest-first snapshots of prior values; defaults to empty for vaults saved before
-    /// revision history existed.
     #[serde(default)]
     pub revisions: Vec<EntryRevision>,
 }
 
-/// A point-in-time snapshot of an entry's values captured before a meaningful update.
-///
-/// Revisions carry historical plaintext secrets, so this type derives `Zeroize` and is only
-/// ever persisted inside the encrypted vault, never surfaced in list/search/audit DTOs.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Zeroize)]
 pub struct EntryRevision {
     pub captured_at: String,

--- a/packages/vault-core/src/types.rs
+++ b/packages/vault-core/src/types.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use zeroize::ZeroizeOnDrop;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Vault encryption key — zeroized on drop.
 #[derive(ZeroizeOnDrop)]
@@ -24,7 +24,7 @@ impl Default for KdfConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Zeroize)]
 pub struct VaultEntry {
     pub id: String,
     pub title: String,
@@ -40,7 +40,7 @@ pub struct VaultEntry {
     pub revisions: Vec<EntryRevision>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Zeroize)]
 pub struct EntryRevision {
     pub captured_at: String,
     pub title: String,

--- a/packages/vault-core/src/types.rs
+++ b/packages/vault-core/src/types.rs
@@ -24,6 +24,10 @@ impl Default for KdfConfig {
     }
 }
 
+/// A single credential stored in the vault, including any retained historical revisions.
+///
+/// Derives `Zeroize` so the plaintext password and other secret fields can be wiped from
+/// memory when a copy is discarded.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Zeroize)]
 pub struct VaultEntry {
     pub id: String,
@@ -36,10 +40,16 @@ pub struct VaultEntry {
     pub tags: Vec<String>,
     pub created_at: String,
     pub updated_at: String,
+    /// Newest-first snapshots of prior values; defaults to empty for vaults saved before
+    /// revision history existed.
     #[serde(default)]
     pub revisions: Vec<EntryRevision>,
 }
 
+/// A point-in-time snapshot of an entry's values captured before a meaningful update.
+///
+/// Revisions carry historical plaintext secrets, so this type derives `Zeroize` and is only
+/// ever persisted inside the encrypted vault, never surfaced in list/search/audit DTOs.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Zeroize)]
 pub struct EntryRevision {
     pub captured_at: String,

--- a/packages/vault-core/src/vault.rs
+++ b/packages/vault-core/src/vault.rs
@@ -212,6 +212,11 @@ fn vault_entry_from_keepass_entry(entry: &KeepassEntry) -> Result<VaultEntry, Va
     })
 }
 
+/// Decode the protected `ArcaRevisions` field into revision snapshots.
+///
+/// Returns an empty history when the field is absent. Malformed JSON is surfaced as a
+/// [`VaultError`] rather than silently discarded, so opening fails loudly instead of
+/// dropping the stored history on the next save.
 fn entry_revisions_from_keepass_entry(
     entry: &KeepassEntry,
 ) -> Result<Vec<EntryRevision>, VaultError> {

--- a/packages/vault-core/src/vault.rs
+++ b/packages/vault-core/src/vault.rs
@@ -212,11 +212,6 @@ fn vault_entry_from_keepass_entry(entry: &KeepassEntry) -> Result<VaultEntry, Va
     })
 }
 
-/// Decode the protected `ArcaRevisions` field into revision snapshots.
-///
-/// Returns an empty history when the field is absent. Malformed JSON is surfaced as a
-/// [`VaultError`] rather than silently discarded, so opening fails loudly instead of
-/// dropping the stored history on the next save.
 fn entry_revisions_from_keepass_entry(
     entry: &KeepassEntry,
 ) -> Result<Vec<EntryRevision>, VaultError> {

--- a/packages/vault-core/src/vault.rs
+++ b/packages/vault-core/src/vault.rs
@@ -17,6 +17,7 @@ const FIELD_PASSWORD: &str = "Password";
 const FIELD_COLLECTION: &str = "ArcaCollection";
 const FIELD_URL: &str = "URL";
 const FIELD_NOTES: &str = "Notes";
+const FIELD_REVISIONS: &str = "ArcaRevisions";
 
 /// Open and decrypt a KDBX file.
 ///
@@ -132,6 +133,11 @@ fn populate_keepass_entry(
     if let Some(notes) = &entry.notes {
         keepass_entry.set_unprotected(FIELD_NOTES, notes.clone());
     }
+    if !entry.revisions.is_empty() {
+        let revisions = serde_json::to_string(&entry.revisions)
+            .map_err(|error| VaultError::SerializationError(error.to_string()))?;
+        keepass_entry.set_protected(FIELD_REVISIONS, revisions);
+    }
 
     keepass_entry.tags = entry.tags.clone();
     keepass_entry.times.creation = Some(parse_rfc3339(&entry.created_at)?);
@@ -202,7 +208,15 @@ fn vault_entry_from_keepass_entry(entry: &KeepassEntry) -> VaultEntry {
         tags: entry.tags.clone(),
         created_at,
         updated_at,
+        revisions: entry_revisions_from_keepass_entry(entry),
     }
+}
+
+fn entry_revisions_from_keepass_entry(entry: &KeepassEntry) -> Vec<crate::types::EntryRevision> {
+    entry
+        .get(FIELD_REVISIONS)
+        .and_then(|value| serde_json::from_str(value).ok())
+        .unwrap_or_default()
 }
 
 fn optional_string(value: Option<&str>) -> Option<String> {

--- a/packages/vault-core/src/vault.rs
+++ b/packages/vault-core/src/vault.rs
@@ -9,7 +9,7 @@ use keepass::{Database, DatabaseKey};
 use uuid::Uuid;
 
 use crate::error::VaultError;
-use crate::types::{VaultEntry, VaultMeta};
+use crate::types::{EntryRevision, VaultEntry, VaultMeta};
 
 const FIELD_TITLE: &str = "Title";
 const FIELD_USERNAME: &str = "UserName";
@@ -34,7 +34,7 @@ pub fn open_vault(path: &Path, password: &str) -> Result<(VaultMeta, Vec<VaultEn
     let key = DatabaseKey::new().with_password(password);
     let database = Database::open(&mut file, key).map_err(map_open_error)?;
     let meta = meta_from_database(&database);
-    let entries = entries_from_database(&database);
+    let entries = entries_from_database(&database)?;
 
     Ok((meta, entries))
 }
@@ -175,14 +175,14 @@ fn meta_from_database(database: &Database) -> VaultMeta {
     }
 }
 
-fn entries_from_database(database: &Database) -> Vec<VaultEntry> {
+fn entries_from_database(database: &Database) -> Result<Vec<VaultEntry>, VaultError> {
     database
         .iter_all_entries()
         .map(|entry| vault_entry_from_keepass_entry(&entry))
         .collect()
 }
 
-fn vault_entry_from_keepass_entry(entry: &KeepassEntry) -> VaultEntry {
+fn vault_entry_from_keepass_entry(entry: &KeepassEntry) -> Result<VaultEntry, VaultError> {
     let now = Utc::now().to_rfc3339();
     let created_at = entry
         .times
@@ -197,7 +197,7 @@ fn vault_entry_from_keepass_entry(entry: &KeepassEntry) -> VaultEntry {
         .map(naive_to_rfc3339)
         .unwrap_or(now);
 
-    VaultEntry {
+    Ok(VaultEntry {
         id: entry.id().to_string(),
         title: entry.get_title().unwrap_or_default().to_string(),
         username: entry.get_username().unwrap_or_default().to_string(),
@@ -208,15 +208,19 @@ fn vault_entry_from_keepass_entry(entry: &KeepassEntry) -> VaultEntry {
         tags: entry.tags.clone(),
         created_at,
         updated_at,
-        revisions: entry_revisions_from_keepass_entry(entry),
-    }
+        revisions: entry_revisions_from_keepass_entry(entry)?,
+    })
 }
 
-fn entry_revisions_from_keepass_entry(entry: &KeepassEntry) -> Vec<crate::types::EntryRevision> {
-    entry
-        .get(FIELD_REVISIONS)
-        .and_then(|value| serde_json::from_str(value).ok())
-        .unwrap_or_default()
+fn entry_revisions_from_keepass_entry(
+    entry: &KeepassEntry,
+) -> Result<Vec<EntryRevision>, VaultError> {
+    let Some(value) = entry.get(FIELD_REVISIONS) else {
+        return Ok(Vec::new());
+    };
+
+    serde_json::from_str(value)
+        .map_err(|_| VaultError::SerializationError("Malformed ArcaRevisions field".to_string()))
 }
 
 fn optional_string(value: Option<&str>) -> Option<String> {
@@ -270,9 +274,17 @@ fn map_save_error(error: DatabaseSaveError) -> VaultError {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::File;
+    use std::io::BufWriter;
     use std::path::Path;
 
-    use super::{create_vault, tmp_path_for};
+    use keepass::{Database, DatabaseKey};
+    use uuid::Uuid;
+
+    use super::{create_vault, open_vault, save_vault, tmp_path_for, FIELD_REVISIONS};
+    use crate::entry::{create_entry, update_entry, EntryPatch};
+    use crate::error::VaultError;
+    use crate::types::VaultMeta;
 
     #[test]
     fn tmp_path_appends_tmp_suffix() {
@@ -286,11 +298,84 @@ mod tests {
     fn create_vault_returns_named_meta() {
         let dir = tempfile::tempdir().expect("tempdir should be created");
         let path = dir.path().join("empty.kdbx");
+        let vault_password = test_vault_password();
 
         let meta =
-            create_vault(&path, "master-password", "TEST_VAULT").expect("vault should be created");
+            create_vault(&path, &vault_password, "TEST_VAULT").expect("vault should be created");
 
         assert_eq!(meta.name, "TEST_VAULT");
         assert!(path.exists());
+    }
+
+    #[test]
+    fn open_vault_rejects_malformed_revision_history_without_rewriting_it() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let path = dir.path().join("malformed-revisions.kdbx");
+        let vault_password = test_vault_password();
+        let malformed_revisions = format!("not-json-{}", Uuid::new_v4());
+        let meta = VaultMeta {
+            name: "TEST_VAULT".to_string(),
+            created_at: "2026-06-11T00:00:00+00:00".to_string(),
+            modified_at: "2026-06-11T00:00:00+00:00".to_string(),
+        };
+        let mut entry = create_entry("GitHub", "arca", &test_entry_credential());
+
+        update_entry(
+            &mut entry,
+            EntryPatch {
+                title: Some("GitHub Enterprise".to_string()),
+                ..EntryPatch::default()
+            },
+        );
+        save_vault(&path, &vault_password, &meta, &[entry]).expect("vault should save");
+        overwrite_revision_field(&path, &vault_password, &malformed_revisions);
+
+        let error =
+            open_vault(&path, &vault_password).expect_err("malformed revisions should fail");
+        assert!(matches!(error, VaultError::SerializationError(_)));
+        assert_eq!(
+            read_revision_field(&path, &vault_password).as_deref(),
+            Some(malformed_revisions.as_str()),
+        );
+    }
+
+    fn overwrite_revision_field(path: &Path, vault_password: &str, value: &str) {
+        let mut file = File::open(path).expect("vault should open");
+        let mut database =
+            Database::open(&mut file, DatabaseKey::new().with_password(vault_password))
+                .expect("vault should decrypt");
+        database.foreach_entry_mut(|mut entry| {
+            entry.set_protected(FIELD_REVISIONS, value);
+        });
+
+        let file = File::create(path).expect("vault should be writable");
+        let mut writer = BufWriter::new(file);
+        database
+            .save(
+                &mut writer,
+                DatabaseKey::new().with_password(vault_password),
+            )
+            .expect("vault should save with malformed revisions");
+    }
+
+    fn read_revision_field(path: &Path, vault_password: &str) -> Option<String> {
+        let mut file = File::open(path).expect("vault should open");
+        let database = Database::open(&mut file, DatabaseKey::new().with_password(vault_password))
+            .expect("vault should decrypt");
+
+        let revisions = database
+            .iter_all_entries()
+            .next()
+            .and_then(|entry| entry.get(FIELD_REVISIONS).map(str::to_string));
+
+        revisions
+    }
+
+    fn test_vault_password() -> String {
+        Uuid::new_v4().to_string()
+    }
+
+    fn test_entry_credential() -> String {
+        Uuid::new_v4().to_string()
     }
 }

--- a/packages/vault-core/tests/vault_roundtrip.rs
+++ b/packages/vault-core/tests/vault_roundtrip.rs
@@ -38,6 +38,7 @@ fn test_create_open_roundtrip() {
         Some("primary repository account")
     );
     assert_eq!(entries[0].tags, vec!["work", "ssh"]);
+    assert!(entries[0].revisions.is_empty());
 }
 
 #[test]
@@ -176,6 +177,58 @@ fn test_current_save_opens_with_keepass_and_protects_password() {
     assert_eq!(keepass_entry.get_username(), Some("fixture_user"));
     assert_eq!(keepass_entry.get_password(), Some(entry_password.as_str()));
     assert!(password_value.is_protected());
+}
+
+#[test]
+fn test_entry_revisions_roundtrip_and_use_protected_field() {
+    let dir = tempfile::tempdir().expect("tempdir should be created");
+    let path = dir.path().join("revisions.kdbx");
+    let meta = VaultMeta {
+        name: "REVISION_KEEPASS".to_string(),
+        created_at: "2026-06-11T00:00:00+00:00".to_string(),
+        modified_at: "2026-06-11T00:00:00+00:00".to_string(),
+    };
+    let vault_password = test_password(&["revision", "vault", "password"]);
+    let original_password = test_password(&["original", "entry", "password"]);
+    let updated_password = test_password(&["updated", "entry", "password"]);
+    let mut entry = create_entry("Revision Entry", "fixture_user", &original_password);
+
+    update_entry(
+        &mut entry,
+        EntryPatch {
+            password: Some(updated_password.clone()),
+            notes: Some(Some("rotated credential".to_string())),
+            ..EntryPatch::default()
+        },
+    );
+
+    save_vault(&path, &vault_password, &meta, &[entry.clone()])
+        .expect("revision vault should save");
+
+    let (_, reopened_entries) =
+        open_vault(&path, &vault_password).expect("revision vault should reopen");
+    let reopened = reopened_entries
+        .first()
+        .expect("revision vault should contain an entry");
+
+    assert_eq!(reopened.password, updated_password);
+    assert_eq!(reopened.revisions.len(), 1);
+    assert_eq!(reopened.revisions[0].password, original_password);
+    assert!(reopened.revisions[0].notes.is_none());
+
+    let mut file = File::open(&path).expect("saved vault should exist");
+    let key = DatabaseKey::new().with_password(&vault_password);
+    let database = Database::open(&mut file, key).expect("keepass crate should open saved vault");
+    let keepass_entry = database
+        .iter_all_entries()
+        .next()
+        .expect("saved vault should contain one entry");
+    let revisions_value = keepass_entry
+        .fields
+        .get("ArcaRevisions")
+        .expect("saved entry should contain protected revisions");
+
+    assert!(revisions_value.is_protected());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add encrypted bounded entry revisions in vault-core before meaningful entry updates
- expose revisionCount through Tauri and render the real count in entry detail
- add a Settings control for password history retention: off, 1, 3, 5, 10, or 25 previous passwords
- trim existing unlocked-vault revisions when the retention setting is lowered

## Security notes
- revision snapshots are persisted inside the encrypted KDBX as a protected Arca field
- list/search/audit DTOs still do not expose historical plaintext values
- retention defaults to 5 and is hard-capped at 25 in vault-core
- setting retention to off uses 0 and clears stored revisions for the unlocked vault

Closes #157

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added password revision history for vault entries.
  * Display revision counts and the last modified timestamp in entry details.
  * Added settings to choose how many password revisions to retain, including disabling history.
  * Preserved revision history securely when vaults are saved and reopened.

* **Bug Fixes**
  * Automatically trims stored revisions when retention settings are reduced.
  * Prevents unchanged edits from creating unnecessary revisions.
  * Securely removes discarded revision data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->