### PR TITLE
security: tune codeql fuzz analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: "Arca CodeQL config"
+
+# Fuzz targets intentionally build deterministic, non-secret credentials from
+# generated input. They are exercised by the dedicated fuzz workflow instead of
+# regular CodeQL analysis, which otherwise reports fixture values as production
+# hard-coded cryptographic material.
+paths-ignore:
+  - "packages/vault-core/fuzz/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
       - if: matrix.build-mode == 'autobuild'
         uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938
       - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938

--- a/packages/vault-core/fuzz/README.md
+++ b/packages/vault-core/fuzz/README.md
@@ -12,6 +12,10 @@ cargo install cargo-fuzz --version 0.13.2 --locked
 The GitHub fuzzing workflow pins the same reviewed `cargo-fuzz` version so
 scheduled runs stay reproducible across runner releases.
 
+The fuzz harness is excluded from regular CodeQL analysis because it builds
+deterministic, non-secret credentials from generated input. Keep real secrets
+out of fuzz corpora and use the dedicated fuzz workflow for this path.
+
 ## Run
 
 From `packages/vault-core`:


### PR DESCRIPTION
## Summary

- add a repo CodeQL config file
- wire the CodeQL workflow to use the config
- exclude `packages/vault-core/fuzz/**` from regular CodeQL analysis because the fuzz harness uses generated, deterministic, non-secret credentials
- document the rationale in the fuzz README

## Notes

The existing `rust/hard-coded-cryptographic-value` query remains enabled for production Rust code. The current hard-coded crypto alerts were triaged and dismissed separately as test/fuzz fixtures or a Tauri macro false positive.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeql.yml"); YAML.load_file(".github/codeql/codeql-config.yml"); puts "yaml ok"'`
- `git -c core.fsmonitor=false diff --check`
