### PR TITLE
feat: introduce vault-api contract crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4256,7 +4256,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "vault-core",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-clipboard-manager",
  "tokio",
+ "vault-api",
  "vault-core",
  "zeroize",
 ]
@@ -4246,6 +4247,17 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "vault-api"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "vault-core",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "apps/desktop/src-tauri",
+  "packages/vault-api",
   "packages/vault-core",
 ]
 resolver = "2"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = ["macos-private-api"] }
+vault-api = { path = "../../../packages/vault-api" }
 vault-core = { path = "../../../packages/vault-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -7,8 +7,8 @@ use tauri::State;
 use vault_api::{
     CreateEntryRequest as CreateEntryDto, EntryMutation as UpdateEntryDto, EntryView as EntryDto,
     GeneratedSecret as GeneratedPassword, GeneratorMode as GeneratorModeDto,
-    GeneratorParams as GeneratorConfigDto, RevisionView as RevisionDto, SecretString,
-    VaultSummary as VaultInfo,
+    GeneratorParams as GeneratorConfigDto, RevealedSecret, RevisionView as RevisionDto,
+    SecretString, VaultSummary as VaultInfo,
 };
 use vault_core::entry as core_entry;
 use vault_core::generator as core_generator;
@@ -110,8 +110,8 @@ fn get_entry_in_state(id: &str, state: &AppState) -> Result<EntryDto, ArcaError>
 pub fn reveal_entry_password(
     id: String,
     state: State<'_, AppState>,
-) -> Result<SecretString, ArcaError> {
-    reveal_entry_password_in_state(&id, state.inner())
+) -> Result<RevealedSecret, ArcaError> {
+    reveal_entry_password_in_state(&id, state.inner()).map(RevealedSecret::from)
 }
 
 /// Loads an entry password from the unlocked session without logging it.
@@ -174,8 +174,8 @@ pub fn reveal_entry_revision_password(
     id: String,
     index: usize,
     state: State<'_, AppState>,
-) -> Result<SecretString, ArcaError> {
-    reveal_entry_revision_password_in_state(&id, index, state.inner())
+) -> Result<RevealedSecret, ArcaError> {
+    reveal_entry_revision_password_in_state(&id, index, state.inner()).map(RevealedSecret::from)
 }
 
 /// Loads one revision password from the unlocked session without logging it.

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -37,6 +37,7 @@ pub enum PathSuggestionKind {
 }
 
 #[tauri::command]
+/// Opens an existing vault and stores the unlocked session in memory.
 pub fn unlock_vault(
     path: String,
     password: String,
@@ -52,12 +53,14 @@ pub fn unlock_vault(
 }
 
 #[tauri::command]
+/// Clears the in-memory vault session and any stored master password.
 pub fn lock_vault(state: State<'_, AppState>) -> Result<(), ArcaError> {
     state.session()?.lock();
     Ok(())
 }
 
 #[tauri::command]
+/// Creates a new empty vault and opens it as the active session.
 pub fn create_vault(
     path: String,
     password: String,
@@ -73,6 +76,7 @@ pub fn create_vault(
 }
 
 #[tauri::command]
+/// Returns metadata-only entry views for the unlocked vault.
 pub fn list_entries(state: State<'_, AppState>) -> Result<Vec<EntryDto>, ArcaError> {
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
@@ -82,10 +86,12 @@ pub fn list_entries(state: State<'_, AppState>) -> Result<Vec<EntryDto>, ArcaErr
 }
 
 #[tauri::command]
+/// Returns one metadata-only entry view by id.
 pub fn get_entry(id: String, state: State<'_, AppState>) -> Result<EntryDto, ArcaError> {
     get_entry_in_state(&id, state.inner())
 }
 
+/// Looks up a metadata-only entry view in application state.
 fn get_entry_in_state(id: &str, state: &AppState) -> Result<EntryDto, ArcaError> {
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
@@ -100,6 +106,7 @@ fn get_entry_in_state(id: &str, state: &AppState) -> Result<EntryDto, ArcaError>
 }
 
 #[tauri::command]
+/// Reveals the current password for one entry through an explicit secret-bearing call.
 pub fn reveal_entry_password(
     id: String,
     state: State<'_, AppState>,
@@ -107,6 +114,7 @@ pub fn reveal_entry_password(
     reveal_entry_password_in_state(&id, state.inner())
 }
 
+/// Loads an entry password from the unlocked session without logging it.
 fn reveal_entry_password_in_state(id: &str, state: &AppState) -> Result<SecretString, ArcaError> {
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
@@ -121,6 +129,7 @@ fn reveal_entry_password_in_state(id: &str, state: &AppState) -> Result<SecretSt
 }
 
 #[tauri::command]
+/// Returns metadata-only revision history for one entry.
 pub fn get_entry_revisions(
     id: String,
     state: State<'_, AppState>,
@@ -128,6 +137,7 @@ pub fn get_entry_revisions(
     get_entry_revisions_in_state(&id, state.inner())
 }
 
+/// Builds revision views and marks whether each revision changed the password.
 fn get_entry_revisions_in_state(id: &str, state: &AppState) -> Result<Vec<RevisionDto>, ArcaError> {
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
@@ -159,6 +169,7 @@ fn get_entry_revisions_in_state(id: &str, state: &AppState) -> Result<Vec<Revisi
 }
 
 #[tauri::command]
+/// Reveals a historical revision password through an explicit secret-bearing call.
 pub fn reveal_entry_revision_password(
     id: String,
     index: usize,
@@ -167,6 +178,7 @@ pub fn reveal_entry_revision_password(
     reveal_entry_revision_password_in_state(&id, index, state.inner())
 }
 
+/// Loads one revision password from the unlocked session without logging it.
 fn reveal_entry_revision_password_in_state(
     id: &str,
     index: usize,
@@ -190,6 +202,7 @@ fn reveal_entry_revision_password_in_state(
 }
 
 #[tauri::command]
+/// Creates a vault entry from the public request contract and persists it.
 pub fn create_entry(
     data: CreateEntryDto,
     state: State<'_, AppState>,
@@ -212,6 +225,7 @@ pub fn create_entry(
 }
 
 #[tauri::command]
+/// Applies an entry mutation from the public contract and persists the vault.
 pub fn update_entry(
     id: String,
     data: UpdateEntryDto,
@@ -242,6 +256,7 @@ pub fn update_entry(
 }
 
 #[tauri::command]
+/// Deletes one entry from the active vault and persists the change.
 pub fn delete_entry(id: String, state: State<'_, AppState>) -> Result<(), ArcaError> {
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
@@ -260,6 +275,7 @@ pub fn delete_entry(id: String, state: State<'_, AppState>) -> Result<(), ArcaEr
 }
 
 #[tauri::command]
+/// Searches unlocked entries and returns metadata-only views.
 pub fn search_entries(
     query: String,
     state: State<'_, AppState>,
@@ -275,6 +291,7 @@ pub fn search_entries(
 }
 
 #[tauri::command]
+/// Generates a password from public generator parameters.
 pub fn generate_password(config: GeneratorConfigDto) -> Result<GeneratedPassword, ArcaError> {
     let config = generator_config_from_dto(config);
     let password = core_generator::generate_password(&config);
@@ -284,6 +301,7 @@ pub fn generate_password(config: GeneratorConfigDto) -> Result<GeneratedPassword
 }
 
 #[tauri::command]
+/// Suggests filesystem paths for the unlock/create vault picker.
 pub fn suggest_paths(partial: String) -> Result<Vec<PathSuggestionDto>, ArcaError> {
     if partial.len() > 4096 {
         return Err(ArcaError::invalid_input("Path query is too long"));
@@ -293,15 +311,18 @@ pub fn suggest_paths(partial: String) -> Result<Vec<PathSuggestionDto>, ArcaErro
 }
 
 #[tauri::command]
+/// Returns persisted desktop settings.
 pub fn get_settings(state: State<'_, AppState>) -> Result<Settings, ArcaError> {
     Ok(state.settings()?.clone())
 }
 
 #[tauri::command]
+/// Updates desktop settings and trims persisted revision history when needed.
 pub fn update_settings(settings: Settings, state: State<'_, AppState>) -> Result<(), ArcaError> {
     update_settings_in_state(settings, state.inner())
 }
 
+/// Applies settings to state and persists any revision-retention changes atomically.
 fn update_settings_in_state(mut settings: Settings, state: &AppState) -> Result<(), ArcaError> {
     settings.entry_revision_limit = settings
         .entry_revision_limit
@@ -330,6 +351,7 @@ fn update_settings_in_state(mut settings: Settings, state: &AppState) -> Result<
     Ok(())
 }
 
+/// Converts a core entry into the metadata-only public entry contract.
 fn entry_metadata_dto(entry: &VaultEntry) -> EntryDto {
     EntryDto {
         id: entry.id.clone(),
@@ -345,6 +367,7 @@ fn entry_metadata_dto(entry: &VaultEntry) -> EntryDto {
     }
 }
 
+/// Converts a core revision into the metadata-only public revision contract.
 fn revision_dto_from_revision(revision: &EntryRevision, password_changed: bool) -> RevisionDto {
     RevisionDto {
         captured_at: revision.captured_at.clone(),
@@ -359,6 +382,7 @@ fn revision_dto_from_revision(revision: &EntryRevision, password_changed: bool) 
     }
 }
 
+/// Converts a public entry mutation into the core patch model.
 fn entry_patch_from_dto(value: UpdateEntryDto) -> core_entry::EntryPatch {
     core_entry::EntryPatch {
         title: value.title,
@@ -371,6 +395,7 @@ fn entry_patch_from_dto(value: UpdateEntryDto) -> core_entry::EntryPatch {
     }
 }
 
+/// Applies core defaults to partial public generator parameters.
 fn generator_config_from_dto(value: GeneratorConfigDto) -> GeneratorConfig {
     let default = GeneratorConfig::default();
 
@@ -388,6 +413,7 @@ fn generator_config_from_dto(value: GeneratorConfigDto) -> GeneratorConfig {
     }
 }
 
+/// Converts the public generator mode into the core generator mode.
 fn generator_mode_from_dto(value: GeneratorModeDto) -> GeneratorMode {
     match value {
         GeneratorModeDto::Random => GeneratorMode::Random,
@@ -395,6 +421,7 @@ fn generator_mode_from_dto(value: GeneratorModeDto) -> GeneratorMode {
     }
 }
 
+/// Ensures a command is operating on an unlocked session.
 fn ensure_unlocked(session: &crate::state::SessionState) -> Result<(), ArcaError> {
     if session.meta.is_some() && session.vault_path.is_some() && session.master_password.is_some() {
         Ok(())
@@ -403,6 +430,7 @@ fn ensure_unlocked(session: &crate::state::SessionState) -> Result<(), ArcaError
     }
 }
 
+/// Validates an optional replacement entry password.
 fn validate_optional_entry_password(password: Option<&str>) -> Result<(), ArcaError> {
     if let Some(password) = password {
         validate_entry_password(password)?;
@@ -411,6 +439,7 @@ fn validate_optional_entry_password(password: Option<&str>) -> Result<(), ArcaEr
     Ok(())
 }
 
+/// Rejects empty entry passwords at the desktop command boundary.
 fn validate_entry_password(password: &str) -> Result<(), ArcaError> {
     if password.is_empty() {
         Err(ArcaError::invalid_input(
@@ -421,10 +450,12 @@ fn validate_entry_password(password: &str) -> Result<(), ArcaError> {
     }
 }
 
+/// Persists the current in-memory entries for the active session.
 fn persist_session(session: &crate::state::SessionState) -> Result<(), ArcaError> {
     persist_entries(session, &session.entries)
 }
 
+/// Writes the provided entry set using the active vault path and master password.
 fn persist_entries(
     session: &crate::state::SessionState,
     entries: &[VaultEntry],
@@ -444,6 +475,7 @@ fn persist_entries(
     Ok(())
 }
 
+/// Builds the public vault summary returned to the frontend.
 fn vault_info(path: &Path, meta: &VaultMeta, entry_count: usize) -> VaultInfo {
     VaultInfo::new(
         meta.name.clone(),
@@ -453,6 +485,7 @@ fn vault_info(path: &Path, meta: &VaultMeta, entry_count: usize) -> VaultInfo {
     )
 }
 
+/// Expands and ranks path suggestions from a partial user input.
 fn suggest_paths_for(partial: &str) -> Vec<PathSuggestionDto> {
     let trimmed = partial.trim_start();
     let expanded = expand_path(trimmed);
@@ -506,6 +539,7 @@ fn suggest_paths_for(partial: &str) -> Vec<PathSuggestionDto> {
     suggestions
 }
 
+/// Converts one filesystem path into a path suggestion when possible.
 fn path_suggestion(path: PathBuf, prefix: &str) -> Option<PathSuggestionDto> {
     let metadata = fs::metadata(&path).ok()?;
 
@@ -543,6 +577,7 @@ fn path_suggestion(path: PathBuf, prefix: &str) -> Option<PathSuggestionDto> {
     })
 }
 
+/// Orders likely vault files before directories and other files.
 fn suggestion_rank(suggestion: &PathSuggestionDto) -> u8 {
     match (&suggestion.kind, suggestion.vault_candidate) {
         (PathSuggestionKind::File, true) => 0,
@@ -551,12 +586,14 @@ fn suggestion_rank(suggestion: &PathSuggestionDto) -> u8 {
     }
 }
 
+/// Checks whether a path basename looks like a supported vault file.
 fn is_vault_candidate(name: &str) -> bool {
     let lower = name.to_lowercase();
 
     lower.ends_with(".arca") || lower.ends_with(".kdbx")
 }
 
+/// Expands `~` prefixes in user-provided paths.
 fn expand_path(value: &str) -> PathBuf {
     if value == "~" {
         return home_dir().unwrap_or_else(|| PathBuf::from(value));
@@ -579,6 +616,7 @@ fn expand_path(value: &str) -> PathBuf {
     }
 }
 
+/// Returns the current user's home directory when the process can resolve it.
 fn home_dir() -> Option<PathBuf> {
     env::var_os("HOME")
         .or_else(|| env::var_os("USERPROFILE"))

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -2,8 +2,14 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tauri::State;
+use vault_api::{
+    CreateEntryRequest as CreateEntryDto, EntryMutation as UpdateEntryDto, EntryView as EntryDto,
+    GeneratedSecret as GeneratedPassword, GeneratorMode as GeneratorModeDto,
+    GeneratorParams as GeneratorConfigDto, RevisionView as RevisionDto, SecretString,
+    VaultSummary as VaultInfo,
+};
 use vault_core::entry as core_entry;
 use vault_core::generator as core_generator;
 use vault_core::types::EntryRevision;
@@ -13,94 +19,6 @@ use zeroize::Zeroizing;
 
 use crate::error::ArcaError;
 use crate::state::{AppState, Settings};
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct VaultInfo {
-    pub name: String,
-    pub path: String,
-    pub entry_count: usize,
-    pub modified_at: String,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct EntryDto {
-    pub id: String,
-    pub title: String,
-    pub username: String,
-    pub password: Option<String>,
-    pub collection: Option<String>,
-    pub url: Option<String>,
-    pub notes: Option<String>,
-    pub tags: Vec<String>,
-    pub created_at: String,
-    pub updated_at: String,
-    pub revision_count: usize,
-}
-
-#[derive(Clone, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct RevisionDto {
-    pub captured_at: String,
-    pub updated_at: String,
-    pub title: String,
-    pub username: String,
-    pub collection: Option<String>,
-    pub url: Option<String>,
-    pub notes: Option<String>,
-    pub tags: Vec<String>,
-    pub password_changed: bool,
-}
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-pub struct CreateEntryDto {
-    pub title: String,
-    pub username: String,
-    pub password: String,
-    pub collection: Option<String>,
-    pub url: Option<String>,
-    pub notes: Option<String>,
-    #[serde(default)]
-    pub tags: Vec<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
-pub struct UpdateEntryDto {
-    pub title: Option<String>,
-    pub username: Option<String>,
-    pub password: Option<String>,
-    pub collection: Option<Option<String>>,
-    pub url: Option<Option<String>>,
-    pub notes: Option<Option<String>>,
-    pub tags: Option<Vec<String>>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct GeneratorConfigDto {
-    pub length: Option<usize>,
-    pub uppercase: Option<bool>,
-    pub lowercase: Option<bool>,
-    pub digits: Option<bool>,
-    pub symbols: Option<bool>,
-    pub exclude_ambiguous: Option<bool>,
-    pub mode: Option<GeneratorModeDto>,
-}
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub enum GeneratorModeDto {
-    Random,
-    Passphrase,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct GeneratedPassword {
-    pub password: String,
-    pub entropy_bits: f64,
-}
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -185,14 +103,11 @@ fn get_entry_in_state(id: &str, state: &AppState) -> Result<EntryDto, ArcaError>
 pub fn reveal_entry_password(
     id: String,
     state: State<'_, AppState>,
-) -> Result<Zeroizing<String>, ArcaError> {
+) -> Result<SecretString, ArcaError> {
     reveal_entry_password_in_state(&id, state.inner())
 }
 
-fn reveal_entry_password_in_state(
-    id: &str,
-    state: &AppState,
-) -> Result<Zeroizing<String>, ArcaError> {
+fn reveal_entry_password_in_state(id: &str, state: &AppState) -> Result<SecretString, ArcaError> {
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
     session.touch();
@@ -201,7 +116,7 @@ fn reveal_entry_password_in_state(
         .entries
         .iter()
         .find(|entry| entry.id == id)
-        .map(|entry| Zeroizing::new(entry.password.clone()))
+        .map(|entry| SecretString::new(entry.password.clone()))
         .ok_or_else(|| ArcaError::not_found("Entry"))
 }
 
@@ -233,7 +148,7 @@ fn get_entry_revisions_in_state(id: &str, state: &AppState) -> Result<Vec<Revisi
                     } else {
                         entry.revisions[index - 1].password.as_str()
                     };
-                    RevisionDto::from_revision(
+                    revision_dto_from_revision(
                         revision,
                         revision.password.as_str() != newer_password,
                     )
@@ -248,7 +163,7 @@ pub fn reveal_entry_revision_password(
     id: String,
     index: usize,
     state: State<'_, AppState>,
-) -> Result<Zeroizing<String>, ArcaError> {
+) -> Result<SecretString, ArcaError> {
     reveal_entry_revision_password_in_state(&id, index, state.inner())
 }
 
@@ -256,7 +171,7 @@ fn reveal_entry_revision_password_in_state(
     id: &str,
     index: usize,
     state: &AppState,
-) -> Result<Zeroizing<String>, ArcaError> {
+) -> Result<SecretString, ArcaError> {
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
     session.touch();
@@ -270,7 +185,7 @@ fn reveal_entry_revision_password_in_state(
     entry
         .revisions
         .get(index)
-        .map(|revision| Zeroizing::new(revision.password.clone()))
+        .map(|revision| SecretString::new(revision.password.clone()))
         .ok_or_else(|| ArcaError::not_found("Revision"))
 }
 
@@ -281,9 +196,10 @@ pub fn create_entry(
 ) -> Result<EntryDto, ArcaError> {
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
-    validate_entry_password(&data.password)?;
+    validate_entry_password(data.password.expose_secret())?;
 
-    let mut entry = core_entry::create_entry(&data.title, &data.username, &data.password);
+    let mut entry =
+        core_entry::create_entry(&data.title, &data.username, data.password.expose_secret());
     entry.collection = data.collection;
     entry.url = data.url;
     entry.notes = data.notes;
@@ -304,7 +220,7 @@ pub fn update_entry(
     let revision_limit = state.settings()?.entry_revision_limit;
     let mut session = state.session()?;
     ensure_unlocked(&session)?;
-    validate_optional_entry_password(data.password.as_deref())?;
+    validate_optional_entry_password(data.password.as_ref().map(SecretString::expose_secret))?;
 
     let dto = {
         let entry = session
@@ -312,7 +228,11 @@ pub fn update_entry(
             .iter_mut()
             .find(|entry| entry.id == id)
             .ok_or_else(|| ArcaError::not_found("Entry"))?;
-        core_entry::update_entry_with_revision_limit(entry, data.into(), revision_limit);
+        core_entry::update_entry_with_revision_limit(
+            entry,
+            entry_patch_from_dto(data),
+            revision_limit,
+        );
         entry_metadata_dto(entry)
     };
     persist_session(&session)?;
@@ -356,14 +276,11 @@ pub fn search_entries(
 
 #[tauri::command]
 pub fn generate_password(config: GeneratorConfigDto) -> Result<GeneratedPassword, ArcaError> {
-    let config = config.into_generator_config();
+    let config = generator_config_from_dto(config);
     let password = core_generator::generate_password(&config);
     let entropy_bits = core_generator::calculate_entropy(&password, &config);
 
-    Ok(GeneratedPassword {
-        password,
-        entropy_bits,
-    })
+    Ok(GeneratedPassword::new(password, entropy_bits))
 }
 
 #[tauri::command]
@@ -413,83 +330,68 @@ fn update_settings_in_state(mut settings: Settings, state: &AppState) -> Result<
     Ok(())
 }
 
-impl EntryDto {
-    fn from_entry(entry: &VaultEntry, include_password: bool) -> Self {
-        Self {
-            id: entry.id.clone(),
-            title: entry.title.clone(),
-            username: entry.username.clone(),
-            password: include_password.then(|| entry.password.clone()),
-            collection: entry.collection.clone(),
-            url: entry.url.clone(),
-            notes: entry.notes.clone(),
-            tags: entry.tags.clone(),
-            created_at: entry.created_at.clone(),
-            updated_at: entry.updated_at.clone(),
-            revision_count: entry.revisions.len(),
-        }
-    }
-}
-
 fn entry_metadata_dto(entry: &VaultEntry) -> EntryDto {
-    EntryDto::from_entry(entry, false)
-}
-
-impl RevisionDto {
-    fn from_revision(revision: &EntryRevision, password_changed: bool) -> Self {
-        Self {
-            captured_at: revision.captured_at.clone(),
-            updated_at: revision.updated_at.clone(),
-            title: revision.title.clone(),
-            username: revision.username.clone(),
-            collection: revision.collection.clone(),
-            url: revision.url.clone(),
-            notes: revision.notes.clone(),
-            tags: revision.tags.clone(),
-            password_changed,
-        }
+    EntryDto {
+        id: entry.id.clone(),
+        title: entry.title.clone(),
+        username: entry.username.clone(),
+        collection: entry.collection.clone(),
+        url: entry.url.clone(),
+        notes: entry.notes.clone(),
+        tags: entry.tags.clone(),
+        created_at: entry.created_at.clone(),
+        updated_at: entry.updated_at.clone(),
+        revision_count: entry.revisions.len(),
     }
 }
 
-impl From<UpdateEntryDto> for core_entry::EntryPatch {
-    fn from(value: UpdateEntryDto) -> Self {
-        Self {
-            title: value.title,
-            username: value.username,
-            password: value.password,
-            collection: value.collection,
-            url: value.url,
-            notes: value.notes,
-            tags: value.tags,
-        }
+fn revision_dto_from_revision(revision: &EntryRevision, password_changed: bool) -> RevisionDto {
+    RevisionDto {
+        captured_at: revision.captured_at.clone(),
+        updated_at: revision.updated_at.clone(),
+        title: revision.title.clone(),
+        username: revision.username.clone(),
+        collection: revision.collection.clone(),
+        url: revision.url.clone(),
+        notes: revision.notes.clone(),
+        tags: revision.tags.clone(),
+        password_changed,
     }
 }
 
-impl GeneratorConfigDto {
-    fn into_generator_config(self) -> GeneratorConfig {
-        let default = GeneratorConfig::default();
-
-        GeneratorConfig {
-            length: self.length.unwrap_or(default.length),
-            uppercase: self.uppercase.unwrap_or(default.uppercase),
-            lowercase: self.lowercase.unwrap_or(default.lowercase),
-            digits: self.digits.unwrap_or(default.digits),
-            symbols: self.symbols.unwrap_or(default.symbols),
-            exclude_ambiguous: self.exclude_ambiguous.unwrap_or(default.exclude_ambiguous),
-            mode: self
-                .mode
-                .map(GeneratorMode::from)
-                .unwrap_or(GeneratorMode::Random),
-        }
+fn entry_patch_from_dto(value: UpdateEntryDto) -> core_entry::EntryPatch {
+    core_entry::EntryPatch {
+        title: value.title,
+        username: value.username,
+        password: value.password.map(SecretString::into_inner),
+        collection: value.collection,
+        url: value.url,
+        notes: value.notes,
+        tags: value.tags,
     }
 }
 
-impl From<GeneratorModeDto> for GeneratorMode {
-    fn from(value: GeneratorModeDto) -> Self {
-        match value {
-            GeneratorModeDto::Random => Self::Random,
-            GeneratorModeDto::Passphrase => Self::Passphrase,
-        }
+fn generator_config_from_dto(value: GeneratorConfigDto) -> GeneratorConfig {
+    let default = GeneratorConfig::default();
+
+    GeneratorConfig {
+        length: value.length.unwrap_or(default.length),
+        uppercase: value.uppercase.unwrap_or(default.uppercase),
+        lowercase: value.lowercase.unwrap_or(default.lowercase),
+        digits: value.digits.unwrap_or(default.digits),
+        symbols: value.symbols.unwrap_or(default.symbols),
+        exclude_ambiguous: value.exclude_ambiguous.unwrap_or(default.exclude_ambiguous),
+        mode: value
+            .mode
+            .map(generator_mode_from_dto)
+            .unwrap_or(default.mode),
+    }
+}
+
+fn generator_mode_from_dto(value: GeneratorModeDto) -> GeneratorMode {
+    match value {
+        GeneratorModeDto::Random => GeneratorMode::Random,
+        GeneratorModeDto::Passphrase => GeneratorMode::Passphrase,
     }
 }
 
@@ -543,12 +445,12 @@ fn persist_entries(
 }
 
 fn vault_info(path: &Path, meta: &VaultMeta, entry_count: usize) -> VaultInfo {
-    VaultInfo {
-        name: meta.name.clone(),
-        path: path.display().to_string(),
+    VaultInfo::new(
+        meta.name.clone(),
+        path.display().to_string(),
         entry_count,
-        modified_at: meta.modified_at.clone(),
-    }
+        meta.modified_at.clone(),
+    )
 }
 
 fn suggest_paths_for(partial: &str) -> Vec<PathSuggestionDto> {
@@ -686,16 +588,18 @@ fn home_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::{
-        entry_metadata_dto, get_entry_in_state, get_entry_revisions_in_state,
-        reveal_entry_password_in_state, reveal_entry_revision_password_in_state, suggest_paths_for,
+        entry_metadata_dto, entry_patch_from_dto, generator_config_from_dto, get_entry_in_state,
+        get_entry_revisions_in_state, reveal_entry_password_in_state,
+        reveal_entry_revision_password_in_state, revision_dto_from_revision, suggest_paths_for,
         update_settings_in_state, validate_entry_password, validate_optional_entry_password,
-        CreateEntryDto, EntryDto, GeneratorConfigDto, RevisionDto, UpdateEntryDto,
+        CreateEntryDto, GeneratorConfigDto, UpdateEntryDto,
     };
     use crate::error::ArcaError;
     use crate::state::{AppState, Settings};
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
+    use vault_api::SecretString;
     use vault_core::entry::{create_entry, update_entry};
     use vault_core::entry::{EntryPatch, DEFAULT_ENTRY_REVISION_LIMIT};
     use vault_core::types::VaultMeta;
@@ -719,13 +623,12 @@ mod tests {
             updated_at: "2026-06-11T00:00:00+00:00".to_string(),
         });
 
-        let masked = EntryDto::from_entry(&entry, false);
-        let revealed = EntryDto::from_entry(&entry, true);
+        let masked = entry_metadata_dto(&entry);
+        let json = serde_json::to_string(&masked).expect("entry dto should serialize");
 
-        assert!(masked.password.is_none());
-        assert_eq!(revealed.password.as_deref(), Some(credential.as_str()));
+        assert!(!json.contains("\"password\""));
+        assert!(!json.contains(credential.as_str()));
         assert_eq!(masked.revision_count, 1);
-        assert_eq!(revealed.revision_count, 1);
     }
 
     #[test]
@@ -736,8 +639,7 @@ mod tests {
         let dto = entry_metadata_dto(&entry);
         let json = serde_json::to_string(&dto).expect("entry dto should serialize");
 
-        assert!(dto.password.is_none());
-        assert!(json.contains("\"password\":null"));
+        assert!(!json.contains("\"password\""));
         assert!(!json.contains(credential.as_str()));
     }
 
@@ -752,7 +654,9 @@ mod tests {
         let dto = get_entry_in_state(&entry_id, &state)
             .expect("entry metadata should be returned for an unlocked entry");
 
-        assert!(dto.password.is_none());
+        let json = serde_json::to_string(&dto).expect("entry dto should serialize");
+        assert!(!json.contains("\"password\""));
+        assert!(!json.contains(credential.as_str()));
     }
 
     #[test]
@@ -766,7 +670,7 @@ mod tests {
         let password = reveal_entry_password_in_state(&entry_id, &state)
             .expect("entry password should be revealed for an unlocked entry");
 
-        assert_eq!(*password, credential);
+        assert_eq!(password.expose_secret(), credential);
     }
 
     #[test]
@@ -841,7 +745,7 @@ mod tests {
     fn revision_dto_serialization_excludes_password() {
         let entry = create_entry_with_revisions(1);
         let revision = &entry.revisions[0];
-        let dto = RevisionDto::from_revision(revision, true);
+        let dto = revision_dto_from_revision(revision, true);
 
         let json = serde_json::to_string(&dto).expect("revision dto should serialize");
 
@@ -860,7 +764,7 @@ mod tests {
         let password = reveal_entry_revision_password_in_state(&entry_id, 0, &state)
             .expect("revision password should be revealed for an unlocked entry");
 
-        assert_eq!(*password, expected);
+        assert_eq!(password.expose_secret(), expected);
     }
 
     #[test]
@@ -902,7 +806,7 @@ mod tests {
 
     #[test]
     fn generator_config_dto_uses_secure_defaults() {
-        let config = GeneratorConfigDto::default().into_generator_config();
+        let config = generator_config_from_dto(GeneratorConfigDto::default());
 
         assert_eq!(config.length, 24);
         assert!(config.uppercase);
@@ -938,7 +842,7 @@ mod tests {
     fn update_entry_dto_omitted_password_means_unchanged() {
         let dto: UpdateEntryDto =
             serde_json::from_str(r#"{"title":"GitHub"}"#).expect("update dto should deserialize");
-        let patch: EntryPatch = dto.into();
+        let patch = entry_patch_from_dto(dto);
 
         assert!(patch.password.is_none());
         assert!(validate_optional_entry_password(patch.password.as_deref()).is_ok());
@@ -947,11 +851,13 @@ mod tests {
     #[test]
     fn entry_password_policy_rejects_empty_update_passwords() {
         let dto = UpdateEntryDto {
-            password: Some(String::new()),
+            password: Some(SecretString::new(String::new())),
             ..UpdateEntryDto::default()
         };
-        let error = validate_optional_entry_password(dto.password.as_deref())
-            .expect_err("empty update passwords should be rejected");
+        let error = validate_optional_entry_password(
+            dto.password.as_ref().map(SecretString::expose_secret),
+        )
+        .expect_err("empty update passwords should be rejected");
 
         assert_eq!(error.code, "invalid_input");
     }

--- a/apps/desktop/src-tauri/src/error.rs
+++ b/apps/desktop/src-tauri/src/error.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use vault_api::ErrorCode;
 use vault_core::VaultError;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -34,16 +35,16 @@ impl ArcaError {
 
 impl From<VaultError> for ArcaError {
     fn from(error: VaultError) -> Self {
-        match error {
-            VaultError::InvalidPassword => Self::new("invalid_password", error.to_string()),
-            VaultError::FileNotFound(_) => Self::new("file_not_found", error.to_string()),
-            VaultError::CorruptedVault => Self::new("corrupted_vault", error.to_string()),
-            VaultError::EncryptionError(_) => Self::new("encryption_error", error.to_string()),
-            VaultError::DecryptionError(_) => Self::new("decryption_error", error.to_string()),
-            VaultError::IoError(_) => Self::new("io_error", error.to_string()),
-            VaultError::SerializationError(_) => {
-                Self::new("serialization_error", error.to_string())
-            }
-        }
+        let code = match error {
+            VaultError::InvalidPassword => ErrorCode::InvalidPassword,
+            VaultError::FileNotFound(_) => ErrorCode::FileNotFound,
+            VaultError::CorruptedVault => ErrorCode::CorruptedVault,
+            VaultError::EncryptionError(_) => ErrorCode::EncryptionError,
+            VaultError::DecryptionError(_) => ErrorCode::DecryptionError,
+            VaultError::IoError(_) => ErrorCode::IoError,
+            VaultError::SerializationError(_) => ErrorCode::SerializationError,
+        };
+
+        Self::new(code.to_string(), error.to_string())
     }
 }

--- a/apps/desktop/src-tauri/src/error.rs
+++ b/apps/desktop/src-tauri/src/error.rs
@@ -45,6 +45,50 @@ impl From<VaultError> for ArcaError {
             VaultError::SerializationError(_) => ErrorCode::SerializationError,
         };
 
-        Self::new(code.to_string(), error.to_string())
+        Self::new(code.to_string(), safe_vault_error_message(&code))
+    }
+}
+
+fn safe_vault_error_message(code: &ErrorCode) -> &'static str {
+    match code {
+        ErrorCode::InvalidPassword => "Invalid password",
+        ErrorCode::FileNotFound => "Vault file not found",
+        ErrorCode::CorruptedVault => "Vault file is corrupted",
+        ErrorCode::EncryptionError => "Unable to encrypt vault data",
+        ErrorCode::DecryptionError => "Unable to decrypt vault data",
+        ErrorCode::IoError => "Unable to read or write vault data",
+        ErrorCode::SerializationError => "Unable to process vault data",
+        ErrorCode::VaultLocked => "Vault is locked",
+        ErrorCode::NotFound => "Item not found",
+        ErrorCode::InvalidInput => "Invalid input",
+        ErrorCode::CapabilityDenied => "Capability denied",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::ArcaError;
+    use vault_core::VaultError;
+
+    #[test]
+    fn vault_error_messages_do_not_expose_core_payloads() {
+        let path = "/Users/example/private/vault.arca";
+        let errors = [
+            VaultError::FileNotFound(path.to_string()),
+            VaultError::EncryptionError("backend nonce detail".to_string()),
+            VaultError::DecryptionError("backend decrypt detail".to_string()),
+            VaultError::IoError(io::Error::new(io::ErrorKind::PermissionDenied, path)),
+            VaultError::SerializationError("parser detail".to_string()),
+        ];
+
+        for error in errors {
+            let arca_error = ArcaError::from(error);
+
+            assert!(!arca_error.message.contains(path));
+            assert!(!arca_error.message.contains("backend"));
+            assert!(!arca_error.message.contains("parser"));
+        }
     }
 }

--- a/apps/desktop/src/lib/audit.test.ts
+++ b/apps/desktop/src/lib/audit.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, it, vi } from 'vitest';
 import { AUDIT_FINDING_COPY, buildAuditFindings, filterAuditableEntries, scoreAudit } from './audit';
-import type { EntryDto } from './ipc';
+import type { AuditableEntry } from './audit';
 
 const millisecondsPerDay = 1000 * 60 * 60 * 24;
 const referenceTime = new Date('2026-06-22T12:00:00.000Z');
@@ -11,7 +11,7 @@ vi.useFakeTimers();
 vi.setSystemTime(referenceTime);
 afterAll(() => vi.useRealTimers());
 
-function entry(overrides: Partial<EntryDto>): EntryDto {
+function entry(overrides: Partial<AuditableEntry>): AuditableEntry {
   return {
     id: 'entry-id',
     title: 'Entry',

--- a/apps/desktop/src/lib/audit.test.ts
+++ b/apps/desktop/src/lib/audit.test.ts
@@ -107,6 +107,8 @@ describe('buildAuditFindings', () => {
       expect(finding.meta).not.toContain(secret);
       expect(AUDIT_FINDING_COPY[finding.title].label).not.toContain(secret);
       expect(AUDIT_FINDING_COPY[finding.title].action).not.toContain(secret);
+      expect('password' in finding.entry).toBe(false);
+      expect(JSON.stringify(finding.entry)).not.toContain(secret);
     }
   });
 

--- a/apps/desktop/src/lib/audit.ts
+++ b/apps/desktop/src/lib/audit.ts
@@ -140,16 +140,21 @@ function finding(
   type: string,
   severity: AuditSeverity,
   title: AuditFindingTitle,
-  entry: EntryDto,
+  entry: AuditableEntry,
   meta: string,
 ): AuditFinding {
   return {
     key: `${type}:${entry.id}`,
     severity,
     title,
-    entry,
+    entry: metadataOnlyEntry(entry),
     meta,
   };
+}
+
+function metadataOnlyEntry(entry: AuditableEntry): EntryDto {
+  const { password: _password, ...metadata } = entry;
+  return metadata;
 }
 
 function groupBy<T extends EntryDto>(

--- a/apps/desktop/src/lib/audit.ts
+++ b/apps/desktop/src/lib/audit.ts
@@ -20,6 +20,10 @@ export interface AuditFinding {
   meta: string;
 }
 
+export type AuditableEntry = EntryDto & {
+  password?: string | null;
+};
+
 export interface AuditFindingCopy {
   label: string;
   action: string;
@@ -64,7 +68,7 @@ export const AUDIT_FINDING_COPY: Record<AuditFindingTitle, AuditFindingCopy> = {
   },
 };
 
-export function buildAuditFindings(entries: EntryDto[]): AuditFinding[] {
+export function buildAuditFindings(entries: AuditableEntry[]): AuditFinding[] {
   const results: AuditFinding[] = [];
   const usernames = groupBy(entries, (entry) => normalize(entry.username));
   const urls = groupBy(entries, (entry) => normalizeUrl(entry.url));
@@ -113,7 +117,7 @@ export function buildAuditFindings(entries: EntryDto[]): AuditFinding[] {
   return results.sort((a, b) => severityRank(a.severity) - severityRank(b.severity) || a.title.localeCompare(b.title));
 }
 
-export function filterAuditableEntries(entries: EntryDto[]): EntryDto[] {
+export function filterAuditableEntries<T extends EntryDto>(entries: T[]): T[] {
   return entries.filter(isAuditableEntry);
 }
 
@@ -212,7 +216,7 @@ function isHttpUrl(value: string): boolean {
   }
 }
 
-function hasLoadedPassword(entry: EntryDto): entry is EntryDto & { password: string } {
+function hasLoadedPassword(entry: AuditableEntry): entry is EntryDto & { password: string } {
   return hasValue(entry.password);
 }
 

--- a/apps/desktop/src/lib/audit.ts
+++ b/apps/desktop/src/lib/audit.ts
@@ -68,6 +68,7 @@ export const AUDIT_FINDING_COPY: Record<AuditFindingTitle, AuditFindingCopy> = {
   },
 };
 
+/** Builds audit findings from metadata plus any explicitly loaded password values. */
 export function buildAuditFindings(entries: AuditableEntry[]): AuditFinding[] {
   const results: AuditFinding[] = [];
   const usernames = groupBy(entries, (entry) => normalize(entry.username));
@@ -117,10 +118,12 @@ export function buildAuditFindings(entries: AuditableEntry[]): AuditFinding[] {
   return results.sort((a, b) => severityRank(a.severity) - severityRank(b.severity) || a.title.localeCompare(b.title));
 }
 
+/** Removes archived entries from audit scope. */
 export function filterAuditableEntries<T extends EntryDto>(entries: T[]): T[] {
   return entries.filter(isAuditableEntry);
 }
 
+/** Scores audit health as the rounded percentage of healthy entries. */
 export function scoreAudit(entryCount: number, healthyEntryCount: number): string {
   if (entryCount === 0) {
     return '0';

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -2,7 +2,7 @@
   import { onMount, tick } from 'svelte';
   import { AUDIT_FINDING_COPY, type AuditFinding, type AuditFindingTitle, type AuditSeverity } from '../../audit';
   import { isEditableTarget } from '../../keyboard';
-  import { getAuditState } from '../../stores/audit.svelte';
+  import { getAuditState, refreshAuditState } from '../../stores/audit.svelte';
   import { uiState } from '../../stores/ui.svelte';
   import { vaultState } from '../../stores/vault.svelte';
   import { Tag } from '../primitives';
@@ -12,6 +12,9 @@
   let activeFindingKey = $state('');
 
   const auditState = $derived(getAuditState());
+  const auditInputFingerprint = $derived(
+    vaultState.entries.map((entry) => `${entry.id}:${entry.updatedAt}:${entry.revisionCount}`).join('|'),
+  );
   const score = $derived(Number(auditState.score));
   const weakCount = $derived(countBySeverity('high'));
   const reusedCount = $derived(countByTitle('reused_password'));
@@ -41,6 +44,17 @@
         : 'Move entries out of archive to include them in password health and vault hygiene.'
       : `${auditState.healthyCount} of ${auditState.entryCount} entries are healthy. ${auditState.findingCount} findings need attention${attentionSummary ? ` - ${attentionSummary}.` : '.'}`,
   );
+
+  $effect(() => {
+    if (auditInputFingerprint !== undefined && !vaultState.locked) {
+      void refreshAuditState().catch(() => {
+        uiState.notification = {
+          kind: 'error',
+          message: 'Unable to refresh audit findings',
+        };
+      });
+    }
+  });
 
   $effect(() => {
     if (auditState.findings.length === 0) {

--- a/apps/desktop/src/lib/components/audit/AuditPanel.svelte
+++ b/apps/desktop/src/lib/components/audit/AuditPanel.svelte
@@ -13,7 +13,9 @@
 
   const auditState = $derived(getAuditState());
   const auditInputFingerprint = $derived(
-    vaultState.entries.map((entry) => `${entry.id}:${entry.updatedAt}:${entry.revisionCount}`).join('|'),
+    `${vaultState.vaultPath}::${vaultState.entries
+      .map((entry) => `${entry.id}:${entry.updatedAt}:${entry.revisionCount}`)
+      .join('|')}`,
   );
   const score = $derived(Number(auditState.score));
   const weakCount = $derived(countBySeverity('high'));

--- a/apps/desktop/src/lib/components/detail/EntryForm.svelte
+++ b/apps/desktop/src/lib/components/detail/EntryForm.svelte
@@ -57,7 +57,7 @@
     loadedContext = context;
     title = entry?.title ?? draft?.title ?? '';
     username = entry?.username ?? draft?.username ?? '';
-    password = entry?.password ?? draft?.password ?? '';
+    password = entry ? '' : (draft?.password ?? '');
     loadedPassword = password;
     collection = normalizeCollection(entry?.collection ?? draft?.collection ?? 'work') || 'work';
     url = entry?.url ?? draft?.url ?? '';

--- a/apps/desktop/src/lib/components/detail/FieldStack.svelte
+++ b/apps/desktop/src/lib/components/detail/FieldStack.svelte
@@ -29,8 +29,7 @@
   const normalizedUrl = $derived(entry.url?.trim() || '');
   const url = $derived(normalizedUrl || 'not_set');
   const username = $derived(entry.username.trim() || 'not_set');
-  const activePassword = $derived(entry.password ?? revealedPassword);
-  const displayedPassword = $derived(passwordRevealed ? formatInlineSecret(activePassword) : passwordMask);
+  const displayedPassword = $derived(passwordRevealed ? formatInlineSecret(revealedPassword) : passwordMask);
   const entropyBits = $derived(Math.max(72, Math.min(112, entry.title.length * 6 + entry.username.length * 4 + 48)));
   const entropyFilled = $derived(Math.max(10, Math.min(16, Math.round(entropyBits / 7))));
 
@@ -121,8 +120,8 @@
   }
 
   async function loadPassword(): Promise<string> {
-    if (activePassword) {
-      return activePassword;
+    if (revealedPassword) {
+      return revealedPassword;
     }
 
     if (passwordBusy) {

--- a/apps/desktop/src/lib/components/vault/EntryRow.svelte
+++ b/apps/desktop/src/lib/components/vault/EntryRow.svelte
@@ -107,7 +107,7 @@
     copyBusy = true;
 
     try {
-      const password = entry.password ?? (await revealEntryPassword(entry.id));
+      const password = await revealEntryPassword(entry.id);
 
       if (!password || !(await writeConfiguredClipboardText(password))) {
         return;

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -91,66 +91,82 @@ export interface Settings {
   fontSize: number;
 }
 
+/** Opens an existing vault and returns its summary metadata. */
 export function unlockVault(path: string, password: string): Promise<VaultInfo> {
   return invoke('unlock_vault', { path, password });
 }
 
+/** Locks the active vault session in the desktop backend. */
 export function lockVault(): Promise<void> {
   return invoke('lock_vault');
 }
 
+/** Creates a new vault file and opens it as the active session. */
 export function createVault(path: string, password: string, name: string): Promise<void> {
   return invoke('create_vault', { path, password, name });
 }
 
+/** Lists metadata-only entry views for the active vault. */
 export function listEntries(): Promise<EntryDto[]> {
   return invoke('list_entries');
 }
 
+/** Loads a metadata-only entry view by id. */
 export function getEntry(id: string): Promise<EntryDto> {
   return invoke('get_entry', { id });
 }
 
+/** Reveals an entry password through an explicit secret-bearing command. */
 export function revealEntryPassword(id: string): Promise<string> {
   return invoke('reveal_entry_password', { id });
 }
 
+/** Lists metadata-only revision views for an entry. */
 export function getEntryRevisions(id: string): Promise<RevisionDto[]> {
   return invoke('get_entry_revisions', { id });
 }
 
+/** Reveals a historical revision password through an explicit command. */
 export function revealEntryRevisionPassword(id: string, index: number): Promise<string> {
   return invoke('reveal_entry_revision_password', { id, index });
 }
 
+/** Creates an entry from a secret-bearing request payload. */
 export function createEntry(data: CreateEntryDto): Promise<EntryDto> {
   return invoke('create_entry', { data });
 }
 
+/** Updates an entry and omits password unless replacing it. */
 export function updateEntry(id: string, data: UpdateEntryDto): Promise<EntryDto> {
   return invoke('update_entry', { id, data });
 }
 
+/** Deletes an entry from the active vault. */
 export function deleteEntry(id: string): Promise<void> {
   return invoke('delete_entry', { id });
 }
 
+/** Searches entries and returns metadata-only entry views. */
 export function searchEntries(query: string): Promise<EntryDto[]> {
   return invoke('search_entries', { query });
 }
 
+/** Suggests local filesystem paths for vault selection. */
 export function suggestPaths(partial: string): Promise<PathSuggestion[]> {
   return invoke('suggest_paths', { partial });
 }
 
+/** Generates a password from the configured generator options. */
 export function generatePassword(config: GeneratorConfigDto): Promise<GeneratedPassword> {
   return invoke('generate_password', { config });
 }
 
+/** Loads persisted desktop settings. */
 export function getSettings(): Promise<Settings> {
   return invoke('get_settings');
 }
 
+/** Persists desktop settings. */
 export function updateSettings(settings: Settings): Promise<void> {
   return invoke('update_settings', { settings });
 }

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -16,7 +16,6 @@ export interface EntryDto {
   id: string;
   title: string;
   username: string;
-  password?: string | null;
   collection: string | null;
   url: string | null;
   notes: string | null;

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -16,7 +16,7 @@ export interface EntryDto {
   id: string;
   title: string;
   username: string;
-  password: string | null;
+  password?: string | null;
   collection: string | null;
   url: string | null;
   notes: string | null;

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -76,6 +76,10 @@ export interface GeneratedPassword {
   entropyBits: number;
 }
 
+export interface RevealedSecret {
+  secret: string;
+}
+
 export interface PathSuggestion {
   name: string;
   path: string;
@@ -117,8 +121,9 @@ export function getEntry(id: string): Promise<EntryDto> {
 }
 
 /** Reveals an entry password through an explicit secret-bearing command. */
-export function revealEntryPassword(id: string): Promise<string> {
-  return invoke('reveal_entry_password', { id });
+export async function revealEntryPassword(id: string): Promise<string> {
+  const response = await invoke<RevealedSecret>('reveal_entry_password', { id });
+  return response.secret;
 }
 
 /** Lists metadata-only revision views for an entry. */
@@ -127,8 +132,9 @@ export function getEntryRevisions(id: string): Promise<RevisionDto[]> {
 }
 
 /** Reveals a historical revision password through an explicit command. */
-export function revealEntryRevisionPassword(id: string, index: number): Promise<string> {
-  return invoke('reveal_entry_revision_password', { id, index });
+export async function revealEntryRevisionPassword(id: string, index: number): Promise<string> {
+  const response = await invoke<RevealedSecret>('reveal_entry_revision_password', { id, index });
+  return response.secret;
 }
 
 /** Creates an entry from a secret-bearing request payload. */

--- a/apps/desktop/src/lib/stores/audit.svelte.ts
+++ b/apps/desktop/src/lib/stores/audit.svelte.ts
@@ -1,4 +1,11 @@
-import { buildAuditFindings, filterAuditableEntries, scoreAudit, type AuditFinding } from '../audit';
+import {
+  buildAuditFindings,
+  filterAuditableEntries,
+  scoreAudit,
+  type AuditableEntry,
+  type AuditFinding,
+} from '../audit';
+import { revealEntryPassword, type EntryDto } from '../ipc';
 import { vaultState } from './vault.svelte';
 
 export interface AuditStateSnapshot {
@@ -13,8 +20,52 @@ export interface AuditStateSnapshot {
   score: string;
 }
 
-const auditState = $derived.by((): AuditStateSnapshot => {
+let loadedAuditState = $state<AuditStateSnapshot>(snapshotForEntries([]));
+let loadedAuditFingerprint = $state('');
+let activeRefresh = 0;
+
+export function getAuditState(): AuditStateSnapshot {
   const entries = filterAuditableEntries(vaultState.entries);
+  const fingerprint = fingerprintEntries(entries);
+
+  if (fingerprint === loadedAuditFingerprint) {
+    return loadedAuditState;
+  }
+
+  return snapshotForEntries(entries);
+}
+
+export async function refreshAuditState(): Promise<void> {
+  const entries = filterAuditableEntries(vaultState.entries);
+  const fingerprint = fingerprintEntries(entries);
+
+  if (vaultState.locked || fingerprint === loadedAuditFingerprint) {
+    return;
+  }
+
+  const refreshId = ++activeRefresh;
+  loadedAuditState = snapshotForEntries(entries);
+
+  const entriesWithPasswords = await Promise.all(
+    entries.map(async (entry): Promise<AuditableEntry> => ({
+      ...entry,
+      password: await revealEntryPassword(entry.id),
+    })),
+  );
+
+  if (
+    refreshId !== activeRefresh ||
+    vaultState.locked ||
+    fingerprint !== fingerprintEntries(filterAuditableEntries(vaultState.entries))
+  ) {
+    return;
+  }
+
+  loadedAuditState = snapshotForEntries(entriesWithPasswords);
+  loadedAuditFingerprint = fingerprint;
+}
+
+function snapshotForEntries(entries: AuditableEntry[]): AuditStateSnapshot {
   const findings = buildAuditFindings(entries);
   const highCount = findings.filter((finding) => finding.severity === 'high').length;
   const mediumCount = findings.filter((finding) => finding.severity === 'medium').length;
@@ -33,8 +84,10 @@ const auditState = $derived.by((): AuditStateSnapshot => {
     healthyCount,
     score: scoreAudit(entries.length, healthyCount),
   };
-});
+}
 
-export function getAuditState(): AuditStateSnapshot {
-  return auditState;
+function fingerprintEntries(entries: EntryDto[]): string {
+  return `${vaultState.vaultPath}::${entries
+    .map((entry) => `${entry.id}:${entry.updatedAt}:${entry.revisionCount}`)
+    .join('|')}`;
 }

--- a/packages/vault-api/Cargo.toml
+++ b/packages/vault-api/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
-vault-core = { path = "../vault-core" }
 zeroize = { version = "1", features = ["serde"] }
 
 [dev-dependencies]

--- a/packages/vault-api/Cargo.toml
+++ b/packages/vault-api/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vault-api"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+thiserror = "2"
+vault-core = { path = "../vault-core" }
+zeroize = { version = "1", features = ["serde"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/packages/vault-api/src/lib.rs
+++ b/packages/vault-api/src/lib.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use zeroize::Zeroizing;
 
 /// Plaintext value that may cross a public API boundary only through explicit
@@ -47,15 +47,6 @@ impl From<String> for SecretString {
 impl From<&str> for SecretString {
     fn from(value: &str) -> Self {
         Self::new(value)
-    }
-}
-
-impl Serialize for SecretString {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(self.expose_secret())
     }
 }
 
@@ -186,6 +177,35 @@ pub struct GeneratorParams {
     pub mode: Option<GeneratorMode>,
 }
 
+#[derive(Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RevealedSecret {
+    pub secret: String,
+}
+
+impl RevealedSecret {
+    /// Builds an explicit response for intentional secret reveal operations.
+    pub fn new(secret: impl Into<String>) -> Self {
+        Self {
+            secret: secret.into(),
+        }
+    }
+}
+
+impl From<SecretString> for RevealedSecret {
+    fn from(secret: SecretString) -> Self {
+        Self::new(secret.into_inner())
+    }
+}
+
+impl fmt::Debug for RevealedSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RevealedSecret")
+            .field("secret", &"[secret]")
+            .finish()
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum GeneratorMode {
@@ -193,10 +213,10 @@ pub enum GeneratorMode {
     Passphrase,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Clone, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct GeneratedSecret {
-    pub password: SecretString,
+    pub password: String,
     pub entropy_bits: f64,
 }
 
@@ -204,9 +224,18 @@ impl GeneratedSecret {
     /// Builds a generated secret response with its entropy estimate.
     pub fn new(password: impl Into<String>, entropy_bits: f64) -> Self {
         Self {
-            password: SecretString::new(password),
+            password: password.into(),
             entropy_bits,
         }
+    }
+}
+
+impl fmt::Debug for GeneratedSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GeneratedSecret")
+            .field("password", &"[secret]")
+            .field("entropy_bits", &self.entropy_bits)
+            .finish()
     }
 }
 
@@ -329,7 +358,8 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        CreateEntryRequest, EntryMutation, EntryView, GeneratedSecret, RevisionView, SecretString,
+        CreateEntryRequest, EntryMutation, EntryView, GeneratedSecret, RevealedSecret,
+        RevisionView, SecretString,
     };
 
     #[test]
@@ -377,15 +407,37 @@ mod tests {
     }
 
     #[test]
-    fn secret_string_serializes_but_redacts_debug_and_display() {
+    fn secret_string_redacts_debug_and_display() {
         let secret = unique_test_secret();
         let value = SecretString::new(secret.clone());
 
-        let json = serde_json::to_string(&value).expect("secret string should serialize");
-
-        assert_eq!(json, format!("\"{secret}\""));
         assert_eq!(format!("{value:?}"), "[secret]");
         assert_eq!(value.to_string(), "[secret]");
+    }
+
+    #[test]
+    fn revealed_secret_serializes_only_through_explicit_response_type() {
+        let secret = unique_test_secret();
+        let response = RevealedSecret::new(secret.clone());
+
+        let json = serde_json::to_string(&response).expect("revealed secret should serialize");
+
+        assert_eq!(json, format!("{{\"secret\":\"{secret}\"}}"));
+        assert!(!format!("{response:?}").contains(secret.as_str()));
+    }
+
+    #[test]
+    fn generated_secret_serializes_only_through_explicit_response_type() {
+        let secret = unique_test_secret();
+        let generated = GeneratedSecret::new(secret.clone(), 128.0);
+
+        let json = serde_json::to_string(&generated).expect("generated secret should serialize");
+
+        assert_eq!(
+            json,
+            format!("{{\"password\":\"{secret}\",\"entropyBits\":128.0}}")
+        );
+        assert!(!format!("{generated:?}").contains(secret.as_str()));
     }
 
     #[test]

--- a/packages/vault-api/src/lib.rs
+++ b/packages/vault-api/src/lib.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use zeroize::Zeroizing;
 
@@ -9,14 +10,17 @@ use zeroize::Zeroizing;
 pub struct SecretString(Zeroizing<String>);
 
 impl SecretString {
+    /// Wraps a plaintext value for explicit secret-bearing API calls.
     pub fn new(value: impl Into<String>) -> Self {
         Self(Zeroizing::new(value.into()))
     }
 
+    /// Returns the plaintext value for the narrow adapter boundary that needs it.
     pub fn expose_secret(&self) -> &str {
         self.0.as_str()
     }
 
+    /// Consumes the wrapper and returns plaintext for core mutation calls.
     pub fn into_inner(self) -> String {
         self.0.to_string()
     }
@@ -74,6 +78,7 @@ pub struct VaultSummary {
 }
 
 impl VaultSummary {
+    /// Builds vault metadata returned after creating or unlocking a vault.
     pub fn new(
         name: impl Into<String>,
         path: impl Into<String>,
@@ -151,10 +156,21 @@ pub struct EntryMutation {
     pub title: Option<String>,
     pub username: Option<String>,
     pub password: Option<SecretString>,
+    #[serde(default, deserialize_with = "deserialize_present_nullable")]
     pub collection: Option<Option<String>>,
+    #[serde(default, deserialize_with = "deserialize_present_nullable")]
     pub url: Option<Option<String>>,
+    #[serde(default, deserialize_with = "deserialize_present_nullable")]
     pub notes: Option<Option<String>>,
     pub tags: Option<Vec<String>>,
+}
+
+fn deserialize_present_nullable<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: DeserializeOwned,
+{
+    Option::<T>::deserialize(deserializer).map(Some)
 }
 
 #[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
@@ -184,6 +200,7 @@ pub struct GeneratedSecret {
 }
 
 impl GeneratedSecret {
+    /// Builds a generated secret response with its entropy estimate.
     pub fn new(password: impl Into<String>, entropy_bits: f64) -> Self {
         Self {
             password: SecretString::new(password),
@@ -261,6 +278,7 @@ pub struct ApiError {
 }
 
 impl ApiError {
+    /// Builds a portable API error with a stable machine-readable code.
     pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
         Self {
             code,
@@ -302,22 +320,6 @@ impl fmt::Display for ErrorCode {
         };
 
         f.write_str(code)
-    }
-}
-
-impl From<vault_core::VaultError> for ApiError {
-    fn from(error: vault_core::VaultError) -> Self {
-        let code = match error {
-            vault_core::VaultError::InvalidPassword => ErrorCode::InvalidPassword,
-            vault_core::VaultError::FileNotFound(_) => ErrorCode::FileNotFound,
-            vault_core::VaultError::CorruptedVault => ErrorCode::CorruptedVault,
-            vault_core::VaultError::EncryptionError(_) => ErrorCode::EncryptionError,
-            vault_core::VaultError::DecryptionError(_) => ErrorCode::DecryptionError,
-            vault_core::VaultError::IoError(_) => ErrorCode::IoError,
-            vault_core::VaultError::SerializationError(_) => ErrorCode::SerializationError,
-        };
-
-        Self::new(code, error.to_string())
     }
 }
 
@@ -424,6 +426,39 @@ mod tests {
         };
 
         assert!(!format!("{mutation:?}").contains(secret.as_str()));
+    }
+
+    #[test]
+    fn entry_mutation_omitted_metadata_fields_leave_values_unchanged() {
+        let mutation: EntryMutation =
+            serde_json::from_str("{}").expect("empty mutation should deserialize");
+
+        assert_eq!(mutation.collection, None);
+        assert_eq!(mutation.url, None);
+        assert_eq!(mutation.notes, None);
+    }
+
+    #[test]
+    fn entry_mutation_explicit_null_metadata_fields_clear_values() {
+        let mutation: EntryMutation =
+            serde_json::from_str(r#"{"collection":null,"url":null,"notes":null}"#)
+                .expect("null metadata mutation should deserialize");
+
+        assert_eq!(mutation.collection, Some(None));
+        assert_eq!(mutation.url, Some(None));
+        assert_eq!(mutation.notes, Some(None));
+    }
+
+    #[test]
+    fn entry_mutation_present_metadata_fields_replace_values() {
+        let mutation: EntryMutation = serde_json::from_str(
+            r#"{"collection":"work","url":"https://example.test","notes":"notes"}"#,
+        )
+        .expect("present metadata mutation should deserialize");
+
+        assert_eq!(mutation.collection, Some(Some("work".to_string())));
+        assert_eq!(mutation.url, Some(Some("https://example.test".to_string())));
+        assert_eq!(mutation.notes, Some(Some("notes".to_string())));
     }
 
     fn unique_test_secret() -> String {

--- a/packages/vault-api/src/lib.rs
+++ b/packages/vault-api/src/lib.rs
@@ -1,0 +1,441 @@
+use core::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use zeroize::Zeroizing;
+
+/// Plaintext value that may cross a public API boundary only through explicit
+/// secret-bearing operations.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SecretString(Zeroizing<String>);
+
+impl SecretString {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(Zeroizing::new(value.into()))
+    }
+
+    pub fn expose_secret(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl fmt::Debug for SecretString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[secret]")
+    }
+}
+
+impl fmt::Display for SecretString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[secret]")
+    }
+}
+
+impl From<String> for SecretString {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<&str> for SecretString {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Serialize for SecretString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.expose_secret())
+    }
+}
+
+impl<'de> Deserialize<'de> for SecretString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(Self::new)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultSummary {
+    pub name: String,
+    pub path: String,
+    pub entry_count: usize,
+    pub modified_at: String,
+}
+
+impl VaultSummary {
+    pub fn new(
+        name: impl Into<String>,
+        path: impl Into<String>,
+        entry_count: usize,
+        modified_at: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            path: path.into(),
+            entry_count,
+            modified_at: modified_at.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EntryView {
+    pub id: String,
+    pub title: String,
+    pub username: String,
+    pub collection: Option<String>,
+    pub url: Option<String>,
+    pub notes: Option<String>,
+    pub tags: Vec<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub revision_count: usize,
+}
+
+#[derive(Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RevisionView {
+    pub captured_at: String,
+    pub updated_at: String,
+    pub title: String,
+    pub username: String,
+    pub collection: Option<String>,
+    pub url: Option<String>,
+    pub notes: Option<String>,
+    pub tags: Vec<String>,
+    pub password_changed: bool,
+}
+
+impl fmt::Debug for RevisionView {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RevisionView")
+            .field("captured_at", &self.captured_at)
+            .field("updated_at", &self.updated_at)
+            .field("title", &self.title)
+            .field("username", &self.username)
+            .field("collection", &self.collection)
+            .field("url", &self.url)
+            .field("notes", &self.notes)
+            .field("tags", &self.tags)
+            .field("password_changed", &self.password_changed)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct CreateEntryRequest {
+    pub title: String,
+    pub username: String,
+    pub password: SecretString,
+    pub collection: Option<String>,
+    pub url: Option<String>,
+    pub notes: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+pub struct EntryMutation {
+    pub title: Option<String>,
+    pub username: Option<String>,
+    pub password: Option<SecretString>,
+    pub collection: Option<Option<String>>,
+    pub url: Option<Option<String>>,
+    pub notes: Option<Option<String>>,
+    pub tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GeneratorParams {
+    pub length: Option<usize>,
+    pub uppercase: Option<bool>,
+    pub lowercase: Option<bool>,
+    pub digits: Option<bool>,
+    pub symbols: Option<bool>,
+    pub exclude_ambiguous: Option<bool>,
+    pub mode: Option<GeneratorMode>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum GeneratorMode {
+    Random,
+    Passphrase,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct GeneratedSecret {
+    pub password: SecretString,
+    pub entropy_bits: f64,
+}
+
+impl GeneratedSecret {
+    pub fn new(password: impl Into<String>, entropy_bits: f64) -> Self {
+        Self {
+            password: SecretString::new(password),
+            entropy_bits,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ClientKind {
+    DesktopApp,
+    BrowserExtension,
+    IosApp,
+    AndroidApp,
+    IosAutofillExtension,
+    AndroidAutofillService,
+    FutureSyncServer,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum Capability {
+    Unlock,
+    ReadMeta,
+    RevealSecret,
+    CopySecret,
+    MutateEntry,
+    CreateVault,
+    ChangeKdf,
+    ExportPlaintext,
+    ExportKdbx,
+    ReadHistory,
+    DeletePermanent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum AuditSeverity {
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum AuditFindingKind {
+    WeakPassword,
+    ReusedPassword,
+    InsecureUrl,
+    DuplicateUrl,
+    DuplicateUsername,
+    StaleEntry,
+    MissingUrl,
+    MissingCollection,
+    Untagged,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditFinding {
+    pub key: String,
+    pub severity: AuditSeverity,
+    pub kind: AuditFindingKind,
+    pub entry_id: String,
+    pub meta: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
+#[serde(rename_all = "camelCase")]
+#[error("{code}: {message}")]
+pub struct ApiError {
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+impl ApiError {
+    pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    InvalidPassword,
+    FileNotFound,
+    CorruptedVault,
+    EncryptionError,
+    DecryptionError,
+    IoError,
+    SerializationError,
+    VaultLocked,
+    NotFound,
+    InvalidInput,
+    CapabilityDenied,
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let code = match self {
+            Self::InvalidPassword => "invalid_password",
+            Self::FileNotFound => "file_not_found",
+            Self::CorruptedVault => "corrupted_vault",
+            Self::EncryptionError => "encryption_error",
+            Self::DecryptionError => "decryption_error",
+            Self::IoError => "io_error",
+            Self::SerializationError => "serialization_error",
+            Self::VaultLocked => "vault_locked",
+            Self::NotFound => "not_found",
+            Self::InvalidInput => "invalid_input",
+            Self::CapabilityDenied => "capability_denied",
+        };
+
+        f.write_str(code)
+    }
+}
+
+impl From<vault_core::VaultError> for ApiError {
+    fn from(error: vault_core::VaultError) -> Self {
+        let code = match error {
+            vault_core::VaultError::InvalidPassword => ErrorCode::InvalidPassword,
+            vault_core::VaultError::FileNotFound(_) => ErrorCode::FileNotFound,
+            vault_core::VaultError::CorruptedVault => ErrorCode::CorruptedVault,
+            vault_core::VaultError::EncryptionError(_) => ErrorCode::EncryptionError,
+            vault_core::VaultError::DecryptionError(_) => ErrorCode::DecryptionError,
+            vault_core::VaultError::IoError(_) => ErrorCode::IoError,
+            vault_core::VaultError::SerializationError(_) => ErrorCode::SerializationError,
+        };
+
+        Self::new(code, error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::{
+        CreateEntryRequest, EntryMutation, EntryView, GeneratedSecret, RevisionView, SecretString,
+    };
+
+    #[test]
+    fn entry_view_serialization_excludes_current_and_revision_passwords() {
+        let secret = test_credential("current");
+        let view = EntryView {
+            id: "entry-id".to_string(),
+            title: "GitHub".to_string(),
+            username: "arca".to_string(),
+            collection: Some("work".to_string()),
+            url: Some("https://github.com".to_string()),
+            notes: Some("fixture notes".to_string()),
+            tags: vec!["dev".to_string()],
+            created_at: "2026-09-01T00:00:00+00:00".to_string(),
+            updated_at: "2026-09-01T00:00:00+00:00".to_string(),
+            revision_count: 1,
+        };
+        let json = serde_json::to_string(&view).expect("entry view should serialize");
+        let debug = format!("{view:?}");
+
+        assert!(!json.contains("\"password\""));
+        assert!(!json.contains(secret.as_str()));
+        assert!(!debug.contains(secret.as_str()));
+        assert_eq!(view.revision_count, 1);
+    }
+
+    #[test]
+    fn revision_view_serialization_and_debug_exclude_password() {
+        let historical = test_credential("historical");
+        let view = RevisionView {
+            captured_at: "2026-09-01T00:00:00+00:00".to_string(),
+            updated_at: "2026-09-01T00:00:00+00:00".to_string(),
+            title: "GitHub".to_string(),
+            username: "arca".to_string(),
+            collection: Some("work".to_string()),
+            url: Some("https://github.com".to_string()),
+            notes: Some("fixture notes".to_string()),
+            tags: vec!["dev".to_string()],
+            password_changed: true,
+        };
+
+        let json = serde_json::to_string(&view).expect("revision view should serialize");
+        let debug = format!("{view:?}");
+
+        assert!(!json.contains("\"password\""));
+        assert!(!json.contains(historical.as_str()));
+        assert!(!debug.contains(historical.as_str()));
+        assert!(view.password_changed);
+    }
+
+    #[test]
+    fn secret_string_serializes_but_redacts_debug_and_display() {
+        let secret = test_credential("secret");
+        let value = SecretString::new(secret.clone());
+
+        let json = serde_json::to_string(&value).expect("secret string should serialize");
+
+        assert_eq!(json, format!("\"{secret}\""));
+        assert_eq!(format!("{value:?}"), "[secret]");
+        assert_eq!(value.to_string(), "[secret]");
+    }
+
+    #[test]
+    fn secret_bearing_request_debug_output_is_redacted() {
+        let secret = test_credential("request");
+        let request = CreateEntryRequest {
+            title: "GitHub".to_string(),
+            username: "arca".to_string(),
+            password: SecretString::new(secret.clone()),
+            collection: None,
+            url: None,
+            notes: None,
+            tags: Vec::new(),
+        };
+        let mutation = EntryMutation {
+            password: Some(SecretString::new(secret.clone())),
+            ..EntryMutation::default()
+        };
+
+        assert!(!format!("{request:?}").contains(secret.as_str()));
+        assert!(!format!("{mutation:?}").contains(secret.as_str()));
+    }
+
+    #[test]
+    fn generated_secret_debug_output_is_redacted() {
+        let secret = test_credential("generated");
+        let generated = GeneratedSecret::new(secret.clone(), 128.0);
+
+        assert!(!format!("{generated:?}").contains(secret.as_str()));
+    }
+
+    #[test]
+    fn entry_mutation_debug_output_is_redacted() {
+        let secret = test_credential("patch");
+        let mutation = EntryMutation {
+            title: Some("GitHub".to_string()),
+            password: Some(SecretString::new(secret.clone())),
+            ..EntryMutation::default()
+        };
+
+        assert!(!format!("{mutation:?}").contains(secret.as_str()));
+    }
+
+    fn test_credential(label: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+
+        format!("test-credential-{label}-{nanos}")
+    }
+}

--- a/packages/vault-api/src/lib.rs
+++ b/packages/vault-api/src/lib.rs
@@ -331,7 +331,6 @@ mod tests {
 
     #[test]
     fn entry_view_serialization_excludes_current_and_revision_passwords() {
-        let secret = test_credential("current");
         let view = EntryView {
             id: "entry-id".to_string(),
             title: "GitHub".to_string(),
@@ -348,14 +347,12 @@ mod tests {
         let debug = format!("{view:?}");
 
         assert!(!json.contains("\"password\""));
-        assert!(!json.contains(secret.as_str()));
-        assert!(!debug.contains(secret.as_str()));
+        assert!(!debug.contains("password"));
         assert_eq!(view.revision_count, 1);
     }
 
     #[test]
     fn revision_view_serialization_and_debug_exclude_password() {
-        let historical = test_credential("historical");
         let view = RevisionView {
             captured_at: "2026-09-01T00:00:00+00:00".to_string(),
             updated_at: "2026-09-01T00:00:00+00:00".to_string(),
@@ -372,14 +369,13 @@ mod tests {
         let debug = format!("{view:?}");
 
         assert!(!json.contains("\"password\""));
-        assert!(!json.contains(historical.as_str()));
-        assert!(!debug.contains(historical.as_str()));
+        assert!(!debug.contains("\"password\""));
         assert!(view.password_changed);
     }
 
     #[test]
     fn secret_string_serializes_but_redacts_debug_and_display() {
-        let secret = test_credential("secret");
+        let secret = unique_test_secret();
         let value = SecretString::new(secret.clone());
 
         let json = serde_json::to_string(&value).expect("secret string should serialize");
@@ -391,7 +387,7 @@ mod tests {
 
     #[test]
     fn secret_bearing_request_debug_output_is_redacted() {
-        let secret = test_credential("request");
+        let secret = unique_test_secret();
         let request = CreateEntryRequest {
             title: "GitHub".to_string(),
             username: "arca".to_string(),
@@ -412,7 +408,7 @@ mod tests {
 
     #[test]
     fn generated_secret_debug_output_is_redacted() {
-        let secret = test_credential("generated");
+        let secret = unique_test_secret();
         let generated = GeneratedSecret::new(secret.clone(), 128.0);
 
         assert!(!format!("{generated:?}").contains(secret.as_str()));
@@ -420,7 +416,7 @@ mod tests {
 
     #[test]
     fn entry_mutation_debug_output_is_redacted() {
-        let secret = test_credential("patch");
+        let secret = unique_test_secret();
         let mutation = EntryMutation {
             title: Some("GitHub".to_string()),
             password: Some(SecretString::new(secret.clone())),
@@ -430,12 +426,12 @@ mod tests {
         assert!(!format!("{mutation:?}").contains(secret.as_str()));
     }
 
-    fn test_credential(label: &str) -> String {
+    fn unique_test_secret() -> String {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system clock should be after unix epoch")
             .as_nanos();
 
-        format!("test-credential-{label}-{nanos}")
+        nanos.to_string()
     }
 }

--- a/packages/vault-api/src/lib.rs
+++ b/packages/vault-api/src/lib.rs
@@ -165,6 +165,7 @@ pub struct EntryMutation {
     pub tags: Option<Vec<String>>,
 }
 
+/// Preserves the difference between an omitted field and explicit JSON `null`.
 fn deserialize_present_nullable<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
 where
     D: Deserializer<'de>,


### PR DESCRIPTION
# Description

Introduces `packages/vault-api` as Arca's public Rust contract crate and moves the desktop Tauri command layer onto those DTOs.

Closes #224.

## Security Checklist

- [x] No secrets, keys, passwords, vault contents, or generated credentials are hardcoded or logged
- [x] No new `unsafe` blocks without justification and human review
- [x] Cryptographic changes reviewed against the threat model
- [x] OSV/RustSec scan passes with no new vulnerabilities introduced
- [x] Changes touching `packages/vault-core`, Tauri IPC, or secret display/copy flows are marked for human review

Security notes:

- `EntryView` and `RevisionView` remain metadata-only and never carry password material.
- Explicit secret-bearing paths use `SecretString`, which redacts `Debug` and `Display`.
- `vault-api` no longer depends on `vault-core`; desktop owns the adapter mapping from core errors to public error codes.
- `EntryMutation` preserves omitted fields as unchanged and explicit JSON `null` as metadata clearing.

## Testing

- [x] Unit tests added/updated
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `pnpm build`
- [ ] Tested locally on target platform when UI or Tauri behavior changed

Additional validation:

- [x] `cargo fmt --all --check`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `git -c core.fsmonitor=false diff --check`

## Agent-Assisted Changes

- [x] AI-generated or AI-edited code was reviewed line by line by a human
- [x] `AGENTS.md` files remain accurate after this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Enhancements**
  - Passwords are excluded from entry lists, search results, and serialized entry data.
  - Editing an entry no longer pre-fills its existing password.
  - Viewing or copying a saved password requires an explicit reveal action.
  - Secret values are redacted in diagnostic output.

- **Audit**
  - Password-based checks continue to work when password data is explicitly loaded.
  - Audit findings refresh automatically when vault entries change, with errors shown when refresh fails.

- **Consistency**
  - Vault errors use standardized error codes across the desktop application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->