### PR TITLE
ci: notarize and staple the release DMG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,6 @@ jobs:
           security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain
           rm -f "$CERT_PATH"
 
-      # tauri signs when APPLE_SIGNING_IDENTITY is set and notarizes when the
-      # APPLE_ID / APPLE_PASSWORD / APPLE_TEAM_ID trio is set. Empty values
-      # (secrets not configured yet) produce an unsigned build with no error.
       - name: Build desktop bundle
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
@@ -91,10 +88,6 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm --filter @arca/desktop tauri build
 
-      # tauri notarizes and staples the .app but not the DMG wrapper. A
-      # downloaded DMG is Gatekeeper-checked when opened, so the DMG itself
-      # must be notarized or users hit the "cannot be checked" block. Runs
-      # only when signing is configured, matching the certificate-import gate.
       - name: Notarize and staple the DMG
         if: ${{ env.APPLE_CERTIFICATE != '' }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,13 @@
 name: Release Build
 
 # Builds the macOS (Apple Silicon) desktop bundle for a release candidate.
-# Runs the RELEASE.md required checks, then `tauri build`, and uploads the .app.
+# Runs the RELEASE.md required checks, then `tauri build`, notarizes and
+# staples the DMG, and uploads it.
 #
 # Signing + notarization activate automatically once the Apple secrets are
 # configured (see RELEASE.md, "Activating signing and notarization"). Until
-# then the build is unsigned and for maintainer smoke testing only. Enabling
-# DMG packaging and publishing a GitHub Release are the remaining manual steps
-# in that guide (issue #167).
+# then the build is unsigned and for maintainer smoke testing only. Publishing
+# a GitHub Release is the remaining manual step (issue #167).
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,25 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm --filter @arca/desktop tauri build
 
+      # tauri notarizes and staples the .app but not the DMG wrapper. A
+      # downloaded DMG is Gatekeeper-checked when opened, so the DMG itself
+      # must be notarized or users hit the "cannot be checked" block. Runs
+      # only when signing is configured, matching the certificate-import gate.
+      - name: Notarize and staple the DMG
+        if: ${{ env.APPLE_CERTIFICATE != '' }}
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          DMG=$(ls target/release/bundle/dmg/*.dmg | head -1)
+          xcrun notarytool submit "$DMG" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          xcrun stapler staple "$DMG"
+
       - name: Upload DMG
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:


### PR DESCRIPTION
## Problem

Verifying the `v0.1.0-rc.3` DMG showed the `.app` inside is fully notarized and stapled, but the **DMG wrapper itself is not**:

- `.app` inside: `spctl -t exec` -> `accepted · Notarized Developer ID`, staple valid.
- `Arca_0.1.0_aarch64.dmg`: `spctl -t open` -> **`rejected · Unnotarized Developer ID`**, no ticket stapled.

Gatekeeper checks the DMG when a downloaded (quarantined) image is opened. An unnotarized DMG triggers the "cannot be checked for malicious software" block, even though the app inside is notarized. So the DMG is not safe to distribute as-is.

## Fix

Add a post-`tauri build` step that submits the built DMG to Apple's notary service and staples the ticket:

- Uses the `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID` secrets already in the `release` environment.
- Gated on `env.APPLE_CERTIFICATE != ''`, matching the certificate-import step, so unsigned builds still work with no error.
- Adds a couple of minutes for the notary `--wait`.

## Verification plan

After merge, tag `v0.1.0-rc.4` -> approve -> re-check the DMG. Expect `spctl -a -t open` on the DMG to report `accepted` and `xcrun stapler validate` on the DMG to pass.

Completes the DMG half of #167.