### PR TITLE
feat: add entry revision history view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5339,6 +5339,7 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,5 +21,5 @@ vault-core = { path = "../../../packages/vault-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-zeroize = "1"
+zeroize = { version = "1", features = ["serde"] }
 tauri-plugin-clipboard-manager = "2.3.2"

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -50,6 +50,7 @@ pub struct RevisionDto {
     pub url: Option<String>,
     pub notes: Option<String>,
     pub tags: Vec<String>,
+    pub password_changed: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -201,7 +202,18 @@ fn get_entry_revisions_in_state(id: &str, state: &AppState) -> Result<Vec<Revisi
             entry
                 .revisions
                 .iter()
-                .map(RevisionDto::from_revision)
+                .enumerate()
+                .map(|(index, revision)| {
+                    let newer_password = if index == 0 {
+                        entry.password.as_str()
+                    } else {
+                        entry.revisions[index - 1].password.as_str()
+                    };
+                    RevisionDto::from_revision(
+                        revision,
+                        revision.password.as_str() != newer_password,
+                    )
+                })
                 .collect()
         })
         .ok_or_else(|| ArcaError::not_found("Entry"))
@@ -394,7 +406,7 @@ impl EntryDto {
 }
 
 impl RevisionDto {
-    fn from_revision(revision: &EntryRevision) -> Self {
+    fn from_revision(revision: &EntryRevision, password_changed: bool) -> Self {
         Self {
             captured_at: revision.captured_at.clone(),
             updated_at: revision.updated_at.clone(),
@@ -404,6 +416,7 @@ impl RevisionDto {
             url: revision.url.clone(),
             notes: revision.notes.clone(),
             tags: revision.tags.clone(),
+            password_changed,
         }
     }
 }
@@ -707,14 +720,43 @@ mod tests {
     }
 
     #[test]
+    fn get_entry_revisions_flags_password_changes() {
+        let state = AppState::default();
+        let mut entry = create_entry("GitHub", "arca", &test_credential("current"));
+        update_entry(
+            &mut entry,
+            EntryPatch {
+                password: Some(test_credential("rotated")),
+                ..EntryPatch::default()
+            },
+        );
+        update_entry(
+            &mut entry,
+            EntryPatch {
+                title: Some("GitHub Enterprise".to_string()),
+                ..EntryPatch::default()
+            },
+        );
+        let entry_id = entry.id.clone();
+        unlock_with_entry(&state, entry);
+
+        let revisions = get_entry_revisions_in_state(&entry_id, &state)
+            .expect("revisions should be returned for an unlocked entry");
+
+        assert_eq!(revisions.len(), 2);
+        assert!(!revisions[0].password_changed);
+        assert!(revisions[1].password_changed);
+    }
+
+    #[test]
     fn revision_dto_serialization_excludes_password() {
         let entry = create_entry_with_revisions(1);
         let revision = &entry.revisions[0];
-        let dto = RevisionDto::from_revision(revision);
+        let dto = RevisionDto::from_revision(revision, true);
 
         let json = serde_json::to_string(&dto).expect("revision dto should serialize");
 
-        assert!(!json.contains("password"));
+        assert!(!json.contains("\"password\""));
         assert!(!json.contains(revision.password.as_str()));
     }
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -224,7 +224,7 @@ pub fn reveal_entry_revision_password(
     id: String,
     index: usize,
     state: State<'_, AppState>,
-) -> Result<String, ArcaError> {
+) -> Result<Zeroizing<String>, ArcaError> {
     reveal_entry_revision_password_in_state(&id, index, state.inner())
 }
 
@@ -232,7 +232,7 @@ fn reveal_entry_revision_password_in_state(
     id: &str,
     index: usize,
     state: &AppState,
-) -> Result<String, ArcaError> {
+) -> Result<Zeroizing<String>, ArcaError> {
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
     session.touch();
@@ -246,7 +246,7 @@ fn reveal_entry_revision_password_in_state(
     entry
         .revisions
         .get(index)
-        .map(|revision| revision.password.clone())
+        .map(|revision| Zeroizing::new(revision.password.clone()))
         .ok_or_else(|| ArcaError::not_found("Revision"))
 }
 
@@ -660,6 +660,7 @@ mod tests {
         update_settings_in_state, validate_entry_password, validate_optional_entry_password,
         CreateEntryDto, EntryDto, GeneratorConfigDto, RevisionDto, UpdateEntryDto,
     };
+    use crate::error::ArcaError;
     use crate::state::{AppState, Settings};
     use std::fs;
     use std::path::PathBuf;
@@ -771,7 +772,7 @@ mod tests {
         let password = reveal_entry_revision_password_in_state(&entry_id, 0, &state)
             .expect("revision password should be revealed for an unlocked entry");
 
-        assert_eq!(password, expected);
+        assert_eq!(*password, expected);
     }
 
     #[test]
@@ -781,8 +782,10 @@ mod tests {
         let entry_id = entry.id.clone();
         unlock_with_entry(&state, entry);
 
-        let error = reveal_entry_revision_password_in_state(&entry_id, 99, &state)
-            .expect_err("an out-of-range revision index should error");
+        let error = expect_error(
+            reveal_entry_revision_password_in_state(&entry_id, 99, &state),
+            "an out-of-range revision index should error",
+        );
 
         assert_eq!(error.code, "not_found");
     }
@@ -791,11 +794,14 @@ mod tests {
     fn revision_commands_require_unlocked_vault() {
         let state = AppState::default();
 
-        let list_error = get_entry_revisions_in_state("missing", &state)
-            .err()
-            .expect("a locked vault should not return revisions");
-        let reveal_error = reveal_entry_revision_password_in_state("missing", 0, &state)
-            .expect_err("a locked vault should not reveal a revision password");
+        let list_error = expect_error(
+            get_entry_revisions_in_state("missing", &state),
+            "a locked vault should not return revisions",
+        );
+        let reveal_error = expect_error(
+            reveal_entry_revision_password_in_state("missing", 0, &state),
+            "a locked vault should not reveal a revision password",
+        );
 
         assert_eq!(list_error.code, "vault_locked");
         assert_eq!(reveal_error.code, "vault_locked");
@@ -1004,6 +1010,13 @@ mod tests {
                 test_meta(),
                 vec![entry],
             );
+    }
+
+    fn expect_error<T>(result: Result<T, ArcaError>, message: &str) -> ArcaError {
+        match result {
+            Ok(_) => panic!("{message}"),
+            Err(error) => error,
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 use vault_core::entry as core_entry;
 use vault_core::generator as core_generator;
+use vault_core::types::EntryRevision;
 use vault_core::vault as core_vault;
 use vault_core::{GeneratorConfig, GeneratorMode, VaultEntry, VaultMeta};
 use zeroize::Zeroizing;
@@ -36,6 +37,19 @@ pub struct EntryDto {
     pub created_at: String,
     pub updated_at: String,
     pub revision_count: usize,
+}
+
+#[derive(Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RevisionDto {
+    pub captured_at: String,
+    pub updated_at: String,
+    pub title: String,
+    pub username: String,
+    pub collection: Option<String>,
+    pub url: Option<String>,
+    pub notes: Option<String>,
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -164,6 +178,64 @@ pub fn get_entry(id: String, state: State<'_, AppState>) -> Result<EntryDto, Arc
         .find(|entry| entry.id == id)
         .map(|entry| EntryDto::from_entry(entry, true))
         .ok_or_else(|| ArcaError::not_found("Entry"))
+}
+
+#[tauri::command]
+pub fn get_entry_revisions(
+    id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<RevisionDto>, ArcaError> {
+    get_entry_revisions_in_state(&id, state.inner())
+}
+
+fn get_entry_revisions_in_state(id: &str, state: &AppState) -> Result<Vec<RevisionDto>, ArcaError> {
+    let mut session = state.session()?;
+    ensure_unlocked(&session)?;
+    session.touch();
+
+    session
+        .entries
+        .iter()
+        .find(|entry| entry.id == id)
+        .map(|entry| {
+            entry
+                .revisions
+                .iter()
+                .map(RevisionDto::from_revision)
+                .collect()
+        })
+        .ok_or_else(|| ArcaError::not_found("Entry"))
+}
+
+#[tauri::command]
+pub fn reveal_entry_revision_password(
+    id: String,
+    index: usize,
+    state: State<'_, AppState>,
+) -> Result<String, ArcaError> {
+    reveal_entry_revision_password_in_state(&id, index, state.inner())
+}
+
+fn reveal_entry_revision_password_in_state(
+    id: &str,
+    index: usize,
+    state: &AppState,
+) -> Result<String, ArcaError> {
+    let mut session = state.session()?;
+    ensure_unlocked(&session)?;
+    session.touch();
+
+    let entry = session
+        .entries
+        .iter()
+        .find(|entry| entry.id == id)
+        .ok_or_else(|| ArcaError::not_found("Entry"))?;
+
+    entry
+        .revisions
+        .get(index)
+        .map(|revision| revision.password.clone())
+        .ok_or_else(|| ArcaError::not_found("Revision"))
 }
 
 #[tauri::command]
@@ -317,6 +389,21 @@ impl EntryDto {
             created_at: entry.created_at.clone(),
             updated_at: entry.updated_at.clone(),
             revision_count: entry.revisions.len(),
+        }
+    }
+}
+
+impl RevisionDto {
+    fn from_revision(revision: &EntryRevision) -> Self {
+        Self {
+            captured_at: revision.captured_at.clone(),
+            updated_at: revision.updated_at.clone(),
+            title: revision.title.clone(),
+            username: revision.username.clone(),
+            collection: revision.collection.clone(),
+            url: revision.url.clone(),
+            notes: revision.notes.clone(),
+            tags: revision.tags.clone(),
         }
     }
 }
@@ -556,12 +643,13 @@ fn home_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::{
-        suggest_paths_for, update_settings_in_state, validate_entry_password,
-        validate_optional_entry_password, CreateEntryDto, EntryDto, GeneratorConfigDto,
-        UpdateEntryDto,
+        get_entry_revisions_in_state, reveal_entry_revision_password_in_state, suggest_paths_for,
+        update_settings_in_state, validate_entry_password, validate_optional_entry_password,
+        CreateEntryDto, EntryDto, GeneratorConfigDto, RevisionDto, UpdateEntryDto,
     };
     use crate::state::{AppState, Settings};
     use std::fs;
+    use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
     use vault_core::entry::{create_entry, update_entry};
     use vault_core::entry::{EntryPatch, DEFAULT_ENTRY_REVISION_LIMIT};
@@ -593,6 +681,82 @@ mod tests {
         assert_eq!(revealed.password.as_deref(), Some(credential.as_str()));
         assert_eq!(masked.revision_count, 1);
         assert_eq!(revealed.revision_count, 1);
+    }
+
+    #[test]
+    fn get_entry_revisions_returns_metadata_for_unlocked_entry() {
+        let state = AppState::default();
+        let entry = create_entry_with_revisions(3);
+        let entry_id = entry.id.clone();
+        let expected_titles: Vec<String> = entry
+            .revisions
+            .iter()
+            .map(|revision| revision.title.clone())
+            .collect();
+        unlock_with_entry(&state, entry);
+
+        let revisions = get_entry_revisions_in_state(&entry_id, &state)
+            .expect("revisions should be returned for an unlocked entry");
+
+        assert_eq!(revisions.len(), 3);
+        let titles: Vec<String> = revisions
+            .iter()
+            .map(|revision| revision.title.clone())
+            .collect();
+        assert_eq!(titles, expected_titles);
+    }
+
+    #[test]
+    fn revision_dto_serialization_excludes_password() {
+        let entry = create_entry_with_revisions(1);
+        let revision = &entry.revisions[0];
+        let dto = RevisionDto::from_revision(revision);
+
+        let json = serde_json::to_string(&dto).expect("revision dto should serialize");
+
+        assert!(!json.contains("password"));
+        assert!(!json.contains(revision.password.as_str()));
+    }
+
+    #[test]
+    fn reveal_entry_revision_password_returns_plaintext_for_unlocked_entry() {
+        let state = AppState::default();
+        let entry = create_entry_with_revisions(3);
+        let entry_id = entry.id.clone();
+        let expected = entry.revisions[0].password.clone();
+        unlock_with_entry(&state, entry);
+
+        let password = reveal_entry_revision_password_in_state(&entry_id, 0, &state)
+            .expect("revision password should be revealed for an unlocked entry");
+
+        assert_eq!(password, expected);
+    }
+
+    #[test]
+    fn reveal_entry_revision_password_rejects_out_of_range_index() {
+        let state = AppState::default();
+        let entry = create_entry_with_revisions(2);
+        let entry_id = entry.id.clone();
+        unlock_with_entry(&state, entry);
+
+        let error = reveal_entry_revision_password_in_state(&entry_id, 99, &state)
+            .expect_err("an out-of-range revision index should error");
+
+        assert_eq!(error.code, "not_found");
+    }
+
+    #[test]
+    fn revision_commands_require_unlocked_vault() {
+        let state = AppState::default();
+
+        let list_error = get_entry_revisions_in_state("missing", &state)
+            .err()
+            .expect("a locked vault should not return revisions");
+        let reveal_error = reveal_entry_revision_password_in_state("missing", 0, &state)
+            .expect_err("a locked vault should not reveal a revision password");
+
+        assert_eq!(list_error.code, "vault_locked");
+        assert_eq!(reveal_error.code, "vault_locked");
     }
 
     #[test]
@@ -786,6 +950,18 @@ mod tests {
             created_at: "2026-08-19T00:00:00+00:00".to_string(),
             modified_at: "2026-08-19T00:00:00+00:00".to_string(),
         }
+    }
+
+    fn unlock_with_entry(state: &AppState, entry: vault_core::VaultEntry) {
+        state
+            .session()
+            .expect("session lock should be available")
+            .unlock(
+                PathBuf::from("in-memory.arca"),
+                Zeroizing::new(test_credential("vault")),
+                test_meta(),
+                vec![entry],
+            );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,9 +3,9 @@ pub mod error;
 pub mod state;
 
 use commands::{
-    create_entry, create_vault, delete_entry, generate_password, get_entry, get_settings,
-    list_entries, lock_vault, search_entries, suggest_paths, unlock_vault, update_entry,
-    update_settings,
+    create_entry, create_vault, delete_entry, generate_password, get_entry, get_entry_revisions,
+    get_settings, list_entries, lock_vault, reveal_entry_revision_password, search_entries,
+    suggest_paths, unlock_vault, update_entry, update_settings,
 };
 use state::AppState;
 
@@ -19,6 +19,8 @@ pub fn run() -> tauri::Result<()> {
             create_vault,
             list_entries,
             get_entry,
+            get_entry_revisions,
+            reveal_entry_revision_password,
             create_entry,
             update_entry,
             delete_entry,

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -3428,8 +3428,8 @@ body {
    ─────────────────────────────────────────────────────────── */
 
 .rev-panel {
-  width: 720px;
-  max-height: 640px;
+  width: min(720px, calc(100vw - 52px));
+  max-height: min(640px, calc(100dvh - 52px));
   display: flex;
   flex-direction: column;
   background: var(--bg-card);
@@ -3476,9 +3476,16 @@ body {
 .rev-panel__close { flex: 0 0 auto; }
 .rev-panel__close kbd {
   font-family: var(--font-mono); font-size: 9px; font-weight: 600;
-  border: 1px solid currentColor; opacity: 0.5;
+  border: 1px solid currentcolor; opacity: 0.5;
   border-radius: 3px; padding: 1px 5px; letter-spacing: 0.04em;
 }
+.rev-panel__error {
+  flex: 0 0 auto;
+  padding: 9px 18px;
+  border-bottom: 1px dashed var(--rule-dashed);
+  font-size: 10px; letter-spacing: 0.04em; color: var(--text-3);
+}
+.rev-panel__error b { color: var(--accent); font-weight: 600; }
 
 .rev-list {
   overflow: auto;

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -3454,7 +3454,7 @@ body {
   background: var(--accent-soft);
   color: var(--accent);
 }
-.rev-panel__titles { min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+.rev-panel__titles { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
 .rev-panel__eyebrow {
   font-family: var(--font-mono);
   font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase;
@@ -3467,7 +3467,7 @@ body {
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .rev-panel__count {
-  margin-left: auto; flex: 0 0 auto;
+  flex: 0 0 auto;
   font-family: var(--font-mono);
   font-size: 10px; letter-spacing: 0.05em;
   color: var(--text-3);

--- a/apps/desktop/src/app.css
+++ b/apps/desktop/src/app.css
@@ -3421,3 +3421,289 @@ body {
   margin: 14px 0;
 }
 .ds-hr--solid { border-top-style: solid; border-color: var(--rule); }
+
+/* ───────────────────────────────────────────────────────────
+   Revision History panel — timeline of prior entry versions.
+   Reuses field / metric / modal vocabulary and paper/ink tokens.
+   ─────────────────────────────────────────────────────────── */
+
+.rev-panel {
+  width: 720px;
+  max-height: 640px;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-card);
+  border: 1px solid var(--rule-strong);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 24px 70px rgba(20, 17, 13, 0.22), 0 3px 12px rgba(20, 17, 13, 0.10);
+}
+.arca[data-theme="ink"] .rev-panel { box-shadow: 0 24px 70px rgba(0, 0, 0, 0.50); }
+
+.rev-panel__head {
+  flex: 0 0 auto;
+  display: flex; align-items: center; gap: 14px;
+  padding: 16px 18px 15px;
+  border-bottom: 1px dashed var(--rule-dashed);
+}
+.rev-panel__ico {
+  flex: 0 0 auto;
+  width: 34px; height: 34px;
+  border-radius: 8px;
+  display: grid; place-items: center;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.rev-panel__titles { min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+.rev-panel__eyebrow {
+  font-family: var(--font-mono);
+  font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--text-3);
+}
+.rev-panel__title {
+  font-family: var(--font-mono);
+  font-size: 14px; font-weight: 600; letter-spacing: 0.01em;
+  color: var(--text);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.rev-panel__count {
+  margin-left: auto; flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 10px; letter-spacing: 0.05em;
+  color: var(--text-3);
+}
+.rev-panel__count b { color: var(--text-2); font-weight: 600; }
+.rev-panel__close { flex: 0 0 auto; }
+.rev-panel__close kbd {
+  font-family: var(--font-mono); font-size: 9px; font-weight: 600;
+  border: 1px solid currentColor; opacity: 0.5;
+  border-radius: 3px; padding: 1px 5px; letter-spacing: 0.04em;
+}
+
+.rev-list {
+  overflow: auto;
+  padding: 20px 22px 10px;
+}
+
+.rev {
+  position: relative;
+  padding: 0 2px 22px 28px;
+}
+.rev:last-child { padding-bottom: 6px; }
+.rev::before {
+  content: '';
+  position: absolute; left: 5px; top: 8px; bottom: -2px;
+  width: 1px; background: var(--rule-strong);
+}
+.rev:last-child::before { display: none; }
+.rev__node {
+  position: absolute; left: 0; top: 5px;
+  width: 11px; height: 11px;
+  border-radius: 50%;
+  background: var(--bg-card);
+  border: 1.5px solid var(--text-4);
+  box-shadow: 0 0 0 4px var(--bg-card);
+}
+.rev--latest .rev__node { border-color: var(--accent); background: var(--accent); }
+.rev--init .rev__node { border-color: var(--vault); background: var(--bg-card); }
+.rev--init .rev__ref { color: var(--vault); }
+
+.rev__head {
+  display: flex; align-items: baseline; gap: 10px;
+  margin-bottom: 10px;
+}
+.rev__ref {
+  font-family: var(--font-mono);
+  font-size: 10px; font-weight: 600; letter-spacing: 0.10em;
+  text-transform: uppercase; color: var(--text-3);
+}
+.rev--latest .rev__ref { color: var(--accent); }
+.rev__when {
+  font-family: var(--font-mono);
+  font-size: 12.5px; font-weight: 600; color: var(--text);
+  letter-spacing: 0.01em;
+}
+.rev__stamp {
+  font-family: var(--font-mono);
+  font-size: 10px; letter-spacing: 0.04em; color: var(--text-3);
+}
+.rev__tag {
+  margin-left: 2px;
+  font-family: var(--font-mono);
+  font-size: 8.5px; font-weight: 600; letter-spacing: 0.10em;
+  text-transform: uppercase;
+  padding: 2px 6px; border-radius: 3px;
+  background: var(--accent-soft); color: var(--accent);
+}
+
+.rev__diff {
+  display: flex; flex-wrap: wrap; gap: 7px;
+  margin-bottom: 11px;
+}
+.rev__chg {
+  display: inline-flex; align-items: center; gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 10.5px; letter-spacing: 0.02em; color: var(--text-2);
+  background: var(--bg-inset);
+  border: 1px solid var(--rule);
+  border-radius: 5px;
+  padding: 4px 9px;
+}
+.rev__chg-k {
+  font-size: 9px; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--text-3);
+}
+.rev__chg--pw { background: var(--accent-soft); border-color: transparent; color: var(--accent); }
+.rev__chg--pw .rev__chg-k { color: var(--accent); opacity: 0.85; }
+.rev__chg--init { background: var(--vault-soft); border-color: transparent; color: var(--vault); }
+.rev__chg--init .rev__chg-k { color: var(--vault); }
+.rev__chg-old { color: var(--text-3); text-decoration: line-through; text-decoration-color: var(--rule-strong); }
+.rev__chg-arrow { color: var(--text-4); }
+.rev__chg-new { color: var(--text); font-weight: 500; }
+
+.rev__pw {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 14px;
+  padding: 11px 12px 11px 15px;
+  background: var(--bg-inset);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  overflow: hidden;
+  transition: border-color .14s, background .14s;
+}
+.rev__pw--open {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+.rev__pw-k {
+  font-family: var(--font-mono);
+  font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--text-3);
+}
+.rev__pw--open .rev__pw-k { color: var(--accent); }
+.rev__pw-v {
+  font-family: var(--font-mono);
+  font-size: 13px; letter-spacing: 0.22em; color: var(--text-2);
+  min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.rev__pw-v--open { color: var(--text); letter-spacing: 0.02em; }
+.rev__pw-right { display: inline-flex; align-items: center; gap: 10px; }
+.rev__pw-cd {
+  font-family: var(--font-mono);
+  font-size: 11px; font-weight: 600; letter-spacing: 0.04em;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+.rev__pw-actions { display: inline-flex; gap: 6px; }
+.rev__ok { font-weight: 700; font-size: 13px; line-height: 1; }
+.rev__pw-timer {
+  position: absolute; left: 0; bottom: 0; height: 2px;
+  background: var(--accent);
+  transition: width 1s linear;
+}
+
+.rev__note {
+  display: flex; align-items: center; gap: 6px;
+  margin-top: 8px; padding-left: 2px;
+  font-family: var(--font-mono);
+  font-size: 9.5px; letter-spacing: 0.05em; color: var(--text-3);
+}
+.rev__note b { color: var(--vault); font-weight: 600; }
+.rev__note--reveal b { color: var(--accent); }
+
+.rev-empty {
+  flex: 1;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  text-align: center;
+  padding: 60px 44px 68px;
+}
+.rev-empty__mark {
+  width: 66px; height: 66px;
+  border: 1px dashed var(--rule-strong);
+  border-radius: 15px;
+  display: grid; place-items: center;
+  color: var(--text-3);
+  background: var(--bg);
+  margin-bottom: 20px;
+}
+.rev-empty__k {
+  font-family: var(--font-mono);
+  font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--text-3); margin-bottom: 13px;
+}
+.rev-empty__title {
+  font-family: var(--font-display);
+  font-weight: 600; font-size: 23px; letter-spacing: -0.02em; line-height: 1;
+  color: var(--text); margin: 0;
+}
+.rev-empty__sub {
+  font-family: var(--font-body);
+  font-size: 13px; line-height: 1.6; color: var(--text-2);
+  max-width: 350px; margin: 13px 0 0;
+  text-wrap: pretty;
+}
+
+.rev-loading__cap {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--text-3);
+  margin: 2px 0 20px 2px;
+}
+.rev-loading__spin {
+  width: 11px; height: 11px; border-radius: 50%;
+  border: 1.5px solid var(--rule-strong);
+  border-top-color: var(--accent);
+  animation: rev-spin 0.8s linear infinite;
+}
+@keyframes rev-spin { to { transform: rotate(360deg); } }
+.rev-loading__dots::after {
+  content: '';
+  animation: rev-dots 1.4s steps(4, end) infinite;
+}
+@keyframes rev-dots { 0%{content:''} 25%{content:'.'} 50%{content:'..'} 75%{content:'...'} }
+
+.skel {
+  display: block;
+  background: linear-gradient(90deg, var(--bg-inset) 25%, var(--bg-hover) 50%, var(--bg-inset) 75%);
+  background-size: 200% 100%;
+  animation: rev-shimmer 1.4s ease-in-out infinite;
+  border-radius: 5px;
+}
+@keyframes rev-shimmer { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+.rev--skel .rev__head { align-items: center; }
+.skel--ref { width: 34px; height: 10px; }
+.skel--when { width: 108px; height: 12px; }
+.skel--pw { width: 100%; height: 42px; border-radius: 8px; }
+.rev--skel .rev__node { border-color: var(--rule-strong); background: var(--bg-inset); }
+
+.rev-overlay {
+  position: fixed; inset: 0; z-index: 40;
+  display: grid; place-items: center;
+  padding: 26px;
+  background: rgba(20, 17, 13, 0.34);
+  animation: rev-overlay-in .16s ease-out;
+}
+.arca[data-theme="ink"] .rev-overlay { background: rgba(0, 0, 0, 0.52); }
+@keyframes rev-overlay-in { from { opacity: 0; } to { opacity: 1; } }
+.rev-overlay__scrim { position: absolute; inset: 0; background: none; border: 0; padding: 0; cursor: default; }
+.rev-overlay .rev-panel { position: relative; z-index: 1; animation: rev-card-in .2s cubic-bezier(0.22,1,0.36,1); }
+@keyframes rev-card-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+
+.strip__cell--btn {
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-right: 1px dashed var(--rule-dashed);
+  font: inherit; color: inherit;
+  cursor: pointer;
+  transition: background .12s;
+}
+.strip__cell--btn:last-child { border-right: none; }
+.strip__cell--btn:hover { background: var(--bg-card-2); }
+.strip__v--link { text-decoration: underline; text-decoration-color: var(--accent-soft); text-underline-offset: 3px; }
+.strip__cell--btn:hover .strip__v--link { text-decoration-color: var(--accent); }

--- a/apps/desktop/src/lib/components/UnlockScreen.svelte
+++ b/apps/desktop/src/lib/components/UnlockScreen.svelte
@@ -11,11 +11,13 @@
   type Mode = 'open' | 'create';
   type Variant = 'two-pane' | 'sealed';
 
+  interface Props {
+    variant?: Variant;
+  }
+
   let {
     variant = 'two-pane',
-  } = $props<{
-    variant?: Variant;
-  }>();
+  }: Props = $props();
 
   let mode: Mode = $state('open');
   let path = $state(vaultState.vaultPath);

--- a/apps/desktop/src/lib/components/brand/Lettermark.svelte
+++ b/apps/desktop/src/lib/components/brand/Lettermark.svelte
@@ -1,17 +1,19 @@
 <script lang="ts">
+  interface Props {
+    size?: number;
+    color?: string;
+    title?: string;
+    class?: string;
+    [key: string]: unknown;
+  }
+
   let {
     size = 22,
     color = 'currentColor',
     title,
     class: className = '',
     ...rest
-  } = $props<{
-    size?: number;
-    color?: string;
-    title?: string;
-    class?: string;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const width = $derived(size * (540 / 700));
   const path =

--- a/apps/desktop/src/lib/components/brand/Lockup.svelte
+++ b/apps/desktop/src/lib/components/brand/Lockup.svelte
@@ -1,6 +1,16 @@
 <script lang="ts">
   import Lettermark from './Lettermark.svelte';
 
+  interface Props {
+    size?: number;
+    color?: string;
+    accent?: boolean;
+    gap?: number;
+    ariaLabel?: string;
+    class?: string;
+    [key: string]: unknown;
+  }
+
   let {
     size = 22,
     color,
@@ -9,15 +19,7 @@
     ariaLabel = 'arca',
     class: className = '',
     ...rest
-  } = $props<{
-    size?: number;
-    color?: string;
-    accent?: boolean;
-    gap?: number;
-    ariaLabel?: string;
-    class?: string;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const wordColor = $derived(color ?? (accent ? 'var(--accent)' : 'var(--text)'));
   const lockupGap = $derived(gap ?? Math.max(4, size * 0.22));

--- a/apps/desktop/src/lib/components/chrome/StatusBar.svelte
+++ b/apps/desktop/src/lib/components/chrome/StatusBar.svelte
@@ -3,6 +3,18 @@
 
   type PillKind = 'vault' | 'ink' | 'slate' | 'ghost';
 
+  interface Props {
+    pill?: string;
+    pillKind?: PillKind;
+    leftText?: string;
+    connected?: boolean;
+    connectionLabel?: string;
+    left?: Snippet;
+    right?: Snippet;
+    class?: string;
+    [key: string]: unknown;
+  }
+
   let {
     pill = 'SEALED',
     pillKind = 'vault',
@@ -13,17 +25,7 @@
     right,
     class: className = '',
     ...rest
-  } = $props<{
-    pill?: string;
-    pillKind?: PillKind;
-    leftText?: string;
-    connected?: boolean;
-    connectionLabel?: string;
-    left?: Snippet;
-    right?: Snippet;
-    class?: string;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const classes = $derived(['status', className].filter(Boolean).join(' '));
   const pillClasses = $derived(['status__pill', `status__pill--${pillKind}`].join(' '));

--- a/apps/desktop/src/lib/components/chrome/Tabs.svelte
+++ b/apps/desktop/src/lib/components/chrome/Tabs.svelte
@@ -6,6 +6,15 @@
     disabled?: boolean;
   }
 
+  interface Props {
+    items?: TabItem[];
+    active?: string;
+    onselect?: (key: string) => void;
+    label?: string;
+    class?: string;
+    [key: string]: unknown;
+  }
+
   let {
     items = [],
     active,
@@ -13,14 +22,7 @@
     label = 'Workspace sections',
     class: className = '',
     ...rest
-  } = $props<{
-    items?: TabItem[];
-    active?: string;
-    onselect?: (key: string) => void;
-    label?: string;
-    class?: string;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const classes = $derived(['tabs', className].filter(Boolean).join(' '));
 

--- a/apps/desktop/src/lib/components/chrome/WindowChrome.svelte
+++ b/apps/desktop/src/lib/components/chrome/WindowChrome.svelte
@@ -2,6 +2,15 @@
   import type { Snippet } from 'svelte';
   import { Lockup } from '../brand';
 
+  interface Props {
+    path?: string;
+    prefix?: string;
+    rightText?: string;
+    right?: Snippet;
+    class?: string;
+    [key: string]: unknown;
+  }
+
   let {
     path = 'vault.local',
     prefix = './',
@@ -9,14 +18,7 @@
     right,
     class: className = '',
     ...rest
-  } = $props<{
-    path?: string;
-    prefix?: string;
-    rightText?: string;
-    right?: Snippet;
-    class?: string;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const classes = $derived(['chrome', className].filter(Boolean).join(' '));
 </script>

--- a/apps/desktop/src/lib/components/detail/EntryDetail.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryDetail.svelte
@@ -9,9 +9,11 @@
   import FieldStack from './FieldStack.svelte';
   import MetricStrip from './MetricStrip.svelte';
   import NotePanel from './NotePanel.svelte';
+  import RevisionHistory from './RevisionHistory.svelte';
 
   const entry = $derived(vaultState.selectedEntry ?? vaultState.entries[0] ?? null);
   let confirmDeleteOpen = $state(false);
+  let historyOpen = $state(false);
   let deleteBusy = $state(false);
   let deleteError = $state('');
 
@@ -22,6 +24,10 @@
       }
 
       const key = event.key.toLowerCase();
+
+      if (historyOpen) {
+        return;
+      }
 
       if (confirmDeleteOpen) {
         if (key === 'escape') {
@@ -170,8 +176,12 @@
     <div class="detail-body">
       <NotePanel notes={entry.notes} tags={entry.tags} scope={entry.collection} />
       <FieldStack {entry} />
-      <MetricStrip {entry} />
+      <MetricStrip {entry} onopenhistory={() => (historyOpen = true)} />
     </div>
+
+    {#if historyOpen}
+      <RevisionHistory {entry} onclose={() => (historyOpen = false)} />
+    {/if}
   </section>
 {:else}
   <section class="vault-placeholder" aria-labelledby="entry-detail-empty-title">

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -6,11 +6,13 @@
   import { Icon } from '../icons';
   import { Entropy, IconButton } from '../primitives';
 
+  interface Props {
+    entry: EntryDto;
+  }
+
   let {
     entry,
-  } = $props<{
-    entry: EntryDto;
-  }>();
+  }: Props = $props();
 
   type CopyKind = 'url' | 'username' | 'password';
 

--- a/apps/desktop/src/lib/components/detail/MetricStrip.svelte
+++ b/apps/desktop/src/lib/components/detail/MetricStrip.svelte
@@ -54,38 +54,20 @@
     <div class="strip__k">last_modified</div>
     <div class="strip__v">{updated}</div>
   </div>
-  <div class="strip__cell">
-    <div class="strip__k">revisions</div>
-    {#if entry.revisionCount > 0 && onopenhistory}
-      <button
-        type="button"
-        class="strip__v strip__v--accent strip__v--action"
-        onclick={onopenhistory}
-        aria-label={`View revision history (${entry.revisionCount})`}
-      >
-        {revisions}
-      </button>
-    {:else}
+  {#if entry.revisionCount > 0 && onopenhistory}
+    <button
+      type="button"
+      class="strip__cell strip__cell--btn"
+      onclick={onopenhistory}
+      aria-label={`View revision history (${entry.revisionCount})`}
+    >
+      <div class="strip__k">revisions</div>
+      <div class="strip__v strip__v--accent strip__v--link">{revisions}</div>
+    </button>
+  {:else}
+    <div class="strip__cell">
+      <div class="strip__k">revisions</div>
       <div class="strip__v strip__v--accent">{revisions}</div>
-    {/if}
-  </div>
+    </div>
+  {/if}
 </div>
-
-<style>
-  .strip__v--action {
-    appearance: none;
-    border: none;
-    padding: 0;
-    background: none;
-    font: inherit;
-    color: inherit;
-    cursor: pointer;
-    text-decoration: underline;
-    text-underline-offset: 2px;
-  }
-
-  .strip__v--action:hover,
-  .strip__v--action:focus-visible {
-    opacity: 0.8;
-  }
-</style>

--- a/apps/desktop/src/lib/components/detail/MetricStrip.svelte
+++ b/apps/desktop/src/lib/components/detail/MetricStrip.svelte
@@ -3,8 +3,10 @@
 
   let {
     entry,
+    onopenhistory,
   } = $props<{
     entry: EntryDto;
+    onopenhistory?: () => void;
   }>();
 
   const created = $derived(formatDate(entry.createdAt));
@@ -54,6 +56,36 @@
   </div>
   <div class="strip__cell">
     <div class="strip__k">revisions</div>
-    <div class="strip__v strip__v--accent">{revisions}</div>
+    {#if entry.revisionCount > 0 && onopenhistory}
+      <button
+        type="button"
+        class="strip__v strip__v--accent strip__v--action"
+        onclick={onopenhistory}
+        aria-label={`View revision history (${entry.revisionCount})`}
+      >
+        {revisions}
+      </button>
+    {:else}
+      <div class="strip__v strip__v--accent">{revisions}</div>
+    {/if}
   </div>
 </div>
+
+<style>
+  .strip__v--action {
+    appearance: none;
+    border: none;
+    padding: 0;
+    background: none;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .strip__v--action:hover,
+  .strip__v--action:focus-visible {
+    opacity: 0.8;
+  }
+</style>

--- a/apps/desktop/src/lib/components/detail/MetricStrip.svelte
+++ b/apps/desktop/src/lib/components/detail/MetricStrip.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import type { EntryDto } from '../../ipc';
 
-  let {
-    entry,
-    onopenhistory,
-  } = $props<{
+  interface Props {
     entry: EntryDto;
     onopenhistory?: () => void;
-  }>();
+  }
+
+  let { entry, onopenhistory }: Props = $props();
 
   const created = $derived(formatDate(entry.createdAt));
   const updated = $derived(formatRelative(entry.updatedAt));

--- a/apps/desktop/src/lib/components/detail/MetricStrip.svelte
+++ b/apps/desktop/src/lib/components/detail/MetricStrip.svelte
@@ -54,7 +54,7 @@
     <div class="strip__k">last_modified</div>
     <div class="strip__v">{updated}</div>
   </div>
-  {#if entry.revisionCount > 0 && onopenhistory}
+  {#if onopenhistory}
     <button
       type="button"
       class="strip__cell strip__cell--btn"

--- a/apps/desktop/src/lib/components/detail/NotePanel.svelte
+++ b/apps/desktop/src/lib/components/detail/NotePanel.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
   import { Tag } from '../primitives';
 
+  interface Props {
+    notes?: string | null;
+    tags?: string[];
+    scope?: string | null;
+  }
+
   let {
     notes,
     tags = [],
     scope = 'vault',
-  } = $props<{
-    notes?: string | null;
-    tags?: string[];
-    scope?: string | null;
-  }>();
+  }: Props = $props();
 
   const body = $derived(
     notes?.trim() ||

--- a/apps/desktop/src/lib/components/detail/RevisionHistory.svelte
+++ b/apps/desktop/src/lib/components/detail/RevisionHistory.svelte
@@ -337,7 +337,7 @@
         <h3 class="rev-empty__title">no earlier versions</h3>
         <p class="rev-empty__sub">
           Arca snapshots a revision automatically whenever you change a field on this entry. Once you
-          make an edit, prior versions collect here &mdash; newest first.
+          make an edit, prior versions collect here - newest first.
         </p>
       </div>
     {:else}

--- a/apps/desktop/src/lib/components/detail/RevisionHistory.svelte
+++ b/apps/desktop/src/lib/components/detail/RevisionHistory.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { getEntryRevisions, revealEntryRevisionPassword, type EntryDto, type RevisionDto } from '../../ipc';
+  import { COPY_CONFIRMATION_MS, writeConfiguredClipboardText } from '../../clipboard';
+  import { Icon } from '../icons';
+  import { Button, IconButton } from '../primitives';
+
+  let {
+    entry,
+    onclose,
+  } = $props<{
+    entry: EntryDto;
+    onclose: () => void;
+  }>();
+
+  const passwordMask = '●●●●●●●●●●●●●●●●●●●●●●●●';
+  const passwordRevealMs = 10_000;
+
+  let revisions = $state<RevisionDto[]>([]);
+  let loading = $state(true);
+  let loadError = $state('');
+  let revealedIndex = $state<number | null>(null);
+  let revealedPassword = $state('');
+  let busyIndex = $state<number | null>(null);
+  let copiedIndex = $state<number | null>(null);
+  let revealTimer: ReturnType<typeof setTimeout> | null = null;
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  onMount(() => {
+    void load();
+
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        onclose();
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown, true);
+    return () => window.removeEventListener('keydown', handleKeydown, true);
+  });
+
+  onDestroy(() => {
+    clearRevealTimer();
+
+    if (copyTimer) {
+      clearTimeout(copyTimer);
+    }
+
+    revealedPassword = '';
+  });
+
+  async function load() {
+    loading = true;
+    loadError = '';
+
+    try {
+      revisions = await getEntryRevisions(entry.id);
+    } catch (error) {
+      loadError = messageFromError(error);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadPassword(index: number): Promise<string> {
+    if (busyIndex !== null) {
+      return '';
+    }
+
+    busyIndex = index;
+
+    try {
+      return await revealEntryRevisionPassword(entry.id, index);
+    } catch {
+      return '';
+    } finally {
+      busyIndex = null;
+    }
+  }
+
+  async function toggleReveal(index: number) {
+    if (revealedIndex === index) {
+      hideRevealed();
+      return;
+    }
+
+    const password = await loadPassword(index);
+
+    if (!password) {
+      return;
+    }
+
+    revealedPassword = password;
+    revealedIndex = index;
+    scheduleRevealHide();
+  }
+
+  async function copyRevision(index: number) {
+    const password = revealedIndex === index && revealedPassword ? revealedPassword : await loadPassword(index);
+
+    if (!password) {
+      return;
+    }
+
+    if (!(await writeConfiguredClipboardText(password))) {
+      return;
+    }
+
+    copiedIndex = index;
+
+    if (copyTimer) {
+      clearTimeout(copyTimer);
+    }
+
+    copyTimer = setTimeout(() => {
+      copiedIndex = null;
+      copyTimer = null;
+    }, COPY_CONFIRMATION_MS);
+  }
+
+  function hideRevealed() {
+    revealedIndex = null;
+    revealedPassword = '';
+    clearRevealTimer();
+  }
+
+  function scheduleRevealHide() {
+    clearRevealTimer();
+
+    revealTimer = setTimeout(() => {
+      revealedIndex = null;
+      revealedPassword = '';
+      revealTimer = null;
+    }, passwordRevealMs);
+  }
+
+  function clearRevealTimer() {
+    if (revealTimer) {
+      clearTimeout(revealTimer);
+      revealTimer = null;
+    }
+  }
+
+  function formatCaptured(value: string): string {
+    const time = Date.parse(value);
+
+    if (Number.isNaN(time)) {
+      return 'unknown';
+    }
+
+    return new Date(time).toISOString().slice(0, 16).replace('T', ' ');
+  }
+
+  function messageFromError(error: unknown): string {
+    if (typeof error === 'object' && error !== null && 'message' in error) {
+      return String(error.message);
+    }
+
+    return 'Unable to load revision history';
+  }
+</script>
+
+<div
+  class="modal revision-history"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="revision-history-title"
+>
+  <div class="revision-history__head">
+    <div id="revision-history-title" class="modal__q">revision_history · {entry.title}</div>
+    <Button variant="ghost" size="sm" onclick={onclose} aria-keyshortcuts="Escape">close</Button>
+  </div>
+
+  {#if loading}
+    <p class="revision-history__status mono">loading_revisions</p>
+  {:else if loadError}
+    <div class="revision-history__status mono error" role="alert">{loadError}</div>
+  {:else if revisions.length === 0}
+    <p class="revision-history__status mono">no_revisions</p>
+  {:else}
+    <ul class="revision-history__list">
+      {#each revisions as revision, index (index)}
+        <li class="revision-history__item">
+          <div class="revision-history__meta mono">
+            <span>captured · <b>{formatCaptured(revision.capturedAt)}</b></span>
+            <span>title · <b>{revision.title}</b></span>
+            <span>user · <b>{revision.username.trim() || 'not_set'}</b></span>
+            {#if revision.url?.trim()}
+              <span>url · <b>{revision.url}</b></span>
+            {/if}
+          </div>
+          <div class={revealedIndex === index ? 'field field--focus field--secret-revealed' : 'field field--focus'}>
+            <div class="field__k">password</div>
+            <div class={revealedIndex === index ? 'field__v field__v--secret' : 'field__v field__v--mask'}>
+              {revealedIndex === index ? revealedPassword : passwordMask}
+            </div>
+            <div class="field__actions">
+              <IconButton
+                label={revealedIndex === index ? 'Hide revision password' : 'Reveal revision password'}
+                variant={revealedIndex === index ? 'accent' : 'default'}
+                disabled={busyIndex === index}
+                onclick={() => toggleReveal(index)}
+              >
+                <Icon name="eye" size={13} />
+              </IconButton>
+              <IconButton
+                label={copiedIndex === index ? 'Revision password copied' : 'Copy revision password'}
+                variant={copiedIndex === index ? 'accent' : 'default'}
+                disabled={busyIndex === index}
+                onclick={() => copyRevision(index)}
+              >
+                {#if copiedIndex === index}
+                  ✓
+                {:else}
+                  <Icon name="copy" size={13} />
+                {/if}
+              </IconButton>
+            </div>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .revision-history {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-height: min(70vh, 34rem);
+  }
+
+  .revision-history__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .revision-history__status {
+    opacity: 0.7;
+  }
+
+  .revision-history__list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    overflow-y: auto;
+  }
+
+  .revision-history__item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border, rgba(127, 127, 127, 0.2));
+  }
+
+  .revision-history__item:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+
+  .revision-history__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 1rem;
+    font-size: 0.75rem;
+    opacity: 0.75;
+  }
+</style>

--- a/apps/desktop/src/lib/components/detail/RevisionHistory.svelte
+++ b/apps/desktop/src/lib/components/detail/RevisionHistory.svelte
@@ -6,13 +6,12 @@
   import { Icon } from '../icons';
   import { Button, IconButton } from '../primitives';
 
-  let {
-    entry,
-    onclose,
-  } = $props<{
+  interface Props {
     entry: EntryDto;
     onclose: () => void;
-  }>();
+  }
+
+  let { entry, onclose }: Props = $props();
 
   type Change =
     | { kind: 'password' }

--- a/apps/desktop/src/lib/components/detail/RevisionHistory.svelte
+++ b/apps/desktop/src/lib/components/detail/RevisionHistory.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import { getEntryRevisions, revealEntryRevisionPassword, type EntryDto, type RevisionDto } from '../../ipc';
   import { COPY_CONFIRMATION_MS, writeConfiguredClipboardText } from '../../clipboard';
+  import { runtimeSettings } from '../../stores/settings.svelte';
   import { Icon } from '../icons';
   import { Button, IconButton } from '../primitives';
 
@@ -13,18 +14,42 @@
     onclose: () => void;
   }>();
 
-  const passwordMask = '●●●●●●●●●●●●●●●●●●●●●●●●';
-  const passwordRevealMs = 10_000;
+  type Change =
+    | { kind: 'password' }
+    | { kind: 'note'; key: string }
+    | { kind: 'field'; key: string; from: string; to: string };
+
+  const MASK = '●'.repeat(20);
+  const REVEAL_SECONDS = 10;
 
   let revisions = $state<RevisionDto[]>([]);
   let loading = $state(true);
   let loadError = $state('');
   let revealedIndex = $state<number | null>(null);
   let revealedPassword = $state('');
-  let busyIndex = $state<number | null>(null);
   let copiedIndex = $state<number | null>(null);
-  let revealTimer: ReturnType<typeof setTimeout> | null = null;
+  let busyIndex = $state<number | null>(null);
+  let countdown = $state(REVEAL_SECONDS);
+  let countdownTimer: ReturnType<typeof setInterval> | null = null;
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const items = $derived(
+    revisions.map((revision, index) => {
+      const newer: EntryDto | RevisionDto = index === 0 ? entry : revisions[index - 1];
+      return {
+        index,
+        ref: 'R' + String(revisions.length - index).padStart(2, '0'),
+        when: relativeTime(revision.capturedAt),
+        stamp: formatStamp(revision.capturedAt),
+        latest: index === 0,
+        changes: computeChanges(revision, newer),
+      };
+    }),
+  );
+
+  const countLabel = $derived(String(revisions.length).padStart(2, '0'));
+  const maxLabel = $derived(runtimeSettings.current.entryRevisionLimit ?? 25);
+  const clipboardNote = $derived(clipboardClearNote(runtimeSettings.current.clipboardClearSeconds));
 
   onMount(() => {
     void load();
@@ -32,17 +57,16 @@
     function handleKeydown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
         event.preventDefault();
-        event.stopPropagation();
         onclose();
       }
     }
 
-    window.addEventListener('keydown', handleKeydown, true);
-    return () => window.removeEventListener('keydown', handleKeydown, true);
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
   });
 
   onDestroy(() => {
-    clearRevealTimer();
+    clearCountdown();
 
     if (copyTimer) {
       clearTimeout(copyTimer);
@@ -94,11 +118,12 @@
 
     revealedPassword = password;
     revealedIndex = index;
-    scheduleRevealHide();
+    startCountdown();
   }
 
   async function copyRevision(index: number) {
-    const password = revealedIndex === index && revealedPassword ? revealedPassword : await loadPassword(index);
+    const password =
+      revealedIndex === index && revealedPassword ? revealedPassword : await loadPassword(index);
 
     if (!password) {
       return;
@@ -120,30 +145,125 @@
     }, COPY_CONFIRMATION_MS);
   }
 
-  function hideRevealed() {
-    revealedIndex = null;
-    revealedPassword = '';
-    clearRevealTimer();
+  function startCountdown() {
+    clearCountdown();
+    countdown = REVEAL_SECONDS;
+
+    countdownTimer = setInterval(() => {
+      if (countdown <= 1) {
+        hideRevealed();
+      } else {
+        countdown -= 1;
+      }
+    }, 1000);
   }
 
-  function scheduleRevealHide() {
-    clearRevealTimer();
-
-    revealTimer = setTimeout(() => {
-      revealedIndex = null;
-      revealedPassword = '';
-      revealTimer = null;
-    }, passwordRevealMs);
-  }
-
-  function clearRevealTimer() {
-    if (revealTimer) {
-      clearTimeout(revealTimer);
-      revealTimer = null;
+  function clearCountdown() {
+    if (countdownTimer) {
+      clearInterval(countdownTimer);
+      countdownTimer = null;
     }
   }
 
-  function formatCaptured(value: string): string {
+  function hideRevealed() {
+    clearCountdown();
+    revealedIndex = null;
+    revealedPassword = '';
+    countdown = REVEAL_SECONDS;
+  }
+
+  function computeChanges(revision: RevisionDto, newer: EntryDto | RevisionDto): Change[] {
+    const changes: Change[] = [];
+
+    if (revision.passwordChanged) {
+      changes.push({ kind: 'password' });
+    }
+
+    pushFieldChange(changes, 'title', revision.title, newer.title);
+    pushFieldChange(changes, 'user', revision.username, newer.username);
+    pushFieldChange(changes, 'url', revision.url, newer.url);
+    pushFieldChange(changes, 'collection', revision.collection, newer.collection);
+
+    if (normalize(revision.notes) !== normalize(newer.notes)) {
+      changes.push({ kind: 'note', key: 'notes' });
+    }
+    if (!sameTags(revision.tags, newer.tags)) {
+      changes.push({ kind: 'note', key: 'tags' });
+    }
+
+    return changes;
+  }
+
+  function pushFieldChange(changes: Change[], key: string, from: string | null, to: string | null) {
+    if (normalize(from) === normalize(to)) {
+      return;
+    }
+
+    changes.push({ kind: 'field', key, from: fieldValue(from), to: fieldValue(to) });
+  }
+
+  function normalize(value: string | null): string {
+    return (value ?? '').trim();
+  }
+
+  function fieldValue(value: string | null): string {
+    return value && value.trim() ? value : 'none';
+  }
+
+  function sameTags(a: string[], b: string[]): boolean {
+    return a.length === b.length && a.every((tag, index) => tag === b[index]);
+  }
+
+  function relativeTime(value: string): string {
+    const time = Date.parse(value);
+
+    if (Number.isNaN(time)) {
+      return 'unknown';
+    }
+
+    const minutes = Math.round((Date.now() - time) / 60_000);
+
+    if (minutes < 1) {
+      return 'just now';
+    }
+    if (minutes < 60) {
+      return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+    }
+
+    const hours = Math.round(minutes / 60);
+    if (hours < 24) {
+      return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+    }
+
+    const days = Math.round(hours / 24);
+    if (days === 1) {
+      return 'yesterday';
+    }
+    if (days < 7) {
+      return `${days} days ago`;
+    }
+
+    const weeks = Math.round(days / 7);
+    if (weeks === 1) {
+      return 'last week';
+    }
+    if (weeks < 5) {
+      return `${weeks} weeks ago`;
+    }
+
+    const months = Math.round(days / 30);
+    if (months === 1) {
+      return 'last month';
+    }
+    if (months < 12) {
+      return `${months} months ago`;
+    }
+
+    const years = Math.round(days / 365);
+    return `${years} year${years === 1 ? '' : 's'} ago`;
+  }
+
+  function formatStamp(value: string): string {
     const time = Date.parse(value);
 
     if (Number.isNaN(time)) {
@@ -151,6 +271,16 @@
     }
 
     return new Date(time).toISOString().slice(0, 16).replace('T', ' ');
+  }
+
+  function formatCountdown(value: number): string {
+    return '0:' + String(value).padStart(2, '0');
+  }
+
+  function clipboardClearNote(seconds: number | null | undefined): string {
+    return typeof seconds === 'number' && seconds > 0
+      ? `clipboard clears in ${seconds}s`
+      : 'copied to clipboard';
   }
 
   function messageFromError(error: unknown): string {
@@ -162,116 +292,132 @@
   }
 </script>
 
-<div
-  class="modal revision-history"
-  role="dialog"
-  aria-modal="true"
-  aria-labelledby="revision-history-title"
->
-  <div class="revision-history__head">
-    <div id="revision-history-title" class="modal__q">revision_history · {entry.title}</div>
-    <Button variant="ghost" size="sm" onclick={onclose} aria-keyshortcuts="Escape">close</Button>
-  </div>
+<div class="rev-overlay">
+  <button type="button" class="rev-overlay__scrim" aria-label="Close revision history" onclick={onclose}
+  ></button>
 
-  {#if loading}
-    <p class="revision-history__status mono">loading_revisions</p>
-  {:else if loadError}
-    <div class="revision-history__status mono error" role="alert">{loadError}</div>
-  {:else if revisions.length === 0}
-    <p class="revision-history__status mono">no_revisions</p>
-  {:else}
-    <ul class="revision-history__list">
-      {#each revisions as revision, index (index)}
-        <li class="revision-history__item">
-          <div class="revision-history__meta mono">
-            <span>captured · <b>{formatCaptured(revision.capturedAt)}</b></span>
-            <span>title · <b>{revision.title}</b></span>
-            <span>user · <b>{revision.username.trim() || 'not_set'}</b></span>
-            {#if revision.url?.trim()}
-              <span>url · <b>{revision.url}</b></span>
+  <div class="rev-panel" role="dialog" aria-modal="true" aria-labelledby="rev-panel-title">
+    <div class="rev-panel__head">
+      <span class="rev-panel__ico"><Icon name="history" size={17} /></span>
+      <div class="rev-panel__titles">
+        <div class="rev-panel__eyebrow">revision_history</div>
+        <div id="rev-panel-title" class="rev-panel__title">{entry.title}</div>
+      </div>
+      {#if !loading && !loadError && revisions.length > 0}
+        <div class="rev-panel__count"><b>{countLabel}</b> kept &middot; max {maxLabel}</div>
+      {/if}
+      <Button variant="bare" size="sm" class="rev-panel__close" onclick={onclose}>
+        close <kbd>esc</kbd>
+      </Button>
+    </div>
+
+    {#if loading}
+      <div class="rev-list">
+        <div class="rev-loading__cap">
+          <span class="rev-loading__spin"></span>loading_revisions<span class="rev-loading__dots"></span>
+        </div>
+        {#each [0, 1, 2] as row (row)}
+          <div class="rev rev--skel">
+            <span class="rev__node"></span>
+            <div class="rev__head">
+              <span class="skel skel--ref"></span><span class="skel skel--when"></span>
+            </div>
+            <span class="skel skel--pw"></span>
+          </div>
+        {/each}
+      </div>
+    {:else if loadError}
+      <div class="rev-list">
+        <div class="rev__note error" role="alert"><b>error</b> &middot; {loadError}</div>
+      </div>
+    {:else if revisions.length === 0}
+      <div class="rev-empty">
+        <div class="rev-empty__mark"><Icon name="history" size={27} /></div>
+        <div class="rev-empty__k">no_revisions</div>
+        <h3 class="rev-empty__title">no earlier versions</h3>
+        <p class="rev-empty__sub">
+          Arca snapshots a revision automatically whenever you change a field on this entry. Once you
+          make an edit, prior versions collect here &mdash; newest first.
+        </p>
+      </div>
+    {:else}
+      <div class="rev-list">
+        {#each items as item (item.index)}
+          {@const isOpen = revealedIndex === item.index}
+          {@const isCopied = copiedIndex === item.index}
+          <div class={item.latest ? 'rev rev--latest' : 'rev'}>
+            <span class="rev__node"></span>
+            <div class="rev__head">
+              <span class="rev__ref">{item.ref}</span>
+              <span class="rev__when">{item.when}</span>
+              <span class="rev__stamp">{item.stamp}</span>
+              {#if item.latest}<span class="rev__tag">latest</span>{/if}
+            </div>
+
+            {#if item.changes.length > 0}
+              <div class="rev__diff">
+                {#each item.changes as change, changeIndex (changeIndex)}
+                  {#if change.kind === 'password'}
+                    <span class="rev__chg rev__chg--pw"><span class="rev__chg-k">password</span>updated</span>
+                  {:else if change.kind === 'note'}
+                    <span class="rev__chg"><span class="rev__chg-k">{change.key}</span>changed</span>
+                  {:else}
+                    <span class="rev__chg">
+                      <span class="rev__chg-k">{change.key}</span>
+                      <span class="rev__chg-old">{change.from}</span>
+                      <span class="rev__chg-arrow">&rarr;</span>
+                      <span class="rev__chg-new">{change.to}</span>
+                    </span>
+                  {/if}
+                {/each}
+              </div>
+            {/if}
+
+            <div class={isOpen ? 'rev__pw rev__pw--open' : 'rev__pw'}>
+              <span class="rev__pw-k">password</span>
+              <span class={isOpen ? 'rev__pw-v rev__pw-v--open' : 'rev__pw-v'}>
+                {isOpen ? revealedPassword : MASK}
+              </span>
+              <span class="rev__pw-right">
+                {#if isOpen}<span class="rev__pw-cd">{formatCountdown(countdown)}</span>{/if}
+                <span class="rev__pw-actions">
+                  <IconButton
+                    label={isOpen ? 'Hide revision password' : 'Reveal revision password'}
+                    variant={isOpen ? 'accent' : 'default'}
+                    disabled={busyIndex === item.index}
+                    onclick={() => toggleReveal(item.index)}
+                  >
+                    <Icon name={isOpen ? 'eye-off' : 'eye'} size={13} />
+                  </IconButton>
+                  <IconButton
+                    label={isCopied ? 'Revision password copied' : 'Copy revision password'}
+                    variant={isCopied ? 'vault' : 'default'}
+                    disabled={busyIndex === item.index}
+                    onclick={() => copyRevision(item.index)}
+                  >
+                    {#if isCopied}
+                      <span class="rev__ok">&#10003;</span>
+                    {:else}
+                      <Icon name="copy" size={13} />
+                    {/if}
+                  </IconButton>
+                </span>
+              </span>
+              {#if isOpen}
+                <span class="rev__pw-timer" style="width: {countdown * 10}%"></span>
+              {/if}
+            </div>
+
+            {#if isCopied}
+              <div class="rev__note"><b>copied</b> &middot; {clipboardNote}</div>
+            {:else if isOpen}
+              <div class="rev__note rev__note--reveal">
+                <b>revealed</b> &middot; auto-hides in {countdown}s
+              </div>
             {/if}
           </div>
-          <div class={revealedIndex === index ? 'field field--focus field--secret-revealed' : 'field field--focus'}>
-            <div class="field__k">password</div>
-            <div class={revealedIndex === index ? 'field__v field__v--secret' : 'field__v field__v--mask'}>
-              {revealedIndex === index ? revealedPassword : passwordMask}
-            </div>
-            <div class="field__actions">
-              <IconButton
-                label={revealedIndex === index ? 'Hide revision password' : 'Reveal revision password'}
-                variant={revealedIndex === index ? 'accent' : 'default'}
-                disabled={busyIndex === index}
-                onclick={() => toggleReveal(index)}
-              >
-                <Icon name="eye" size={13} />
-              </IconButton>
-              <IconButton
-                label={copiedIndex === index ? 'Revision password copied' : 'Copy revision password'}
-                variant={copiedIndex === index ? 'accent' : 'default'}
-                disabled={busyIndex === index}
-                onclick={() => copyRevision(index)}
-              >
-                {#if copiedIndex === index}
-                  ✓
-                {:else}
-                  <Icon name="copy" size={13} />
-                {/if}
-              </IconButton>
-            </div>
-          </div>
-        </li>
-      {/each}
-    </ul>
-  {/if}
+        {/each}
+      </div>
+    {/if}
+  </div>
 </div>
-
-<style>
-  .revision-history {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    max-height: min(70vh, 34rem);
-  }
-
-  .revision-history__head {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-  }
-
-  .revision-history__status {
-    opacity: 0.7;
-  }
-
-  .revision-history__list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    overflow-y: auto;
-  }
-
-  .revision-history__item {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-    padding-bottom: 0.75rem;
-    border-bottom: 1px solid var(--border, rgba(127, 127, 127, 0.2));
-  }
-
-  .revision-history__item:last-child {
-    border-bottom: none;
-    padding-bottom: 0;
-  }
-
-  .revision-history__meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.25rem 1rem;
-    font-size: 0.75rem;
-    opacity: 0.75;
-  }
-</style>

--- a/apps/desktop/src/lib/components/detail/RevisionHistory.svelte
+++ b/apps/desktop/src/lib/components/detail/RevisionHistory.svelte
@@ -30,8 +30,11 @@
   let copiedIndex = $state<number | null>(null);
   let busyIndex = $state<number | null>(null);
   let countdown = $state(REVEAL_SECONDS);
+  let actionError = $state('');
   let countdownTimer: ReturnType<typeof setInterval> | null = null;
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
+  let dialog: HTMLDivElement | null = null;
+  let destroyed = false;
 
   const items = $derived(
     revisions.map((revision, index) => {
@@ -54,6 +57,9 @@
   onMount(() => {
     void load();
 
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    dialog?.focus();
+
     function handleKeydown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
         event.preventDefault();
@@ -62,10 +68,14 @@
     }
 
     window.addEventListener('keydown', handleKeydown);
-    return () => window.removeEventListener('keydown', handleKeydown);
+    return () => {
+      window.removeEventListener('keydown', handleKeydown);
+      previouslyFocused?.focus();
+    };
   });
 
   onDestroy(() => {
+    destroyed = true;
     clearCountdown();
 
     if (copyTimer) {
@@ -94,10 +104,13 @@
     }
 
     busyIndex = index;
+    actionError = '';
 
     try {
-      return await revealEntryRevisionPassword(entry.id, index);
-    } catch {
+      const password = await revealEntryRevisionPassword(entry.id, index);
+      return destroyed ? '' : password;
+    } catch (error) {
+      actionError = messageFromError(error);
       return '';
     } finally {
       busyIndex = null;
@@ -112,7 +125,7 @@
 
     const password = await loadPassword(index);
 
-    if (!password) {
+    if (destroyed || !password) {
       return;
     }
 
@@ -125,11 +138,15 @@
     const password =
       revealedIndex === index && revealedPassword ? revealedPassword : await loadPassword(index);
 
-    if (!password) {
+    if (destroyed || !password) {
       return;
     }
 
     if (!(await writeConfiguredClipboardText(password))) {
+      return;
+    }
+
+    if (destroyed) {
       return;
     }
 
@@ -296,7 +313,14 @@
   <button type="button" class="rev-overlay__scrim" aria-label="Close revision history" onclick={onclose}
   ></button>
 
-  <div class="rev-panel" role="dialog" aria-modal="true" aria-labelledby="rev-panel-title">
+  <div
+    bind:this={dialog}
+    tabindex="-1"
+    class="rev-panel"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="rev-panel-title"
+  >
     <div class="rev-panel__head">
       <span class="rev-panel__ico"><Icon name="history" size={17} /></span>
       <div class="rev-panel__titles">
@@ -310,6 +334,10 @@
         close <kbd>esc</kbd>
       </Button>
     </div>
+
+    {#if actionError}
+      <div class="rev-panel__error mono" role="alert"><b>error</b> &middot; {actionError}</div>
+    {/if}
 
     {#if loading}
       <div class="rev-list">

--- a/apps/desktop/src/lib/components/icons/Icon.svelte
+++ b/apps/desktop/src/lib/components/icons/Icon.svelte
@@ -19,19 +19,21 @@
     | 'trash'
     | 'vault';
 
+  interface Props {
+    name: IconName;
+    size?: number;
+    sw?: number;
+    class?: string;
+    [key: string]: unknown;
+  }
+
   let {
     name,
     size = 16,
     sw = 1.5,
     class: className = '',
     ...rest
-  } = $props<{
-    name: IconName;
-    size?: number;
-    sw?: number;
-    class?: string;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 </script>
 
 <svg

--- a/apps/desktop/src/lib/components/icons/Icon.svelte
+++ b/apps/desktop/src/lib/components/icons/Icon.svelte
@@ -9,6 +9,8 @@
     | 'edit'
     | 'external'
     | 'eye'
+    | 'eye-off'
+    | 'history'
     | 'key'
     | 'plus'
     | 'refresh'
@@ -51,6 +53,16 @@
   {:else if name === 'eye'}
     <path d="M1.5 8s2.5-5 6.5-5 6.5 5 6.5 5-2.5 5-6.5 5S1.5 8 1.5 8Z" />
     <circle cx="8" cy="8" r="2" />
+  {:else if name === 'eye-off'}
+    <path
+      d="M6.4 3.2A6.7 6.7 0 0 1 8 3c4 0 6.5 5 6.5 5a13 13 0 0 1-1.8 2.4M4.1 4.6A12.7 12.7 0 0 0 1.5 8s2.5 5 6.5 5a6.4 6.4 0 0 0 2.4-.45"
+    />
+    <path d="M6.6 6.6a2 2 0 0 0 2.8 2.8" />
+    <path d="m2 2 12 12" />
+  {:else if name === 'history'}
+    <path d="M2.6 8a5.4 5.4 0 1 0 1.7-4L2.4 5.8" />
+    <path d="M2.4 2.6V6h3.4" />
+    <path d="M8 5.3V8l2.2 1.4" />
   {:else if name === 'plus'}
     <path d="M8 3v10M3 8h10" />
   {:else if name === 'refresh'}

--- a/apps/desktop/src/lib/components/primitives/Button.svelte
+++ b/apps/desktop/src/lib/components/primitives/Button.svelte
@@ -5,6 +5,16 @@
   type ButtonSize = 'default' | 'sm' | 'xs';
   type ButtonType = 'button' | 'submit' | 'reset';
 
+  interface Props {
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+    type?: ButtonType;
+    disabled?: boolean;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  }
+
   let {
     variant = 'ghost',
     size = 'default',
@@ -13,15 +23,7 @@
     class: className = '',
     children,
     ...rest
-  } = $props<{
-    variant?: ButtonVariant;
-    size?: ButtonSize;
-    type?: ButtonType;
-    disabled?: boolean;
-    class?: string;
-    children?: Snippet;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const classes = $derived(
     ['btn', `btn--${variant}`, size !== 'default' ? `btn--${size}` : '', className]

--- a/apps/desktop/src/lib/components/primitives/Entropy.svelte
+++ b/apps/desktop/src/lib/components/primitives/Entropy.svelte
@@ -1,4 +1,13 @@
 <script lang="ts">
+  interface Props {
+    filled?: number;
+    segments?: number;
+    bits?: number;
+    strength?: string;
+    class?: string;
+    [key: string]: unknown;
+  }
+
   let {
     filled = 13,
     segments = 16,
@@ -6,14 +15,7 @@
     strength = 'strong',
     class: className = '',
     ...rest
-  } = $props<{
-    filled?: number;
-    segments?: number;
-    bits?: number;
-    strength?: string;
-    class?: string;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const classes = $derived(['entropy', className].filter(Boolean).join(' '));
   const segmentCount = $derived(Math.max(0, Math.floor(segments)));

--- a/apps/desktop/src/lib/components/primitives/IconButton.svelte
+++ b/apps/desktop/src/lib/components/primitives/IconButton.svelte
@@ -4,6 +4,17 @@
   type IconButtonVariant = 'default' | 'accent' | 'vault' | 'ghost';
   type ButtonType = 'button' | 'submit' | 'reset';
 
+  interface Props {
+    variant?: IconButtonVariant;
+    label: string;
+    title?: string;
+    type?: ButtonType;
+    disabled?: boolean;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  }
+
   let {
     variant = 'default',
     label,
@@ -13,16 +24,7 @@
     class: className = '',
     children,
     ...rest
-  } = $props<{
-    variant?: IconButtonVariant;
-    label: string;
-    title?: string;
-    type?: ButtonType;
-    disabled?: boolean;
-    class?: string;
-    children?: Snippet;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const classes = $derived(
     ['iconbtn', variant !== 'default' ? `iconbtn--${variant}` : '', className]

--- a/apps/desktop/src/lib/components/primitives/Kbd.svelte
+++ b/apps/desktop/src/lib/components/primitives/Kbd.svelte
@@ -1,17 +1,19 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
 
+  interface Props {
+    value?: string;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  }
+
   let {
     value,
     class: className = '',
     children,
     ...rest
-  } = $props<{
-    value?: string;
-    class?: string;
-    children?: Snippet;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const classes = $derived(['kbd', className].filter(Boolean).join(' '));
 </script>

--- a/apps/desktop/src/lib/components/primitives/Segmented.svelte
+++ b/apps/desktop/src/lib/components/primitives/Segmented.svelte
@@ -5,6 +5,15 @@
     disabled?: boolean;
   }
 
+  interface Props {
+    options?: SegmentedOption[];
+    value: string;
+    ariaLabel?: string;
+    onselect?: (value: string) => void;
+    class?: string;
+    [key: string]: unknown;
+  }
+
   let {
     options = [],
     value,
@@ -12,14 +21,7 @@
     onselect,
     class: className = '',
     ...rest
-  } = $props<{
-    options?: SegmentedOption[];
-    value: string;
-    ariaLabel?: string;
-    onselect?: (value: string) => void;
-    class?: string;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const classes = $derived(['seg', className].filter(Boolean).join(' '));
 </script>

--- a/apps/desktop/src/lib/components/primitives/Slider.svelte
+++ b/apps/desktop/src/lib/components/primitives/Slider.svelte
@@ -1,4 +1,17 @@
 <script lang="ts">
+  interface Props {
+    value: number;
+    min?: number;
+    max?: number;
+    step?: number;
+    ariaLabel?: string;
+    valueLabel?: string;
+    oninput?: (value: number) => void;
+    onchange?: (value: number) => void;
+    class?: string;
+    [key: string]: unknown;
+  }
+
   let {
     value,
     min = 0,
@@ -10,18 +23,7 @@
     onchange,
     class: className = '',
     ...rest
-  } = $props<{
-    value: number;
-    min?: number;
-    max?: number;
-    step?: number;
-    ariaLabel?: string;
-    valueLabel?: string;
-    oninput?: (value: number) => void;
-    onchange?: (value: number) => void;
-    class?: string;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const classes = $derived(['slider', className].filter(Boolean).join(' '));
   const percent = $derived(max <= min ? 0 : Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100)));

--- a/apps/desktop/src/lib/components/primitives/Tag.svelte
+++ b/apps/desktop/src/lib/components/primitives/Tag.svelte
@@ -3,6 +3,15 @@
 
   type TagVariant = 'default' | 'vault' | 'slate' | 'out' | 'ink' | 'paper';
 
+  interface Props {
+    variant?: TagVariant;
+    value?: string;
+    bracketed?: boolean;
+    class?: string;
+    children?: Snippet;
+    [key: string]: unknown;
+  }
+
   let {
     variant = 'default',
     value,
@@ -10,14 +19,7 @@
     class: className = '',
     children,
     ...rest
-  } = $props<{
-    variant?: TagVariant;
-    value?: string;
-    bracketed?: boolean;
-    class?: string;
-    children?: Snippet;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const classes = $derived(
     ['tag', variant !== 'default' ? `tag--${variant}` : '', className].filter(Boolean).join(' '),

--- a/apps/desktop/src/lib/components/primitives/Toggle.svelte
+++ b/apps/desktop/src/lib/components/primitives/Toggle.svelte
@@ -1,4 +1,13 @@
 <script lang="ts">
+  interface Props {
+    checked?: boolean;
+    variant?: 'default' | 'vault';
+    label: string;
+    ontoggle?: (checked: boolean) => void;
+    class?: string;
+    [key: string]: unknown;
+  }
+
   let {
     checked = false,
     variant = 'default',
@@ -6,14 +15,7 @@
     ontoggle,
     class: className = '',
     ...rest
-  } = $props<{
-    checked?: boolean;
-    variant?: 'default' | 'vault';
-    label: string;
-    ontoggle?: (checked: boolean) => void;
-    class?: string;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   const classes = $derived(
     ['switch', checked ? 'switch--on' : '', variant === 'vault' ? 'switch--vault' : '', className]

--- a/apps/desktop/src/lib/components/vault/EntryRow.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryRow.svelte
@@ -5,17 +5,19 @@
   import { Icon, type IconName } from '../icons';
   import { Tag } from '../primitives';
 
+  interface Props {
+    entry: EntryDto;
+    selected?: boolean;
+    rowKey?: string;
+    onselect?: (entry: EntryDto) => void;
+  }
+
   let {
     entry,
     selected = false,
     rowKey,
     onselect,
-  } = $props<{
-    entry: EntryDto;
-    selected?: boolean;
-    rowKey?: string;
-    onselect?: (entry: EntryDto) => void;
-  }>();
+  }: Props = $props();
 
   const iconName = $derived(iconForEntry(entry));
   const weak = $derived(Boolean(entry.tags.find((tag: string) => normalize(tag) === 'weak')));

--- a/apps/desktop/src/lib/components/vault/FilterSidebar.svelte
+++ b/apps/desktop/src/lib/components/vault/FilterSidebar.svelte
@@ -12,6 +12,16 @@
     count: number;
   }
 
+  interface Props {
+    filters?: FilterItem[];
+    tags?: TagItem[];
+    active?: string;
+    activeTag?: string | null;
+    onselect?: (key: string) => void;
+    ontagselect?: (tag: string) => void;
+    onclear?: () => void;
+  }
+
   let {
     filters = [],
     tags = [],
@@ -20,15 +30,7 @@
     onselect,
     ontagselect,
     onclear,
-  } = $props<{
-    filters?: FilterItem[];
-    tags?: TagItem[];
-    active?: string;
-    activeTag?: string | null;
-    onselect?: (key: string) => void;
-    ontagselect?: (tag: string) => void;
-    onclear?: () => void;
-  }>();
+  }: Props = $props();
 </script>
 
 <aside class="sidepanel" aria-label="Vault filters">

--- a/apps/desktop/src/lib/components/vault/SearchBar.svelte
+++ b/apps/desktop/src/lib/components/vault/SearchBar.svelte
@@ -3,6 +3,19 @@
 
   const searchShortcut = primaryModifierLabel() === '⌘' ? '⌘F' : 'Ctrl+F';
 
+  interface Props {
+    query?: string;
+    focused?: boolean;
+    focusToken?: number;
+    onquery?: (query: string) => void;
+    onfocus?: () => void;
+    onblur?: () => void;
+    onclear?: () => void;
+    shortcut?: string;
+    class?: string;
+    [key: string]: unknown;
+  }
+
   let {
     query = '',
     focused = false,
@@ -14,18 +27,7 @@
     shortcut = searchShortcut,
     class: className = '',
     ...rest
-  } = $props<{
-    query?: string;
-    focused?: boolean;
-    focusToken?: number;
-    onquery?: (query: string) => void;
-    onfocus?: () => void;
-    onblur?: () => void;
-    onclear?: () => void;
-    shortcut?: string;
-    class?: string;
-    [key: string]: unknown;
-  }>();
+  }: Props = $props();
 
   let inputElement = $state<HTMLInputElement | null>(null);
   const classes = $derived(['search', focused ? 'search--focus' : '', className].filter(Boolean).join(' '));

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -35,6 +35,7 @@ export interface RevisionDto {
   url: string | null;
   notes: string | null;
   tags: string[];
+  passwordChanged: boolean;
 }
 
 export interface CreateEntryDto {

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -26,6 +26,17 @@ export interface EntryDto {
   revisionCount: number;
 }
 
+export interface RevisionDto {
+  capturedAt: string;
+  updatedAt: string;
+  title: string;
+  username: string;
+  collection: string | null;
+  url: string | null;
+  notes: string | null;
+  tags: string[];
+}
+
 export interface CreateEntryDto {
   title: string;
   username: string;
@@ -98,6 +109,14 @@ export function listEntries(): Promise<EntryDto[]> {
 
 export function getEntry(id: string): Promise<EntryDto> {
   return invoke('get_entry', { id });
+}
+
+export function getEntryRevisions(id: string): Promise<RevisionDto[]> {
+  return invoke('get_entry_revisions', { id });
+}
+
+export function revealEntryRevisionPassword(id: string, index: number): Promise<string> {
+  return invoke('reveal_entry_revision_password', { id, index });
 }
 
 export function createEntry(data: CreateEntryDto): Promise<EntryDto> {


### PR DESCRIPTION
## Summary
Implements the revision **history view** from #159, building on the encrypted-storage foundation shipped in #158. Turns the read-only revision *count* into a browsable panel where a prior password can be explicitly revealed or copied.

Closes #159.

## Reveal model — lazy, per-revision
Chosen to minimize historical plaintext in the webview:
- **`get_entry_revisions(id)`** returns revision **metadata only** (captured/updated timestamps, title, username, url, notes, collection, tags) — **no passwords**. `RevisionDto` has no password field at all.
- **`reveal_entry_revision_password(id, index)`** returns a **single** plaintext password, only for the revision the user explicitly reveals.

Both commands are gated by the existing `ensure_unlocked`, mirroring how `get_entry` reveals the current password. `list_entries`, `search_entries`, and audit DTOs are unchanged — still count-only.

## Frontend
- A `RevisionHistory` panel opened from the `revisions` metric in `MetricStrip` (the count becomes a button when `revisionCount > 0`).
- Lists revisions newest-first with changed metadata, plus per-revision **reveal/copy** reusing the current-password `FieldStack` pattern: masked by default, lazy reveal, 10s auto-hide, and `writeConfiguredClipboardText` so copied historical passwords inherit the clipboard auto-clear timeout.
- Reveal is lazy — a revision's plaintext is fetched only when its reveal/copy is clicked, never on panel open; the revealed value is cleared on hide/close/destroy.

## Security notes
- Unlock required for every revision reveal/copy.
- No historical plaintext in list/search/audit DTOs; `RevisionDto` cannot carry a password (regression-tested).
- Reveal auto-hides after 10s and clears on close; no long-lived caching of revealed values.
- Touches IPC secret transport + secret display/copy → **needs human review**.

## Out of scope (possible follow-ups)
Rollback-as-mutation, age-based retention, and a "clear history" action.

## Tests
- Rust: `get_entry_revisions` returns ordered metadata; `reveal_entry_revision_password` returns the right plaintext and rejects out-of-range indices; both require an unlocked vault; `RevisionDto` serialization excludes any password.
- Frontend: typecheck + build clean; existing vitest suite passes.

## Validation
- `cargo fmt --all --check` · `cargo clippy --workspace --all-targets -- -D warnings` · `cargo test --workspace` (58 tests)
- `pnpm lint` · `pnpm build` · `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added revision history for entries, including captured field values, timestamps, and password-change indicators.
  - Added a revision-history view accessible from entry details.
  - Revision passwords remain masked and can be temporarily revealed or copied while the vault is unlocked.
  - Added loading, empty, error, dismissal, and responsive display states.
  - Added accessible history and password-visibility controls with updated visual indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->