### PR TITLE
fix(deps): bump anyhow to 1.0.104 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arboard"


### PR DESCRIPTION
## Summary

The OSSF Scorecard OSV scan (code-scanning alert #68) flagged **RUSTSEC-2026-0190**: `anyhow` < 1.0.103 has an unsound `Error::downcast_mut()` (undefined behavior when downcasting an error carrying added context). Fixed in 1.0.103.

`anyhow` ships transitively via Tauri, so this bumps the lockfile from 1.0.102 to **1.0.104** (latest compatible; only that one package changes).

## Notes

- Low severity ("unsound", not directly exploitable), but it is in the shipped binary and trivially fixable.
- Lockfile-only, updated via `cargo update -p anyhow` (not hand-edited).
- The other 17 advisories in alert #68 are the Linux GTK/unic transitive deps tracked in #35 (not shipped in the macOS build); they remain until the upstream Tauri stack drops them.