### PR TITLE
ci: add activation-ready macOS signing and notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,11 @@ name: Release Build
 # Builds the macOS (Apple Silicon) desktop bundle for a release candidate.
 # Runs the RELEASE.md required checks, then `tauri build`, and uploads the .app.
 #
-# Signing, notarization, DMG packaging, and publishing a GitHub Release are
-# intentionally NOT wired up yet — see issue #167. Until they are, artifacts
-# from this workflow are unsigned and for maintainer smoke testing only.
+# Signing + notarization activate automatically once the Apple secrets are
+# configured (see RELEASE.md, "Activating signing and notarization"). Until
+# then the build is unsigned and for maintainer smoke testing only. Enabling
+# DMG packaging and publishing a GitHub Release are the remaining manual steps
+# in that guide (issue #167).
 
 on:
   push:
@@ -23,6 +25,9 @@ jobs:
   macos:
     name: macOS (Apple Silicon)
     runs-on: macos-14
+    env:
+      # Exposed at job level so the certificate-import step can gate on it.
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -55,12 +60,35 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace
 
-      - name: Build desktop bundle
-        run: pnpm --filter @arca/desktop tauri build
+      # Imported only when the APPLE_CERTIFICATE secret is present, so the
+      # workflow keeps producing an unsigned build until signing is configured.
+      - name: Import Apple signing certificate
+        if: ${{ env.APPLE_CERTIFICATE != '' }}
+        env:
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode -o "$CERT_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" > /dev/null
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain
+          rm -f "$CERT_PATH"
 
-      # TODO(#167): sign + notarize the .app and re-enable DMG packaging before
-      # publishing any public release. Provide signing/notarization credentials
-      # via repository secrets in the release environment — never in the repo.
+      # tauri signs when APPLE_SIGNING_IDENTITY is set and notarizes when the
+      # APPLE_ID / APPLE_PASSWORD / APPLE_TEAM_ID trio is set. Empty values
+      # (secrets not configured yet) produce an unsigned build with no error.
+      - name: Build desktop bundle
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: pnpm --filter @arca/desktop tauri build
 
       - name: Upload app bundle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
   macos:
     name: macOS (Apple Silicon)
     runs-on: macos-14
+    environment: release
     env:
       # Exposed at job level so the certificate-import step can gate on it.
       APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -92,9 +92,11 @@ Before a public macOS release:
 ### Activating signing and notarization
 
 The `Release Build` workflow (`.github/workflows/release.yml`) already contains
-the signing and notarization steps. They stay inert (unsigned build, no error)
-until the following repository secrets are configured, at which point they
-activate automatically:
+the signing and notarization steps. Its `macos` job runs in the `release`
+GitHub environment, so the secrets below live on that environment (Settings ->
+Environments -> release), not at repository level. The steps stay inert
+(unsigned build, no error) until the secrets are configured, at which point
+they activate automatically:
 
 | Secret | Value |
 | --- | --- |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -89,6 +89,30 @@ Before a public macOS release:
 - Verify Gatekeeper behavior on a clean macOS account or machine.
 - Document the exact signing and notarization commands or CI workflow.
 
+### Activating signing and notarization
+
+The `Release Build` workflow (`.github/workflows/release.yml`) already contains
+the signing and notarization steps. They stay inert (unsigned build, no error)
+until the following repository secrets are configured, at which point they
+activate automatically:
+
+| Secret | Value |
+| --- | --- |
+| `APPLE_CERTIFICATE` | Base64 of the exported **Developer ID Application** certificate (`.p12`). |
+| `APPLE_CERTIFICATE_PASSWORD` | Password used when exporting the `.p12`. |
+| `KEYCHAIN_PASSWORD` | Any strong string; used only for the ephemeral CI keychain. |
+| `APPLE_SIGNING_IDENTITY` | The identity name, e.g. `Developer ID Application: Your Name (TEAMID)`. |
+| `APPLE_ID` | Apple ID email used for notarization. |
+| `APPLE_PASSWORD` | App-specific password for that Apple ID (or use an App Store Connect API key instead). |
+| `APPLE_TEAM_ID` | Your 10-character Apple Developer Team ID. |
+
+Then, to ship a DMG rather than only the `.app`, add `"dmg"` to
+`apps/desktop/src-tauri/tauri.conf.json` under `bundle.targets`
+(e.g. `["app", "dmg"]`) and update the `Upload app bundle` path accordingly.
+
+Finally, verify Gatekeeper on a clean macOS account, and only then publish the
+release.
+
 ## Current Build Verification
 
 Last verified locally:


### PR DESCRIPTION
Pre-wires #167 so signing goes live the moment the Apple secrets exist - no code change needed at release time.

## What it does
- **Certificate import** step (gated on `APPLE_CERTIFICATE` being present) sets up an ephemeral CI keychain.
- **Build step** now passes the Tauri signing/notarization env vars (`APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`) from secrets.
- **RELEASE.md** gains an *Activating signing and notarization* section: the exact secrets to create, and the one `tauri.conf.json` change to ship a DMG.

## Safe to merge now
With the secrets unset, the cert-import step is **skipped** and the Apple env vars are empty, so `tauri build` produces the same **unsigned** `.app` as today - no behavior change until you add the secrets. Then it signs + notarizes automatically.

**You still need** (can't be automated): an Apple Developer account, a Developer ID Application cert, notarization credentials, and a Gatekeeper check on a clean Mac.

Refs #167