### PR TITLE
docs: expand README and add Code of Conduct for public launch

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-**[INSERT CONTACT METHOD]**.
+**https://www.invenbyte.com/contact**.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**[INSERT CONTACT METHOD]**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/77654f67-5294-4d34-94d2-e79786ffc99c">
-  <img alt="Arca — a vault for what you can't lose." src="https://github.com/user-attachments/assets/c44544b8-8737-41c1-8d1a-9aa8583bb7a5">
+  <img alt="Arca - a vault for what you can't lose." src="https://github.com/user-attachments/assets/c44544b8-8737-41c1-8d1a-9aa8583bb7a5">
 </picture>
 
 Open-source, local-first password vault with a terminal-inspired UI.
 
 Arca keeps your credentials in a single encrypted vault file on your own
-machine — no accounts, no sync, no telemetry. Secrets are decrypted only while
+machine - no accounts, no sync, no telemetry. Secrets are decrypted only while
 the vault is unlocked and are cleared from memory when you lock it.
 
 > **Pre-1.0 / pre-release.** Arca has not yet had a tagged release or an
@@ -17,13 +17,13 @@ the vault is unlocked and are cleared from memory when you lock it.
 
 ## Features
 
-- **Local encrypted vault** — one portable vault file, opened with your master password.
-- **Entries** — title, username, password, URL, notes, collection, and tags, with fast search.
-- **Password generator** — configurable length and character classes, with an entropy readout.
-- **Reveal & copy discipline** — passwords stay masked until explicitly revealed; the clipboard auto-clears after a configurable timeout.
-- **Auto-lock** — the vault locks after a configurable period of inactivity.
-- **Revision history** — a bounded, encrypted history of prior entry versions; reveal or copy a previous password on demand.
-- **Audit** — surfaces weak or reused credentials without exposing plaintext.
+- **Local encrypted vault** - one portable vault file, opened with your master password.
+- **Entries** - title, username, password, URL, notes, collection, and tags, with fast search.
+- **Password generator** - configurable length and character classes, with an entropy readout.
+- **Reveal & copy discipline** - passwords stay masked until explicitly revealed; the clipboard auto-clears after a configurable timeout.
+- **Auto-lock** - the vault locks after a configurable period of inactivity.
+- **Revision history** - a bounded, encrypted history of prior entry versions; reveal or copy a previous password on demand.
+- **Audit** - surfaces weak or reused credentials without exposing plaintext.
 
 ## Security model
 
@@ -43,7 +43,7 @@ other platforms are currently unverified. See [RELEASE.md](RELEASE.md) for the
 release process and supported targets.
 
 - Entries require a non-empty password; passwordless entries and password clearing are not supported ([#74](https://github.com/akei9/arca/issues/74)).
-- No remote sync — you are responsible for backing up your vault file.
+- No remote sync - you are responsible for backing up your vault file.
 
 ## Build from source
 
@@ -69,12 +69,12 @@ cargo test --workspace
 
 ## Project layout
 
-- `apps/desktop` — Tauri v2 desktop app (Svelte 5 frontend + thin Rust command layer).
-- `packages/vault-core` — Rust crate holding all cryptography, vault parsing, and secret handling.
+- `apps/desktop` - Tauri v2 desktop app (Svelte 5 frontend + thin Rust command layer).
+- `packages/vault-core` - Rust crate holding all cryptography, vault parsing, and secret handling.
 
 ## Contributing
 
-Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and the
+Contributions are welcome - see [CONTRIBUTING.md](CONTRIBUTING.md) and the
 [Code of Conduct](CODE_OF_CONDUCT.md). Changes touching crypto, vault
 persistence, IPC secret transport, or secret display/copy behavior require human
 review before merge.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,78 @@
 
 Open-source, local-first password vault with a terminal-inspired UI.
 
-## Current Entry Semantics
+Arca keeps your credentials in a single encrypted vault file on your own
+machine — no accounts, no sync, no telemetry. Secrets are decrypted only while
+the vault is unlocked and are cleared from memory when you lock it.
 
-Entries require a non-empty password. Editing an entry may omit the password to
-keep the existing value, or provide a non-empty replacement. Passwordless entries
-and password clearing are not supported in this release; see
-[#74](https://github.com/akei9/arca/issues/74).
+> **Pre-1.0 / pre-release.** Arca has not yet had a tagged release or an
+> independent security audit. Review the code and threat model before trusting
+> it with real secrets. See the [v0.1 milestone](https://github.com/akei9/arca/milestone/1).
 
-## Release Preparation
+## Features
 
-Maintainer release and smoke-test steps live in [RELEASE.md](RELEASE.md).
+- **Local encrypted vault** — one portable vault file, opened with your master password.
+- **Entries** — title, username, password, URL, notes, collection, and tags, with fast search.
+- **Password generator** — configurable length and character classes, with an entropy readout.
+- **Reveal & copy discipline** — passwords stay masked until explicitly revealed; the clipboard auto-clears after a configurable timeout.
+- **Auto-lock** — the vault locks after a configurable period of inactivity.
+- **Revision history** — a bounded, encrypted history of prior entry versions; reveal or copy a previous password on demand.
+- **Audit** — surfaces weak or reused credentials without exposing plaintext.
+
+## Security model
+
+- **Vault format:** KeePass KDBX, so vaults stay portable and interoperable.
+- **Key derivation:** Argon2id (memory-hard) from your master password.
+- **Encryption:** XChaCha20-Poly1305 authenticated encryption.
+- **Secret handling:** all cryptography and secret material live in the `vault-core` Rust crate; plaintext is zeroized after use and never logged.
+- **Local only:** no sync, accounts, or telemetry in this release. You own your vault file and are responsible for its backups.
+
+To report a vulnerability, see [SECURITY.md](.github/SECURITY.md). Please do not
+include real secrets in reports.
+
+## Status & limitations
+
+The first desktop target is **macOS on Apple Silicon** (`aarch64-apple-darwin`);
+other platforms are currently unverified. See [RELEASE.md](RELEASE.md) for the
+release process and supported targets.
+
+- Entries require a non-empty password; passwordless entries and password clearing are not supported ([#74](https://github.com/akei9/arca/issues/74)).
+- No remote sync — you are responsible for backing up your vault file.
+
+## Build from source
+
+Prerequisites: [Node.js](https://nodejs.org) + [pnpm](https://pnpm.io), a
+[Rust](https://rustup.rs) toolchain, and the
+[Tauri v2 system prerequisites](https://v2.tauri.app/start/prerequisites/) for
+your OS.
+
+```sh
+pnpm install
+pnpm dev                                  # run the app in development
+pnpm --filter @arca/desktop tauri build   # build the desktop bundle
+```
+
+Checks (see [RELEASE.md](RELEASE.md) for the full pre-release gate):
+
+```sh
+pnpm lint            # svelte-check
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+## Project layout
+
+- `apps/desktop` — Tauri v2 desktop app (Svelte 5 frontend + thin Rust command layer).
+- `packages/vault-core` — Rust crate holding all cryptography, vault parsing, and secret handling.
+
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and the
+[Code of Conduct](CODE_OF_CONDUCT.md). Changes touching crypto, vault
+persistence, IPC secret transport, or secret display/copy behavior require human
+review before merge.
+
+## License
+
+[MIT](LICENSE) © 2026 Adrian Kucharczyk

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 Open-source, local-first password vault with a terminal-inspired UI.
 
 Arca keeps your credentials in a single encrypted vault file on your own
-machine - no accounts, no sync, no telemetry. Secrets are decrypted only while
-the vault is unlocked and are cleared from memory when you lock it.
+machine - no accounts, no sync, no telemetry. The vault is decrypted only while
+it is unlocked, and locking zeroizes the decrypted vault held in Arca's Rust
+core.
 
 > **Pre-1.0 / pre-release.** Arca has not yet had a tagged release or an
 > independent security audit. Review the code and threat model before trusting
@@ -27,10 +28,9 @@ the vault is unlocked and are cleared from memory when you lock it.
 
 ## Security model
 
-- **Vault format:** KeePass KDBX, so vaults stay portable and interoperable.
-- **Key derivation:** Argon2id (memory-hard) from your master password.
-- **Encryption:** XChaCha20-Poly1305 authenticated encryption.
-- **Secret handling:** all cryptography and secret material live in the `vault-core` Rust crate; plaintext is zeroized after use and never logged.
+- **Vault format:** KeePass KDBX 4, so vaults stay portable and interoperable. Persistence goes through the [`keepass`](https://crates.io/crates/keepass) crate.
+- **At-rest encryption:** the current KDBX 4 defaults - **Argon2d** key derivation from your master password, an **AES-256** outer cipher, and a **ChaCha20** stream cipher for protected fields.
+- **Secret handling:** while the vault is unlocked, decrypted values necessarily flow through the app to be shown or copied - the Rust session state, the Tauri IPC responses, UI strings, and the system clipboard during reveal/copy. Rust-side secrets use `Zeroizing`/`ZeroizeOnDrop` and are zeroized on lock, and secrets are never logged; clipboard contents clear on the configured timeout rather than on lock.
 - **Local only:** no sync, accounts, or telemetry in this release. You own your vault file and are responsible for its backups.
 
 To report a vulnerability, see [SECURITY.md](.github/SECURITY.md). Please do not


### PR DESCRIPTION
Part of the v0.1 launch polish.

- **README** - adds Features, Security model (KDBX + Argon2id + XChaCha20-Poly1305), Status & limitations, Build-from-source, and Project layout sections; keeps the existing hero.
- **CODE_OF_CONDUCT.md** - Contributor Covenant 2.1.

Closes #169
Closes #170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the README with project overview, features, security details, platform limitations, build instructions, project structure, contribution guidance, and licensing information.
  - Added a pre-release warning and removed outdated release-preparation and entry-semantics sections.

- **Community**
  - Added a Contributor Covenant Code of Conduct covering expected behavior, reporting procedures, privacy, responsibilities, and enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->