### PR TITLE
ci: fix TruffleHog base/head for push events

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -21,6 +21,6 @@ jobs:
       - uses: trufflesecurity/trufflehog@a7082b69f5bc6167bbe27ebab82bf6707f267bf6
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.event.pull_request.head.sha || github.sha }}
           extra_args: --results=verified


### PR DESCRIPTION
## Problem
The **Secret Scan** workflow fails on every push/merge to `main` (e.g. [run 32360420247](https://github.com/akei9/arca/actions/runs/32360420247/job/96398626776)) with:

> BASE and HEAD commits are the same. TruffleHog won't scan anything.

This is a config bug, **not** a leaked secret - TruffleHog aborts before scanning.

## Root cause
The job set:

```yaml
base: ${{ github.event.repository.default_branch }}   # -> "main"
head: HEAD
```

On a `push` to `main`, `HEAD` *is* `main`, so `base` and `head` resolve to the same commit and TruffleHog exits 1. It only worked on `pull_request` events (where `HEAD` is the PR branch), which is why it surfaced only after a merge fired the `push` trigger.

## Fix
Resolve `base`/`head` per event type so each gets a real diff range:

```yaml
base: ${{ github.event.pull_request.base.sha || github.event.before }}
head: ${{ github.event.pull_request.head.sha || github.sha }}
```

- **pull_request** → `base.sha … head.sha` (unchanged behavior)
- **push/merge to main** → `before … sha` (the commits the push introduced)

Pinned action SHA, `fetch-depth: 0`, permissions, and `--results=verified` are unchanged.

## Verification
Ran TruffleHog `3.97.0` locally over the full git history of merged `main` (`6bd069e`), stricter than CI (`--results=verified,unknown`):

```
finished scanning  chunks: 2757  verified_secrets: 0  unverified_secrets: 0
exit code: 0
```

No secrets - confirming the CI failure was solely the base/head misconfiguration.
