### PR TITLE
chore: make CodeRabbit reviews manual-trigger only

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,6 +4,8 @@ reviews:
   high_level_summary: true
   poem: false
   review_status: true
+  auto_review:
+    enabled: false
   path_instructions:
     - path: "packages/vault-core/**"
       instructions: |


### PR DESCRIPTION
Disables CodeRabbit **automatic** reviews via `reviews.auto_review.enabled: false`. Reviews can still be triggered on demand by commenting `@coderabbitai review` on a PR.

Everything else (assertive profile, request-changes workflow, path instructions) is unchanged.