### PR TITLE
ci: publish a signed, notarized DMG as the release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,9 +91,9 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm --filter @arca/desktop tauri build
 
-      - name: Upload app bundle
+      - name: Upload DMG
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: Arca-macos-aarch64
-          path: target/release/bundle/macos/Arca.app
+          path: target/release/bundle/dmg/*.dmg
           if-no-files-found: error

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,8 +17,8 @@ smoke-test path:
 - Windows
 - Linux
 
-The Tauri configuration currently builds the macOS `.app` bundle. DMG
-distribution is deferred until signing and notarization are configured.
+The Tauri configuration builds both the macOS `.app` bundle and a `.dmg` for
+distribution. The release workflow uploads the signed, notarized `.dmg`.
 
 ## Required Checks
 
@@ -85,9 +85,11 @@ Before a public macOS release:
 
 - Configure Developer ID signing.
 - Configure notarization credentials in the release environment.
-- Re-enable and verify DMG packaging.
 - Verify Gatekeeper behavior on a clean macOS account or machine.
 - Document the exact signing and notarization commands or CI workflow.
+
+DMG packaging is enabled: `bundle.targets` includes `"dmg"` and the release
+workflow uploads the signed, notarized `.dmg`.
 
 ### Activating signing and notarization
 
@@ -108,9 +110,8 @@ they activate automatically:
 | `APPLE_PASSWORD` | App-specific password for that Apple ID (or use an App Store Connect API key instead). |
 | `APPLE_TEAM_ID` | Your 10-character Apple Developer Team ID. |
 
-Then, to ship a DMG rather than only the `.app`, add `"dmg"` to
-`apps/desktop/src-tauri/tauri.conf.json` under `bundle.targets`
-(e.g. `["app", "dmg"]`) and update the `Upload app bundle` path accordingly.
+The build produces a signed, notarized `.dmg` (`bundle.targets` includes
+`"dmg"`), which the workflow uploads as the release artifact.
 
 Finally, verify Gatekeeper on a clean macOS account, and only then publish the
 release.

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -33,7 +33,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["app"],
+    "targets": ["app", "dmg"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

Now that Developer ID signing and notarization are verified working end-to-end (RC build `v0.1.0-rc.1` passed `spctl` as `source=Notarized Developer ID` with a stapled ticket), enable DMG packaging so a tagged build produces a distributable disk image.

- `bundle.targets`: `["app"]` -> `["app", "dmg"]`.
- Release workflow uploads `target/release/bundle/dmg/*.dmg` instead of the raw `.app` (a single signed file that survives artifact upload cleanly).
- RELEASE.md updated: DMG is no longer "deferred"; the build produces a signed, notarized `.dmg`.

## Verification plan

After merge, the next tag build produces the DMG. I'll re-run the signing/notarization checks (`codesign`, `spctl`, `xcrun stapler validate`) on both the DMG and the `.app` inside it before any public release is published.

Closes the DMG-packaging item of #167.