### PR TITLE
fix: source app version from metadata instead of hardcoding it

### DIFF
--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getVersion } from '@tauri-apps/api/app';
   import { getCurrentWindow } from '@tauri-apps/api/window';
   import { onMount } from 'svelte';
   import { cancelClipboardClear } from './lib/clipboard';
@@ -31,6 +32,7 @@
   let lastActivityAt = $state(Date.now());
   let autoLockTimer: ReturnType<typeof setTimeout> | null = null;
   let isFullscreen = $state(false);
+  let appVersion = $state('');
 
   const modLabel = $derived(primaryModifierLabel());
   const lockShortcut = $derived(shortcutLabel(modLabel, 'Shift', 'L'));
@@ -53,6 +55,10 @@
 
   const chromePath = $derived(
     chromePathFor(uiState.view, vaultState.locked, vaultState.selectedEntry?.title),
+  );
+
+  const chromeVersion = $derived(
+    appVersion ? `v${appVersion} · ${new Date().getFullYear()}` : '',
   );
 
   const unlockSurface = $derived(
@@ -304,6 +310,15 @@
     void loadRuntimeSettings().catch(() => {
       // Browser previews keep the default runtime settings when Tauri IPC is unavailable.
     });
+    void getVersion()
+      .then((version) => {
+        if (mounted) {
+          appVersion = version;
+        }
+      })
+      .catch(() => {
+        // Browser previews leave the version blank when Tauri IPC is unavailable.
+      });
     void syncFullscreenState(windowHandle);
 
     void windowHandle
@@ -372,7 +387,7 @@
 </script>
 
 <main class={appClasses} data-theme={uiState.theme} style={appStyle}>
-  <WindowChrome path={chromePath} />
+  <WindowChrome path={chromePath} rightText={chromeVersion} />
 
   {#if !vaultState.locked}
     <Tabs items={tabItems} active={activeTab} onselect={selectTab} />

--- a/apps/desktop/src/lib/components/chrome/WindowChrome.svelte
+++ b/apps/desktop/src/lib/components/chrome/WindowChrome.svelte
@@ -14,7 +14,7 @@
   let {
     path = 'vault.local',
     prefix = './',
-    rightText = 'v0.2 · 2026',
+    rightText = '',
     right,
     class: className = '',
     ...rest


### PR DESCRIPTION
The window chrome showed a hardcoded **`v0.2 · 2026`**, but the app version is **0.1.0** everywhere (`tauri.conf.json`, `Cargo.toml`, `package.json`) — so the UI was wrong.

**Fix:** fetch the real version at runtime via `getVersion()` (`@tauri-apps/api/app`, which reads `tauri.conf.json` — the single source of truth for the built app) and render `v{version} · {year}`. The stale `rightText` default in `WindowChrome` is cleared so no hardcoded version can leak. Falls back to blank in browser previews where Tauri IPC is unavailable.

Now the chrome shows `v0.1.0 · 2026` and tracks whatever `tauri.conf.json` is bumped to for future releases.