### PR TITLE
security: narrow password reveal IPC

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -160,15 +160,15 @@ pub fn list_entries(state: State<'_, AppState>) -> Result<Vec<EntryDto>, ArcaErr
     ensure_unlocked(&session)?;
     session.touch();
 
-    Ok(session
-        .entries
-        .iter()
-        .map(|entry| EntryDto::from_entry(entry, false))
-        .collect())
+    Ok(session.entries.iter().map(entry_metadata_dto).collect())
 }
 
 #[tauri::command]
 pub fn get_entry(id: String, state: State<'_, AppState>) -> Result<EntryDto, ArcaError> {
+    get_entry_in_state(&id, state.inner())
+}
+
+fn get_entry_in_state(id: &str, state: &AppState) -> Result<EntryDto, ArcaError> {
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
     session.touch();
@@ -177,7 +177,31 @@ pub fn get_entry(id: String, state: State<'_, AppState>) -> Result<EntryDto, Arc
         .entries
         .iter()
         .find(|entry| entry.id == id)
-        .map(|entry| EntryDto::from_entry(entry, true))
+        .map(entry_metadata_dto)
+        .ok_or_else(|| ArcaError::not_found("Entry"))
+}
+
+#[tauri::command]
+pub fn reveal_entry_password(
+    id: String,
+    state: State<'_, AppState>,
+) -> Result<Zeroizing<String>, ArcaError> {
+    reveal_entry_password_in_state(&id, state.inner())
+}
+
+fn reveal_entry_password_in_state(
+    id: &str,
+    state: &AppState,
+) -> Result<Zeroizing<String>, ArcaError> {
+    let mut session = state.session()?;
+    ensure_unlocked(&session)?;
+    session.touch();
+
+    session
+        .entries
+        .iter()
+        .find(|entry| entry.id == id)
+        .map(|entry| Zeroizing::new(entry.password.clone()))
         .ok_or_else(|| ArcaError::not_found("Entry"))
 }
 
@@ -268,7 +292,7 @@ pub fn create_entry(
     persist_session(&session)?;
     session.touch();
 
-    Ok(EntryDto::from_entry(&entry, true))
+    Ok(entry_metadata_dto(&entry))
 }
 
 #[tauri::command]
@@ -282,13 +306,15 @@ pub fn update_entry(
     ensure_unlocked(&session)?;
     validate_optional_entry_password(data.password.as_deref())?;
 
-    let entry = session
-        .entries
-        .iter_mut()
-        .find(|entry| entry.id == id)
-        .ok_or_else(|| ArcaError::not_found("Entry"))?;
-    core_entry::update_entry_with_revision_limit(entry, data.into(), revision_limit);
-    let dto = EntryDto::from_entry(entry, true);
+    let dto = {
+        let entry = session
+            .entries
+            .iter_mut()
+            .find(|entry| entry.id == id)
+            .ok_or_else(|| ArcaError::not_found("Entry"))?;
+        core_entry::update_entry_with_revision_limit(entry, data.into(), revision_limit);
+        entry_metadata_dto(entry)
+    };
     persist_session(&session)?;
     session.touch();
 
@@ -324,7 +350,7 @@ pub fn search_entries(
 
     Ok(core_entry::search_entries(&session.entries, &query)
         .into_iter()
-        .map(|entry| EntryDto::from_entry(entry, false))
+        .map(entry_metadata_dto)
         .collect())
 }
 
@@ -403,6 +429,10 @@ impl EntryDto {
             revision_count: entry.revisions.len(),
         }
     }
+}
+
+fn entry_metadata_dto(entry: &VaultEntry) -> EntryDto {
+    EntryDto::from_entry(entry, false)
 }
 
 impl RevisionDto {
@@ -656,7 +686,8 @@ fn home_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::{
-        get_entry_revisions_in_state, reveal_entry_revision_password_in_state, suggest_paths_for,
+        entry_metadata_dto, get_entry_in_state, get_entry_revisions_in_state,
+        reveal_entry_password_in_state, reveal_entry_revision_password_in_state, suggest_paths_for,
         update_settings_in_state, validate_entry_password, validate_optional_entry_password,
         CreateEntryDto, EntryDto, GeneratorConfigDto, RevisionDto, UpdateEntryDto,
     };
@@ -695,6 +726,63 @@ mod tests {
         assert_eq!(revealed.password.as_deref(), Some(credential.as_str()));
         assert_eq!(masked.revision_count, 1);
         assert_eq!(revealed.revision_count, 1);
+    }
+
+    #[test]
+    fn entry_metadata_dto_never_serializes_password() {
+        let credential = test_credential("current");
+        let entry = create_entry("GitHub", "arca", &credential);
+
+        let dto = entry_metadata_dto(&entry);
+        let json = serde_json::to_string(&dto).expect("entry dto should serialize");
+
+        assert!(dto.password.is_none());
+        assert!(json.contains("\"password\":null"));
+        assert!(!json.contains(credential.as_str()));
+    }
+
+    #[test]
+    fn get_entry_returns_metadata_without_password() {
+        let state = AppState::default();
+        let credential = test_credential("current");
+        let entry = create_entry("GitHub", "arca", &credential);
+        let entry_id = entry.id.clone();
+        unlock_with_entry(&state, entry);
+
+        let dto = get_entry_in_state(&entry_id, &state)
+            .expect("entry metadata should be returned for an unlocked entry");
+
+        assert!(dto.password.is_none());
+    }
+
+    #[test]
+    fn reveal_entry_password_returns_plaintext_for_unlocked_entry() {
+        let state = AppState::default();
+        let credential = test_credential("current");
+        let entry = create_entry("GitHub", "arca", &credential);
+        let entry_id = entry.id.clone();
+        unlock_with_entry(&state, entry);
+
+        let password = reveal_entry_password_in_state(&entry_id, &state)
+            .expect("entry password should be revealed for an unlocked entry");
+
+        assert_eq!(*password, credential);
+    }
+
+    #[test]
+    fn reveal_entry_password_rejects_missing_entry() {
+        let state = AppState::default();
+        unlock_with_entry(
+            &state,
+            create_entry("GitHub", "arca", &test_credential("current")),
+        );
+
+        let error = expect_error(
+            reveal_entry_password_in_state("missing", &state),
+            "a missing entry should not reveal a password",
+        );
+
+        assert_eq!(error.code, "not_found");
     }
 
     #[test]
@@ -794,6 +882,10 @@ mod tests {
     fn revision_commands_require_unlocked_vault() {
         let state = AppState::default();
 
+        let current_reveal_error = expect_error(
+            reveal_entry_password_in_state("missing", &state),
+            "a locked vault should not reveal an entry password",
+        );
         let list_error = expect_error(
             get_entry_revisions_in_state("missing", &state),
             "a locked vault should not return revisions",
@@ -803,6 +895,7 @@ mod tests {
             "a locked vault should not reveal a revision password",
         );
 
+        assert_eq!(current_reveal_error.code, "vault_locked");
         assert_eq!(list_error.code, "vault_locked");
         assert_eq!(reveal_error.code, "vault_locked");
     }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,8 +4,8 @@ pub mod state;
 
 use commands::{
     create_entry, create_vault, delete_entry, generate_password, get_entry, get_entry_revisions,
-    get_settings, list_entries, lock_vault, reveal_entry_revision_password, search_entries,
-    suggest_paths, unlock_vault, update_entry, update_settings,
+    get_settings, list_entries, lock_vault, reveal_entry_password, reveal_entry_revision_password,
+    search_entries, suggest_paths, unlock_vault, update_entry, update_settings,
 };
 use state::AppState;
 
@@ -19,6 +19,7 @@ pub fn run() -> tauri::Result<()> {
             create_vault,
             list_entries,
             get_entry,
+            reveal_entry_password,
             get_entry_revisions,
             reveal_entry_revision_password,
             create_entry,

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
-  import { getEntry, type EntryDto } from '../../ipc';
+  import { revealEntryPassword, type EntryDto } from '../../ipc';
   import { COPY_CONFIRMATION_MS, writeConfiguredClipboardText } from '../../clipboard';
   import { isEditableTarget } from '../../keyboard';
   import { Icon } from '../icons';
@@ -132,7 +132,7 @@
     passwordBusy = true;
 
     try {
-      return (await getEntry(entry.id)).password ?? '';
+      return await revealEntryPassword(entry.id);
     } catch {
       return '';
     } finally {

--- a/apps/desktop/src/lib/components/vault/EntryRow.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryRow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
-  import { getEntry, type EntryDto } from '../../ipc';
+  import { revealEntryPassword, type EntryDto } from '../../ipc';
   import { COPY_CONFIRMATION_MS, writeConfiguredClipboardText } from '../../clipboard';
   import { Icon, type IconName } from '../icons';
   import { Tag } from '../primitives';
@@ -107,7 +107,7 @@
     copyBusy = true;
 
     try {
-      const password = entry.password ?? (await getEntry(entry.id)).password ?? '';
+      const password = entry.password ?? (await revealEntryPassword(entry.id));
 
       if (!password || !(await writeConfiguredClipboardText(password))) {
         return;

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -112,6 +112,10 @@ export function getEntry(id: string): Promise<EntryDto> {
   return invoke('get_entry', { id });
 }
 
+export function revealEntryPassword(id: string): Promise<string> {
+  return invoke('reveal_entry_password', { id });
+}
+
 export function getEntryRevisions(id: string): Promise<RevisionDto[]> {
   return invoke('get_entry_revisions', { id });
 }


### PR DESCRIPTION
## Summary
- add an explicit reveal_entry_password IPC command for user-driven current-password reveal/copy actions
- stop passive entry DTO responses from carrying plaintext passwords through list/search/get/create/update flows
- switch vault row and entry detail password copy/reveal actions to the narrow reveal command
- add command tests proving passive entry metadata stays masked and reveal commands require an unlocked vault

Closes #202

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- pnpm typecheck
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Entry details and search results no longer include passwords by default.
  - Passwords are retrieved only when explicitly revealed or copied.

- **Enhancements**
  - Added dedicated password reveal functionality for viewing and copying entry passwords.
  - Existing password masking, copying, timeout, and error handling remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->