### PR TITLE
docs: add client constitution ADR skeletons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,10 @@
 *.swo
 
 # Local planning docs not ready for the public repo
-/docs/
+/docs/*
+!/docs/CONSTITUTION.md
+!/docs/adr/
+!/docs/adr/**
 
 # Rust
 /target/

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -1,0 +1,121 @@
+# Arca Client Constitution
+
+Status: proposed
+Version: 0.1.0
+Date: 2026-09-01
+Related: #207, #208, #209, #210, #223
+
+This constitution defines the invariants every Arca client must follow. It is
+upstream of ADRs, implementation details, and client repositories. ADRs may
+interpret or extend these principles, but they should not contradict them.
+
+The constitution is intentionally short. It describes what must remain true
+across desktop, browser extension, mobile, autofill, and future clients.
+
+## Scope
+
+This document governs:
+
+- persisted vault compatibility
+- public client API boundaries
+- client capability policy
+- secret lifetime expectations
+- extension and mobile client constraints
+- future repository split decisions
+
+This document does not define:
+
+- a sync service
+- account management
+- a browser extension implementation
+- a mobile implementation
+- a complete API reference
+
+Those belong in ADRs and implementation issues.
+
+## Principles
+
+| ID | Principle | Enforcement |
+| --- | --- | --- |
+| C1 | `vault-core` owns KDBX I/O, cryptography, password generation, audit primitives, and secret lifetime behavior. | Rust module boundaries, code review, `vault-core` tests |
+| C2 | Clients are adapters. They must not implement KDFs, parse KDBX, or persist unlocked vault material. | Client capability checks, generated bindings, security review |
+| C3 | Arca stores vaults as KDBX 4 with pinned write-path parameters. KDBX format version, Arca semantics version, and client protocol version are separate version lines. | ADR-0001, ADR-0005, fixture tests |
+| C4 | The public machine contract is a Rust API layer, expected to be `vault-api`, not `vault-core` internals and not JSON Schema. | `vault-api` crate, generated bindings, CI drift checks |
+| C5 | Client privileges are encoded as `ClientKind` and `Capability` in Rust. Markdown may describe the matrix, but code must enforce it. | Capability denial tests |
+| C6 | Plaintext secrets are explicit, short-lived, and user-driven. Non-secret list, search, and detail DTOs must not carry passwords or revision passwords. | DTO tests, Debug/Display tests, IPC review |
+| C7 | Clipboard clearing, reveal, copy, lock, and zeroization are security behavior, not presentation details. | Core policy tests and desktop integration checks |
+| C8 | `vault-core` has no network access. Future sync or sharing requires a separate ADR and human review. | Dependency review and ADR gate |
+| C9 | Breaking contract changes require an ADR, version bump, fixtures, and migration or refusal tests. | Fixture suite and CI contract drift checks |
+| C10 | Browser extension, iOS autofill, and Android autofill are distinct clients with narrower capabilities than the full desktop app. | Capability matrix and boundary ADRs |
+
+## Version Lines
+
+Arca tracks three compatibility lines independently:
+
+- KDBX format version: the industry vault container format Arca reads and writes.
+- Arca semantics version: Arca-owned fields and behavior such as collections,
+  revisions, archive semantics, audit interpretation, and future migrations.
+- Client protocol or binding version: the IPC, FFI, native messaging, or WASM
+  interface a specific client uses.
+
+A reader may be newer than a writer. A writer must not write an unknown Arca
+semantics version. Unknown future semantics must fail closed unless an ADR
+explicitly defines read-only fallback behavior.
+
+## Initial Client Kinds
+
+The public API should model at least these clients:
+
+- `DesktopApp`
+- `BrowserExtension`
+- `IosApp`
+- `AndroidApp`
+- `IosAutofillExtension`
+- `AndroidAutofillService`
+- `FutureSyncServer`
+
+`FutureSyncServer` is ciphertext-only. It must not receive plaintext secrets.
+
+## Initial Capabilities
+
+The public API should model at least these capabilities:
+
+- `Unlock`
+- `ReadMeta`
+- `RevealSecret`
+- `CopySecret`
+- `MutateEntry`
+- `CreateVault`
+- `ChangeKdf`
+- `ExportPlaintext`
+- `ExportKdbx`
+- `ReadHistory`
+- `DeletePermanent`
+
+Each client kind receives only the capabilities it needs. Autofill and browser
+clients should be narrower than the desktop app.
+
+## ADR Set
+
+The contract phase starts with these proposed ADRs:
+
+- ADR-0001: KDBX 4 canonical on-disk format
+- ADR-0002: Rust `vault-api` is the machine contract
+- ADR-0003: Client capability matrix
+- ADR-0004: Secret lifetime
+- ADR-0005: Versioning and migrations
+- ADR-0006: Repository layout
+- ADR-0007: Browser extension boundary
+- ADR-0008: Mobile UniFFI and native UI
+
+All ADRs start as proposed. Human review is required before treating them as
+accepted architecture.
+
+## Amendment Process
+
+Changing this constitution requires:
+
+1. A dedicated PR.
+2. Human approval.
+3. A version bump in this file.
+4. A note explaining which ADRs, issues, or compatibility tests need follow-up.

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -1,8 +1,8 @@
 # Arca Client Constitution
 
-Status: proposed
+Status: accepted
 Version: 0.1.0
-Date: 2026-09-01
+Date: 2026-09-03
 Related: #207, #208, #209, #210, #223
 
 This constitution defines the invariants every Arca client must follow. It is
@@ -97,7 +97,7 @@ clients should be narrower than the desktop app.
 
 ## ADR Set
 
-The contract phase starts with these proposed ADRs:
+The contract phase starts with these accepted ADRs:
 
 - ADR-0001: KDBX 4 canonical on-disk format
 - ADR-0002: Rust `vault-api` is the machine contract
@@ -108,8 +108,8 @@ The contract phase starts with these proposed ADRs:
 - ADR-0007: Browser extension boundary
 - ADR-0008: Mobile UniFFI and native UI
 
-All ADRs start as proposed. Human review is required before treating them as
-accepted architecture.
+All ADRs start as proposed. Human review is required before treating future
+ADRs as accepted architecture.
 
 ## Amendment Process
 

--- a/docs/adr/0001-kdbx4-canonical-on-disk.md
+++ b/docs/adr/0001-kdbx4-canonical-on-disk.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-date: 2026-09-01
+status: accepted
+date: 2026-09-03
 decision-makers: ["akei9"]
 related: ["#207", "#223"]
 ---
@@ -10,6 +10,7 @@ related: ["#207", "#223"]
 ## Status History
 
 - 2026-09-01 - proposed by Codex for maintainer review.
+- 2026-09-03 - accepted by maintainer approval.
 
 ## Context
 

--- a/docs/adr/0001-kdbx4-canonical-on-disk.md
+++ b/docs/adr/0001-kdbx4-canonical-on-disk.md
@@ -1,0 +1,85 @@
+---
+status: proposed
+date: 2026-09-01
+decision-makers: ["akei9"]
+related: ["#207", "#223"]
+---
+
+# ADR-0001: KDBX 4 canonical on-disk format
+
+## Status History
+
+- 2026-09-01 - proposed by Codex for maintainer review.
+
+## Context
+
+Arca currently writes local-first encrypted vault files through `vault-core`.
+Future clients need to understand which parts of the persisted vault are
+standard KDBX behavior and which parts are Arca-owned semantics.
+
+## Decision Drivers
+
+- Preserve local-first vault ownership.
+- Avoid custom cryptography.
+- Keep compatibility with established KDBX tooling where feasible.
+- Make Arca-specific fields explicit and testable.
+
+## Considered Options
+
+- KDBX 4 as the canonical on-disk container.
+- Arca-native encrypted file format.
+- Dual-format support from the start.
+
+## Proposed Decision
+
+Use KDBX 4 as the canonical on-disk container. `vault-core` owns all reads and
+writes. Arca-specific semantics are encoded as explicit custom fields and
+covered by fixtures.
+
+The current write path pins:
+
+- outer cipher: ChaCha20
+- inner cipher: ChaCha20
+- KDF: Argon2id
+- Argon2id memory: 128 MiB
+- Argon2id iterations: 3
+- Argon2id parallelism: 4
+
+Arca custom fields currently include:
+
+- `ArcaCollection`
+- `ArcaRevisions`
+
+## Consequences
+
+### Positive
+
+- Keeps Arca aligned with a mature password-vault container.
+- Lets compatibility be tested with real KDBX fixtures.
+- Avoids inventing a new encrypted file format.
+
+### Negative
+
+- Arca semantics must be carefully layered over KDBX.
+- Some future behavior may not map cleanly to external KDBX clients.
+
+### Neutral
+
+- KeePassXC portability vs Arca-native semantics remains an explicit tradeoff.
+
+## Compliance
+
+- [ ] Add golden KDBX fixtures for supported Arca semantics versions.
+- [ ] Add tests that verify current write-path cipher and KDF parameters.
+- [ ] Add tests for malformed Arca custom fields.
+
+## Revisit / Out Of Scope
+
+- Full sync semantics are out of scope.
+- New cryptographic algorithms require a separate ADR and human approval.
+
+## References
+
+- #207
+- #223
+- `packages/vault-core/src/vault.rs`

--- a/docs/adr/0002-rust-vault-api-is-the-machine-contract.md
+++ b/docs/adr/0002-rust-vault-api-is-the-machine-contract.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-date: 2026-09-01
+status: accepted
+date: 2026-09-03
 decision-makers: ["akei9"]
 related: ["#209", "#223", "#224"]
 ---
@@ -10,6 +10,7 @@ related: ["#209", "#223", "#224"]
 ## Status History
 
 - 2026-09-01 - proposed by Codex for maintainer review.
+- 2026-09-03 - accepted by maintainer approval.
 
 ## Context
 

--- a/docs/adr/0002-rust-vault-api-is-the-machine-contract.md
+++ b/docs/adr/0002-rust-vault-api-is-the-machine-contract.md
@@ -1,0 +1,79 @@
+---
+status: proposed
+date: 2026-09-01
+decision-makers: ["akei9"]
+related: ["#209", "#223", "#224"]
+---
+
+# ADR-0002: Rust vault-api is the machine contract
+
+## Status History
+
+- 2026-09-01 - proposed by Codex for maintainer review.
+
+## Context
+
+Desktop TypeScript DTOs and future mobile or extension bindings need a stable
+contract. That contract should not expose `vault-core` internals such as KDBX
+parsing, session storage, or zeroization implementation details.
+
+## Decision Drivers
+
+- Rust remains canonical for vault semantics.
+- Clients stay thin.
+- Generated bindings should reduce type drift.
+- JSON Schema should document and verify snapshots, not become source of truth.
+
+## Considered Options
+
+- Rust `vault-api` crate as the source of truth.
+- Thrift, Protobuf, or OpenAPI first.
+- JSON Schema generated from `vault-core` types.
+- Hand-maintained TypeScript interfaces.
+
+## Proposed Decision
+
+Introduce `packages/vault-api` as the public machine contract. It defines
+client-facing DTOs, operations, capabilities, and typed errors. It delegates to
+`vault-core` for implementation and does not expose `vault-core` internals.
+
+Derived artifacts may include:
+
+- desktop TypeScript types
+- JSON Schema snapshots for public DTOs
+- UniFFI Swift and Kotlin bindings
+- future WASM TypeScript bindings if an ADR allows them
+
+## Consequences
+
+### Positive
+
+- Gives every client one public contract to target.
+- Keeps security-sensitive internals behind Rust boundaries.
+- Makes generated bindings possible without exposing the whole core.
+
+### Negative
+
+- Adds another Rust crate and boundary to maintain.
+- Requires migration away from hand-maintained desktop IPC DTOs.
+
+### Neutral
+
+- Some types may exist twice temporarily during migration.
+
+## Compliance
+
+- [ ] Add a `vault-api` crate or accepted equivalent.
+- [ ] Generate or verify desktop DTOs from public API types.
+- [ ] Add CI drift checks for generated artifacts.
+- [ ] Add tests for public secret-bearing and non-secret DTO boundaries.
+
+## Revisit / Out Of Scope
+
+- A future network sync service may use OpenAPI, Protobuf, or another service
+  IDL, but that is not this contract.
+
+## References
+
+- #209
+- #224

--- a/docs/adr/0003-client-capability-matrix.md
+++ b/docs/adr/0003-client-capability-matrix.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-date: 2026-09-01
+status: accepted
+date: 2026-09-03
 decision-makers: ["akei9"]
 related: ["#207", "#223", "#226"]
 ---
@@ -10,6 +10,7 @@ related: ["#207", "#223", "#226"]
 ## Status History
 
 - 2026-09-01 - proposed by Codex for maintainer review.
+- 2026-09-03 - accepted by maintainer approval.
 
 ## Context
 

--- a/docs/adr/0003-client-capability-matrix.md
+++ b/docs/adr/0003-client-capability-matrix.md
@@ -1,0 +1,88 @@
+---
+status: proposed
+date: 2026-09-01
+decision-makers: ["akei9"]
+related: ["#207", "#223", "#226"]
+---
+
+# ADR-0003: Client capability matrix
+
+## Status History
+
+- 2026-09-01 - proposed by Codex for maintainer review.
+
+## Context
+
+Desktop, browser extension, mobile app, autofill extensions, and future sync
+components should not all have the same powers. The policy needs to be enforced
+in code, not only described in Markdown.
+
+## Decision Drivers
+
+- Least privilege by client kind.
+- Explicit secret exposure.
+- Prevent privilege expansion through reused DTOs.
+- Keep future sync ciphertext-only.
+
+## Considered Options
+
+- Encode `ClientKind` and `Capability` in the public API layer.
+- Rely on UI-level checks per client.
+- Rely on documentation and review only.
+
+## Proposed Decision
+
+Model client privileges in Rust using `ClientKind` and `Capability`.
+
+Initial client kinds:
+
+- `DesktopApp`
+- `BrowserExtension`
+- `IosApp`
+- `AndroidApp`
+- `IosAutofillExtension`
+- `AndroidAutofillService`
+- `FutureSyncServer`
+
+Initial capabilities:
+
+- `Unlock`
+- `ReadMeta`
+- `RevealSecret`
+- `CopySecret`
+- `MutateEntry`
+- `CreateVault`
+- `ChangeKdf`
+- `ExportPlaintext`
+- `ExportKdbx`
+- `ReadHistory`
+- `DeletePermanent`
+
+## Consequences
+
+### Positive
+
+- Makes privilege policy reviewable and testable.
+- Gives browser and autofill clients a deliberately narrow surface.
+
+### Negative
+
+- Adds checks that every binding adapter must respect.
+
+### Neutral
+
+- The exact grants may change before acceptance.
+
+## Compliance
+
+- [ ] Add capability denial tests.
+- [ ] Add tests proving restricted clients cannot call privileged operations.
+- [ ] Document the capability matrix in the public API docs.
+
+## Revisit / Out Of Scope
+
+- User roles, teams, and account permissions are out of scope.
+
+## References
+
+- #226

--- a/docs/adr/0004-secret-lifetime.md
+++ b/docs/adr/0004-secret-lifetime.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-date: 2026-09-01
+status: accepted
+date: 2026-09-03
 decision-makers: ["akei9"]
 related: ["#207", "#223", "#224", "#226"]
 ---
@@ -10,6 +10,7 @@ related: ["#207", "#223", "#224", "#226"]
 ## Status History
 
 - 2026-09-01 - proposed by Codex for maintainer review.
+- 2026-09-03 - accepted by maintainer approval.
 
 ## Context
 

--- a/docs/adr/0004-secret-lifetime.md
+++ b/docs/adr/0004-secret-lifetime.md
@@ -1,0 +1,75 @@
+---
+status: proposed
+date: 2026-09-01
+decision-makers: ["akei9"]
+related: ["#207", "#223", "#224", "#226"]
+---
+
+# ADR-0004: Secret lifetime
+
+## Status History
+
+- 2026-09-01 - proposed by Codex for maintainer review.
+
+## Context
+
+Arca handles master passwords, entry passwords, generated passwords, revision
+passwords, and copied secrets. Future clients need one rule set for how
+plaintext can move through the system.
+
+## Decision Drivers
+
+- Plaintext exposure must be explicit and user-driven.
+- Non-secret DTOs must not carry passwords.
+- Secret-bearing APIs should be narrow and easy to audit.
+- Locking should clear unlocked session material.
+
+## Considered Options
+
+- Centralize secret lifetime policy in `vault-core` and `vault-api`.
+- Let each client define its own reveal and copy behavior.
+- Treat secret lifetime as documentation only.
+
+## Proposed Decision
+
+Secret lifetime policy belongs in Rust and is surfaced through narrow API
+operations. Clients may request a secret only through explicit reveal, copy, or
+fill operations allowed by their capabilities.
+
+Non-secret list, search, detail, audit, and revision DTOs must not include
+plaintext passwords or revision passwords.
+
+## Consequences
+
+### Positive
+
+- Reduces passive secret exposure.
+- Gives every client the same baseline behavior.
+- Makes secret-bearing paths easier to review.
+
+### Negative
+
+- Some UI flows require extra explicit calls.
+- Tests can prove DTO and API behavior, but cannot fully prove OS memory or
+  clipboard behavior.
+
+### Neutral
+
+- Desktop integration tests remain important for clipboard and lock behavior.
+
+## Compliance
+
+- [ ] Add tests that Debug and Display output cannot expose secrets.
+- [ ] Add tests that non-secret DTOs omit current and historical passwords.
+- [ ] Add lock tests for clearing unlocked session material.
+- [ ] Add clipboard TTL tests where the platform boundary allows it.
+
+## Revisit / Out Of Scope
+
+- OS-level secure memory guarantees are platform-specific and need separate
+  research before being promised.
+
+## References
+
+- #224
+- #226

--- a/docs/adr/0005-versioning-and-migrations.md
+++ b/docs/adr/0005-versioning-and-migrations.md
@@ -1,0 +1,73 @@
+---
+status: proposed
+date: 2026-09-01
+decision-makers: ["akei9"]
+related: ["#207", "#223", "#225"]
+---
+
+# ADR-0005: Versioning and migrations
+
+## Status History
+
+- 2026-09-01 - proposed by Codex for maintainer review.
+
+## Context
+
+Arca needs compatibility rules before multiple clients can read and write the
+same vault. A single "vault version" is too vague because KDBX, Arca semantics,
+and client protocols evolve independently.
+
+## Decision Drivers
+
+- Avoid accidental data loss.
+- Fail closed for unknown future write semantics.
+- Permit newer readers where safe.
+- Make migrations testable.
+
+## Considered Options
+
+- Separate KDBX, Arca semantics, and client protocol versions.
+- Use one global vault version.
+- Rely on app version numbers only.
+
+## Proposed Decision
+
+Track three version lines:
+
+- KDBX format version
+- Arca semantics version
+- client protocol or binding version
+
+Readers may open older Arca semantics versions if tests prove compatibility.
+Writers must not write unknown future Arca semantics versions. Migrations require
+fixtures and refusal tests.
+
+## Consequences
+
+### Positive
+
+- Prevents clients from silently rewriting data they do not understand.
+- Gives browser and mobile clients a clear compatibility gate.
+
+### Negative
+
+- Requires version metadata and fixture discipline.
+
+### Neutral
+
+- Some migration details depend on `vault-api` design.
+
+## Compliance
+
+- [ ] Add fixtures for supported Arca semantics versions.
+- [ ] Add tests for unknown future semantics versions.
+- [ ] Add migration or refusal tests for every breaking change.
+- [ ] Add CI checks for contract fixture drift.
+
+## Revisit / Out Of Scope
+
+- Sync conflict resolution is out of scope.
+
+## References
+
+- #225

--- a/docs/adr/0005-versioning-and-migrations.md
+++ b/docs/adr/0005-versioning-and-migrations.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-date: 2026-09-01
+status: accepted
+date: 2026-09-03
 decision-makers: ["akei9"]
 related: ["#207", "#223", "#225"]
 ---
@@ -10,6 +10,7 @@ related: ["#207", "#223", "#225"]
 ## Status History
 
 - 2026-09-01 - proposed by Codex for maintainer review.
+- 2026-09-03 - accepted by maintainer approval.
 
 ## Context
 

--- a/docs/adr/0006-repo-layout.md
+++ b/docs/adr/0006-repo-layout.md
@@ -1,0 +1,69 @@
+---
+status: proposed
+date: 2026-09-01
+decision-makers: ["akei9"]
+related: ["#208", "#223"]
+---
+
+# ADR-0006: Repository layout
+
+## Status History
+
+- 2026-09-01 - proposed by Codex for maintainer review.
+
+## Context
+
+Browser extension and mobile work may eventually deserve separate repositories,
+but splitting too early makes contracts and security policy harder to stabilize.
+
+## Decision Drivers
+
+- Keep shared core and compatibility gates canonical.
+- Avoid premature multi-repo coordination.
+- Allow future clients to ship independently once real.
+
+## Considered Options
+
+- Keep monorepo during the contract phase.
+- Split browser and mobile repositories immediately.
+- Keep every future client in this repository permanently.
+
+## Proposed Decision
+
+Keep this repository as canonical core plus desktop during the contract phase.
+Future repositories should be created only when implementation starts and after
+the shared contract is stable enough to consume.
+
+Expected future repositories:
+
+- `arca-extension`
+- `arca-mobile`, unless a later mobile ADR chooses separate native repositories
+
+## Consequences
+
+### Positive
+
+- Keeps early contract work focused.
+- Avoids duplicating policy and fixtures before they are stable.
+
+### Negative
+
+- Future repo bootstraps are deferred.
+
+### Neutral
+
+- Issue references may span repositories later.
+
+## Compliance
+
+- [ ] Keep `vault-core`, `vault-api`, fixtures, and security policy canonical in
+  `akei9/arca`.
+- [ ] Add repo bootstrap checklists before creating new repositories.
+
+## Revisit / Out Of Scope
+
+- Exact mobile repo layout waits for ADR-0008.
+
+## References
+
+- #208

--- a/docs/adr/0006-repo-layout.md
+++ b/docs/adr/0006-repo-layout.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-date: 2026-09-01
+status: accepted
+date: 2026-09-03
 decision-makers: ["akei9"]
 related: ["#208", "#223"]
 ---
@@ -10,6 +10,7 @@ related: ["#208", "#223"]
 ## Status History
 
 - 2026-09-01 - proposed by Codex for maintainer review.
+- 2026-09-03 - accepted by maintainer approval.
 
 ## Context
 

--- a/docs/adr/0007-extension-boundary.md
+++ b/docs/adr/0007-extension-boundary.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-date: 2026-09-01
+status: accepted
+date: 2026-09-03
 decision-makers: ["akei9"]
 related: ["#211", "#213", "#223"]
 ---
@@ -10,6 +10,7 @@ related: ["#211", "#213", "#223"]
 ## Status History
 
 - 2026-09-01 - proposed by Codex for maintainer review.
+- 2026-09-03 - accepted by maintainer approval.
 
 ## Context
 

--- a/docs/adr/0007-extension-boundary.md
+++ b/docs/adr/0007-extension-boundary.md
@@ -1,0 +1,70 @@
+---
+status: proposed
+date: 2026-09-01
+decision-makers: ["akei9"]
+related: ["#211", "#213", "#223"]
+---
+
+# ADR-0007: Browser extension boundary
+
+## Status History
+
+- 2026-09-01 - proposed by Codex for maintainer review.
+
+## Context
+
+A browser extension can make Arca much more useful, but it runs in a hostile
+environment: pages, frames, scripts, origins, and browser storage all change the
+threat model.
+
+## Decision Drivers
+
+- Do not run the full unlock path in a content script or service worker.
+- Keep browser permissions narrow and explainable.
+- Prefer explicit user confirmation for secret injection.
+- Avoid extension storage of unlocked vault material.
+
+## Considered Options
+
+- Native messaging to the desktop app or a small native host.
+- WASM build of the core as the primary unlock path.
+- Browser extension as copy-only UI.
+
+## Proposed Decision
+
+Prefer native messaging to the desktop app or a small native host for the first
+extension boundary. The extension is a UI and autofill client with narrow
+capabilities. WASM may be considered later only for constrained already-unlocked
+working-set operations.
+
+## Consequences
+
+### Positive
+
+- Keeps KDF, KDBX parsing, and long-lived unlocked material out of the browser.
+- Aligns the extension with least privilege.
+
+### Negative
+
+- Requires native host installation or desktop app presence.
+- Store review needs a clear permissions explanation.
+
+### Neutral
+
+- Browser support depends on native messaging compatibility.
+
+## Compliance
+
+- [ ] Add extension capability denial tests.
+- [ ] Add a native messaging protocol contract before implementation.
+- [ ] Add permission justification to the extension release checklist.
+
+## Revisit / Out Of Scope
+
+- A full WASM unlock path is out of scope unless a later ADR accepts the memory,
+  lifecycle, and storage risks.
+
+## References
+
+- #211
+- #213

--- a/docs/adr/0008-mobile-uniffi-native-ui.md
+++ b/docs/adr/0008-mobile-uniffi-native-ui.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-date: 2026-09-01
+status: accepted
+date: 2026-09-03
 decision-makers: ["akei9"]
 related: ["#214", "#216", "#223"]
 ---
@@ -10,6 +10,7 @@ related: ["#214", "#216", "#223"]
 ## Status History
 
 - 2026-09-01 - proposed by Codex for maintainer review.
+- 2026-09-03 - accepted by maintainer approval.
 
 ## Context
 

--- a/docs/adr/0008-mobile-uniffi-native-ui.md
+++ b/docs/adr/0008-mobile-uniffi-native-ui.md
@@ -1,0 +1,74 @@
+---
+status: proposed
+date: 2026-09-01
+decision-makers: ["akei9"]
+related: ["#214", "#216", "#223"]
+---
+
+# ADR-0008: Mobile UniFFI and native UI
+
+## Status History
+
+- 2026-09-01 - proposed by Codex for maintainer review.
+
+## Context
+
+Mobile password managers are primarily judged by secure unlock, search, copy,
+and autofill. Autofill is platform-native and has stricter lifecycle constraints
+than the main app.
+
+## Decision Drivers
+
+- Reuse Rust vault semantics without rewriting crypto.
+- Keep plaintext out of unnecessary JS or Dart heaps.
+- Treat mobile autofill extensions as restricted clients.
+- Ship the smallest useful mobile path first.
+
+## Considered Options
+
+- `vault-api` plus UniFFI, native iOS first, Android next.
+- Flutter plus Rust bridge.
+- React Native plus Rust bridge.
+- Tauri mobile.
+
+## Proposed Decision
+
+Prefer `vault-api` plus UniFFI, with native iOS SwiftUI first and Android Jetpack
+Compose after that. Autofill extensions are separate restricted client kinds.
+
+React Native, Flutter, or Tauri mobile require a separate ADR if chosen as the
+primary strategy.
+
+## Consequences
+
+### Positive
+
+- Keeps the security-critical contract in Rust.
+- Fits native autofill constraints.
+- Gives iOS a natural first target after macOS.
+
+### Negative
+
+- Requires native UI work instead of reusing desktop Svelte UI.
+- Android follows after iOS unless the roadmap changes.
+
+### Neutral
+
+- Flutter may remain a fallback if one maintainer must ship both platforms
+  quickly, but native autofill still needs native code.
+
+## Compliance
+
+- [ ] Add a UniFFI feasibility spike before mobile implementation.
+- [ ] Add mobile capability denial tests.
+- [ ] Add secure storage and autofill lifecycle requirements to the mobile MVP
+  checklist.
+
+## Revisit / Out Of Scope
+
+- Cross-device sync and accounts are out of scope.
+
+## References
+
+- #214
+- #216

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,11 +11,11 @@ new ADR instead of editing the accepted record in place.
 
 | ADR | Status | Title |
 | --- | --- | --- |
-| [0001](0001-kdbx4-canonical-on-disk.md) | proposed | KDBX 4 canonical on-disk format |
-| [0002](0002-rust-vault-api-is-the-machine-contract.md) | proposed | Rust vault-api is the machine contract |
-| [0003](0003-client-capability-matrix.md) | proposed | Client capability matrix |
-| [0004](0004-secret-lifetime.md) | proposed | Secret lifetime |
-| [0005](0005-versioning-and-migrations.md) | proposed | Versioning and migrations |
-| [0006](0006-repo-layout.md) | proposed | Repository layout |
-| [0007](0007-extension-boundary.md) | proposed | Browser extension boundary |
-| [0008](0008-mobile-uniffi-native-ui.md) | proposed | Mobile UniFFI and native UI |
+| [0001](0001-kdbx4-canonical-on-disk.md) | accepted | KDBX 4 canonical on-disk format |
+| [0002](0002-rust-vault-api-is-the-machine-contract.md) | accepted | Rust vault-api is the machine contract |
+| [0003](0003-client-capability-matrix.md) | accepted | Client capability matrix |
+| [0004](0004-secret-lifetime.md) | accepted | Secret lifetime |
+| [0005](0005-versioning-and-migrations.md) | accepted | Versioning and migrations |
+| [0006](0006-repo-layout.md) | accepted | Repository layout |
+| [0007](0007-extension-boundary.md) | accepted | Browser extension boundary |
+| [0008](0008-mobile-uniffi-native-ui.md) | accepted | Mobile UniFFI and native UI |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records
+
+Arca ADRs capture architectural choices that affect vault compatibility,
+security boundaries, client contracts, or repository governance.
+
+ADRs start as `proposed`. A proposed ADR is a review artifact, not settled
+architecture. Once an ADR is accepted, future changes should supersede it with a
+new ADR instead of editing the accepted record in place.
+
+## Index
+
+| ADR | Status | Title |
+| --- | --- | --- |
+| [0001](0001-kdbx4-canonical-on-disk.md) | proposed | KDBX 4 canonical on-disk format |
+| [0002](0002-rust-vault-api-is-the-machine-contract.md) | proposed | Rust vault-api is the machine contract |
+| [0003](0003-client-capability-matrix.md) | proposed | Client capability matrix |
+| [0004](0004-secret-lifetime.md) | proposed | Secret lifetime |
+| [0005](0005-versioning-and-migrations.md) | proposed | Versioning and migrations |
+| [0006](0006-repo-layout.md) | proposed | Repository layout |
+| [0007](0007-extension-boundary.md) | proposed | Browser extension boundary |
+| [0008](0008-mobile-uniffi-native-ui.md) | proposed | Mobile UniFFI and native UI |


### PR DESCRIPTION
## Summary

- add a proposed Arca client constitution for cross-client invariants
- add ADR index plus proposed ADR skeletons for KDBX format, vault-api, capabilities, secret lifetime, versioning, repo layout, browser extension, and mobile
- keep local planning docs ignored while allowing the public constitution and ADR docs

## Notes

This uses the ADR/constitution shape from the local forge.md and sdd-starter examples, but keeps the content Arca-specific and explicitly proposed.

Closes #223

## Validation

- pnpm typecheck
- pnpm build
