### PR TITLE
security: add bounded vault fuzzing workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           workspaces: packages/vault-core/fuzz -> target
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        run: cargo install cargo-fuzz --version 0.13.2 --locked
       - name: Run bounded vault-core fuzz target
         working-directory: packages/vault-core
         env:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,67 @@
+name: Vault Fuzzing
+
+on:
+  schedule:
+    - cron: "37 5 * * 1"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "cargo-fuzz target to run"
+        required: true
+        default: "open_vault_bytes"
+      max_total_time_seconds:
+        description: "libFuzzer max_total_time in seconds, capped at 1800"
+        required: true
+        default: "300"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzz-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vault-core-fuzz:
+    name: vault-core fuzz
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: nightly
+      - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        with:
+          workspaces: packages/vault-core/fuzz -> target
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+      - name: Run bounded vault-core fuzz target
+        working-directory: packages/vault-core
+        env:
+          FUZZ_TARGET: ${{ github.event.inputs.target || 'open_vault_bytes' }}
+          MAX_TOTAL_TIME_SECONDS: ${{ github.event.inputs.max_total_time_seconds || '300' }}
+        run: |
+          case "$FUZZ_TARGET" in
+            open_vault_bytes) ;;
+            *)
+              echo "::error::Unsupported fuzz target: $FUZZ_TARGET"
+              exit 1
+              ;;
+          esac
+
+          case "$MAX_TOTAL_TIME_SECONDS" in
+            ""|*[!0-9]*)
+              echo "::error::max_total_time_seconds must be a positive integer"
+              exit 1
+              ;;
+          esac
+
+          if [ "$MAX_TOTAL_TIME_SECONDS" -lt 1 ] || [ "$MAX_TOTAL_TIME_SECONDS" -gt 1800 ]; then
+            echo "::error::max_total_time_seconds must be between 1 and 1800"
+            exit 1
+          fi
+
+          cargo fuzz run "$FUZZ_TARGET" -- -max_total_time="$MAX_TOTAL_TIME_SECONDS"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -47,7 +47,7 @@ jobs:
           case "$FUZZ_TARGET" in
             open_vault_bytes) ;;
             *)
-              echo "::error::Unsupported fuzz target: $FUZZ_TARGET"
+              echo "::error::Unsupported fuzz target"
               exit 1
               ;;
           esac

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,11 @@ Run the relevant checks before opening a PR:
 `vault-core` has `cargo-fuzz` targets for security-sensitive parser paths. Install the runner with:
 
 ```sh
-cargo install cargo-fuzz
+cargo install cargo-fuzz --version 0.13.2 --locked
 ```
+
+The GitHub fuzzing workflow pins the same reviewed `cargo-fuzz` version so
+scheduled runs do not change behavior when a new runner release is published.
 
 Run the KDBX parser target from `packages/vault-core`:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,13 @@ cargo fuzz run open_vault_bytes -- -max_total_time=60
 
 Fuzz corpora must use generated data only. Do not add real vault files, real passwords, private keys, or recovery material.
 
+Maintainers can also run the `Vault Fuzzing` GitHub Actions workflow manually.
+The workflow runs `open_vault_bytes` for 300 seconds by default, validates the
+requested target and runtime, and caps manual runs at 1800 seconds. It also runs
+weekly on `main` as a bounded maintenance check. Treat crash artifacts and
+reproducers as security-sensitive until reviewed; do not paste them into public
+issues before triage.
+
 ## Pull Requests
 
 - Use Conventional Commit titles such as `feat:`, `fix:`, `security:`, `test:`, and `chore:`.

--- a/packages/vault-core/fuzz/README.md
+++ b/packages/vault-core/fuzz/README.md
@@ -6,8 +6,11 @@ Do not use real vault files or real passwords as corpus material.
 ## Setup
 
 ```sh
-cargo install cargo-fuzz
+cargo install cargo-fuzz --version 0.13.2 --locked
 ```
+
+The GitHub fuzzing workflow pins the same reviewed `cargo-fuzz` version so
+scheduled runs stay reproducible across runner releases.
 
 ## Run
 

--- a/packages/vault-core/fuzz/README.md
+++ b/packages/vault-core/fuzz/README.md
@@ -27,3 +27,14 @@ cargo fuzz run open_vault_bytes -- -max_total_time=60
 normal `vault_core::vault::open_vault` path with a generated non-secret
 credential, and ignores expected parse/authentication errors. Crashes, panics,
 or sanitizer findings should be treated as security-sensitive until triaged.
+
+## GitHub Actions
+
+The `Vault Fuzzing` workflow can be run manually from the Actions tab. It runs
+`open_vault_bytes` for 300 seconds by default and rejects unsupported target
+names or runtimes outside 1-1800 seconds. The same target also runs weekly on
+`main` as a bounded maintenance check.
+
+Crash artifacts and reproducers are generated input, but treat them as
+security-sensitive until reviewed. Do not upload real vault files, passwords,
+private keys, or recovery material as corpus entries.


### PR DESCRIPTION
## Summary
- add a manual and weekly scheduled Vault Fuzzing workflow for vault-core
- run the existing open_vault_bytes target with validated target/runtime inputs
- document workflow usage, bounded runtime, and crash artifact handling

Closes #201

## Security Checklist
- [x] No real vault files, plaintext passwords, vault keys, or recovery material are added.
- [x] Fuzzing remains bounded and separate from normal fast PR CI.
- [x] Manual inputs are validated before being used in the shell command.
- [x] Crash artifacts and reproducers are documented as security-sensitive until reviewed.
- [x] This does not change crypto algorithms, KDF parameters, vault format, or persistence behavior.

## Agent-Assisted Changes
- [x] This PR was prepared with agent assistance.
- [x] Please apply the agent-assisted label.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fuzz.yml"); puts "fuzz workflow yaml ok"'\n- cargo fmt --all --check\n- cargo check --manifest-path packages/vault-core/fuzz/Cargo.toml --bins\n- cargo clippy --manifest-path packages/vault-core/fuzz/Cargo.toml --bins -- -D warnings\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace\n- pnpm typecheck\n- pnpm build\n\nNote: cargo-fuzz is not installed in this local environment, so the workflow itself was not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled and manually triggered fuzz testing for vault data handling.
  * Manual runs support a validated target and runtime of 1–1,800 seconds, defaulting to 300 seconds.
  * Added safeguards and guidance for handling fuzzing crash artifacts and reproducers.

* **Documentation**
  * Documented how to run fuzz testing and the restrictions on sensitive vault files and recovery materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->