### PR TITLE
fix: remove the misleading "sync" button from the vault list

### DIFF
--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -27,9 +27,7 @@
   let selectedTag = $state<string | null>(null);
   let searchFocused = $state(true);
   let searchFocusToken = $state(0);
-  let syncAcknowledged = $state(false);
   let activeRowKey = $state('');
-  let syncAckTimer: ReturnType<typeof setTimeout> | null = null;
 
   const sortedEntries = $derived([...vaultState.entries].sort(compareByUpdatedAt));
   const recentIds = $derived(new Set(sortedEntries.slice(0, 6).map((entry) => entry.id)));
@@ -138,7 +136,6 @@
 
     return () => {
       window.removeEventListener('keydown', handleKeydown);
-      clearSyncAckTimer();
     };
   });
 
@@ -166,15 +163,6 @@
     uiState.view = 'generator';
   }
 
-  function acknowledgeLocalSync() {
-    syncAcknowledged = true;
-    clearSyncAckTimer();
-    syncAckTimer = setTimeout(() => {
-      syncAcknowledged = false;
-      syncAckTimer = null;
-    }, 1400);
-  }
-
   function selectFilter(key: string) {
     selectedFilter = key as FilterKey;
   }
@@ -187,13 +175,6 @@
     selectedFilter = 'all';
     selectedTag = null;
     vaultState.searchQuery = '';
-  }
-
-  function clearSyncAckTimer() {
-    if (syncAckTimer) {
-      clearTimeout(syncAckTimer);
-      syncAckTimer = null;
-    }
   }
 
   function clearFilter() {
@@ -440,10 +421,6 @@
     <Button variant="primary" onclick={openNewEntry} aria-keyshortcuts="N">
       <Icon name="plus" size={11} sw={2} />
       new_entry
-    </Button>
-    <Button variant={syncAcknowledged ? 'vault' : 'ghost'} onclick={acknowledgeLocalSync}>
-      <Icon name="refresh" size={11} sw={2} />
-      {syncAcknowledged ? 'local_only' : 'sync'}
     </Button>
   </div>
 


### PR DESCRIPTION
Arca is local-first with no sync in v0.1, but the vault-list toolbar had a **sync** button that only flipped to `local_only` for ~1.4s when clicked - no actual behavior, and misleading for a no-sync app.

Removes the button and all its dead state (`syncAcknowledged`, `syncAckTimer`, `acknowledgeLocalSync`, `clearSyncAckTimer`). Typecheck + build pass.

Part of the v0.1 pass to remove misleading/placeholder UI (relates to #135).