### PR TITLE
fix: keep the slider knob within the track at min and max

### DIFF
--- a/apps/desktop/src/lib/components/primitives/Slider.svelte
+++ b/apps/desktop/src/lib/components/primitives/Slider.svelte
@@ -27,6 +27,7 @@
 
   const classes = $derived(['slider', className].filter(Boolean).join(' '));
   const percent = $derived(max <= min ? 0 : Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100)));
+  const position = $derived(`calc(7px + (100% - 14px) * ${percent} / 100)`);
 
   function readValue(raw: string): number {
     const parsed = Number(raw);
@@ -36,8 +37,8 @@
 
 <div {...rest} class={classes}>
   <div class="slider__track">
-    <div class="slider__fill" style:width={`${percent}%`}></div>
-    <div class="slider__knob" style:left={`${percent}%`}></div>
+    <div class="slider__fill" style:width={position}></div>
+    <div class="slider__knob" style:left={position}></div>
     <input
       class="slider__native"
       type="range"


### PR DESCRIPTION
**Bug** (found in manual smoke testing): setting the generator **length to 48** (the max) pushes the slider knob past the right edge of the track.

**Cause:** the knob is centered on `left: {percent}%` via `translate(-50%)`, so at 0%/100% its center sits on the track edge and half the 14px knob (7px) protrudes beyond it.

**Fix:** inset the knob (and fill) travel by the knob radius - `calc(7px + (100% - 14px) * percent / 100)` - so the thumb stays fully inside the track at both extremes. One change in the shared `Slider` primitive, so it also fixes the settings font-size slider.

Verified at min (8), a mid value, and max (48): the knob no longer overflows at either end. Typecheck + build pass.