### PR TITLE
fix: use a fixed-length mask for the generated password

### DIFF
--- a/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
+++ b/apps/desktop/src/lib/components/generator/GeneratorPanel.svelte
@@ -23,13 +23,14 @@
   let generationCounter = 0;
 
   const symbolHint = '! @ # $ % ^ & * ( ) - _ = + [ ] { } : ; , . ?';
+  const passwordMask = '•'.repeat(24);
   const hasCharacterSet = $derived(uppercase || lowercase || digits || symbols);
   const entropyBits = $derived(generated ? Math.round(generated.entropyBits) : 0);
   const strengthLabel = $derived(strengthFromEntropy(entropyBits));
   const entropyFilled = $derived(generated ? Math.max(1, Math.min(16, Math.round(entropyBits / 8))) : 0);
   const metaEntropy = $derived(generated ? `${entropyBits} bits` : 'pending');
   const displayedPassword = $derived(
-    generated ? (isRevealed ? generated.password : '•'.repeat(Math.max(generated.password.length, 12))) : '',
+    generated ? (isRevealed ? generated.password : passwordMask) : '',
   );
 
   onMount(() => {


### PR DESCRIPTION
**Bug**: on the generate page, setting length to **48** makes the **hidden/masked** password display overflow - the 48 dots wrap into a broken second row (the revealed password wraps too, but reads acceptably as a wrapped password).

**Cause:** the mask was `'•'.repeat(password.length)` (one dot per character) at 26px, so long passwords overflow the box.

**Fix:** use a **fixed 24-dot mask** - matching how the entry field (`FieldStack`) and revision history already mask passwords. It never overflows, and as a bonus no longer leaks the exact length through the dot count. Verified against the real `app.css` at narrow and wide widths.

Reveal still shows the full password (which may wrap for very long values - acceptable, as discussed).

Part of the v0.1 generate-page smoke-test fixes (relates to #135).