### PR TITLE
fix: correct the crypto badges to the real cipher (chacha20)

### DIFF
--- a/apps/desktop/src/lib/components/UnlockScreen.svelte
+++ b/apps/desktop/src/lib/components/UnlockScreen.svelte
@@ -338,7 +338,7 @@
           <label>
             <div class="unlock__field-label">
               <span>master_password</span>
-              <span>argon2id · aes-512</span>
+              <span>argon2id · chacha20</span>
             </div>
             <div class="unlock__field">
               <input
@@ -500,7 +500,7 @@
         <label>
           <div class="unlock__field-label">
             <span>master_password</span>
-            <span>argon2id · aes-512</span>
+            <span>argon2id · chacha20</span>
           </div>
           <div class="unlock__field">
             <input

--- a/apps/desktop/src/lib/components/vault/EntryList.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryList.svelte
@@ -402,7 +402,7 @@
     <span class="hero__hash mono">#</span>
     <h1 id="vault-list-title" class="hero__title">the vault for what you can't <em>lose.</em></h1>
     <div class="hero__meta mono">
-      <span>encryption · <b>aes-512</b></span>
+      <span>encryption · <b>chacha20</b></span>
       <span>sealed · <b>{sealedAt}</b></span>
       <span>entropy · <b class="vault-list__score">{entropyScore}</b></span>
     </div>


### PR DESCRIPTION
The unlock screen (x2) and the vault list header displayed **`aes-512`** as the cipher. That's not a real cipher (AES is 128/192/256), and it doesn't match Arca's actual at-rest encryption.

After the KDBX pinning (#176) the outer/inner cipher is **ChaCha20**, so:
- unlock screen: `argon2id · aes-512` → `argon2id · chacha20`
- vault header: `encryption · aes-512` → `encryption · chacha20`

Both halves are now accurate (Argon2id KDF + ChaCha20 cipher). Companion to #180, which removed the standalone `aes-512` status-bar pill. No more `aes-512` anywhere in the app.