### PR TITLE
docs: update README for the v0.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ machine - no accounts, no sync, no telemetry. The vault is decrypted only while
 it is unlocked, and locking zeroizes the decrypted vault held in Arca's Rust
 core.
 
-> **Pre-1.0 / pre-release.** Arca has not yet had a tagged release or an
+> **Pre-1.0.** The first tagged release is
+> [v0.1.0](https://github.com/akei9/arca/releases/latest); Arca has not had an
 > independent security audit. Review the code and threat model before trusting
-> it with real secrets. See the [v0.1 milestone](https://github.com/akei9/arca/milestone/1).
+> it with real secrets.
 
 ## Features
 
@@ -44,7 +45,7 @@ core.
 </picture>
 
 - **Vault format:** KeePass KDBX 4, so vaults stay portable and interoperable. Persistence goes through the [`keepass`](https://crates.io/crates/keepass) crate.
-- **At-rest encryption:** the current KDBX 4 defaults - **Argon2d** key derivation from your master password, an **AES-256** outer cipher, and a **ChaCha20** stream cipher for protected fields.
+- **At-rest encryption:** Arca pins the KDBX 4 parameters rather than relying on library defaults - **Argon2id** key derivation from your master password (128 MiB, 3 iterations, parallelism 4), a **ChaCha20** outer cipher, and a **ChaCha20** stream cipher for protected fields.
 - **Secret handling:** while the vault is unlocked, decrypted values necessarily flow through the app to be shown or copied - the Rust session state, the Tauri IPC responses, UI strings, and the system clipboard during reveal/copy. Rust-side secrets use `Zeroizing`/`ZeroizeOnDrop` and are zeroized on lock, and secrets are never logged; clipboard contents clear on the configured timeout rather than on lock.
 - **Local only:** no sync, accounts, or telemetry in this release. You own your vault file and are responsible for its backups.
 
@@ -64,6 +65,19 @@ release process and supported targets.
 
 - Entries require a non-empty password; passwordless entries and password clearing are not supported ([#74](https://github.com/akei9/arca/issues/74)).
 - No remote sync - you are responsible for backing up your vault file.
+
+## Install
+
+Download the latest signed and notarized macOS build from the
+[releases page](https://github.com/akei9/arca/releases/latest):
+
+1. Download `Arca_<version>_aarch64.dmg`.
+2. Open it and drag **Arca** into your Applications folder.
+3. Launch it - the build is signed with a Developer ID certificate and notarized
+   by Apple, so it opens without a Gatekeeper prompt.
+
+Only macOS on Apple Silicon (`aarch64-apple-darwin`) is published today; for any
+other platform, build from source below.
 
 ## Build from source
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ release process and supported targets.
 
 ## Install
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/7aaa3fd1-24a6-4899-a548-c4ef1d6a2c60">
+  <img alt="status-limitations" src="https://github.com/user-attachments/assets/85516f53-c08f-42f8-a839-162234a13e93" width="100%">
+</picture>
+
 Download the latest signed and notarized macOS build from the
 [releases page](https://github.com/akei9/arca/releases/latest):
 
@@ -82,8 +87,8 @@ other platform, build from source below.
 ## Build from source
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/dc6e24e9-d045-40f8-8069-1347a8ff220e">
-  <img alt="build-from-source" src="https://github.com/user-attachments/assets/09803697-4549-41a6-a08e-cb53c7446cc1" width="100%">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/e96722f7-0573-44d1-b2b8-aa3afb17f7e6">
+  <img alt="build-from-source" src="https://github.com/user-attachments/assets/55c4c87a-b50c-4ffd-a5c3-fdb3f2868a8c" width="100%">
 </picture>
 
 Prerequisites: [Node.js](https://nodejs.org) + [pnpm](https://pnpm.io), a
@@ -109,8 +114,8 @@ cargo test --workspace
 ## Project layout
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/a99fbe08-e6e0-425e-ac0c-68e12efd6f53">
-  <img alt="project-layout" src="https://github.com/user-attachments/assets/49cfcaa1-8a63-472b-9b9a-5a7ded0bff53" width="100%">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/44fe12ff-3d71-4a1c-b501-589ed819ce0f">
+  <img alt="project-layout" src="https://github.com/user-attachments/assets/02237161-de75-471d-94c3-470ecf8d4865" width="100%">
 </picture>
 
 - `apps/desktop` - Tauri v2 desktop app (Svelte 5 frontend + thin Rust command layer).
@@ -119,8 +124,8 @@ cargo test --workspace
 ## Contributing
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/521ce1de-abd7-4bd8-90d9-621559d66157">
-  <img alt="contributing" src="https://github.com/user-attachments/assets/01a6e9f3-f080-4e62-85f7-5ad8010d1573" width="100%">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/7692aa5b-9b5a-438d-beb7-d12045f8813b"">
+  <img alt="contributing" src="https://github.com/user-attachments/assets/e5995fb6-3af6-4bc3-a812-47d70b049a4d" width="100%">
 </picture>
 
 Contributions are welcome - see [CONTRIBUTING.md](CONTRIBUTING.md) and the
@@ -131,8 +136,8 @@ review before merge.
 ## License
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/89a4422c-bd14-44da-b352-24fe4138a982">
-  <img alt="license" src="https://github.com/user-attachments/assets/c6391763-c359-4b82-b5ac-bc5e4e6bbb38" width="100%">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/82019149-74d9-42e1-a4c4-4060c087c943">
+  <img alt="license" src="https://github.com/user-attachments/assets/f4ac5ee0-5f90-456e-8df7-7b26c07da863" width="100%">
 </picture>
 
 [MIT](LICENSE) © 2026 Adrian Kucharczyk


### PR DESCRIPTION
## Summary

README updates now that `v0.1.0` is published.

1. **Release banner** - the "Arca has not yet had a tagged release" note was false; replaced with a link to [v0.1.0](https://github.com/akei9/arca/releases/latest), keeping the pre-1.0 / no-independent-audit caution.
2. **Install section** - added download-and-install steps for the signed, notarized macOS DMG.
3. **⚠️ At-rest encryption claim corrected (please review)** - the Security model section described "the current KDBX 4 defaults - Argon2d, AES-256, ChaCha20." That is no longer what Arca produces: `packages/vault-core/src/vault.rs` pins `arca_database_config()` to **Argon2id** (128 MiB / 3 iterations / parallelism 4), a **ChaCha20** outer cipher, and a **ChaCha20** inner cipher, applied on save via `Database::with_config(...)`. The README now matches the code and the CHANGELOG 0.1.0 security note.

## Verification

- `arca_database_config()` (vault.rs:27) sets Argon2id + ChaCha20/ChaCha20; applied at vault.rs:117.
- Matches CHANGELOG `[0.1.0]` Security entry.
- No functional/code change; docs only.