### PR TITLE
docs(security): add the vulnerability reporting link to SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,10 @@ Arca is a password manager. Please avoid public disclosure of suspected vulnerab
 
 ## Reporting a Vulnerability
 
-Use GitHub private vulnerability reporting for this repository if it is available. If private reporting is not enabled, contact the maintainers directly before sharing exploit details publicly.
+Report suspected vulnerabilities through GitHub private vulnerability reporting:
+https://github.com/akei9/arca/security/advisories/new
+
+If private reporting is not enabled, contact the maintainers directly before sharing exploit details publicly.
 
 Do not include real passwords, vault files, private keys, recovery material, or other secrets in reports.
 


### PR DESCRIPTION
## Summary

OSSF Scorecard's Security-Policy check (code-scanning alert #67) scored the policy low with `no linked content found` - the file described private reporting but contained no URL or email.

Add the GitHub private advisory reporting link (`https://github.com/akei9/arca/security/advisories/new`) to the "Reporting a Vulnerability" section. This gives reporters a direct link and satisfies Scorecard's linked-content requirement.

Docs only; no code change.