### PR TITLE
test: add vault-api contract fixtures

### DIFF
--- a/packages/vault-api/src/lib.rs
+++ b/packages/vault-api/src/lib.rs
@@ -59,7 +59,42 @@ impl<'de> Deserialize<'de> for SecretString {
     }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub const KDBX_FORMAT_VERSION: u16 = 4;
+pub const ARCA_SEMANTICS_VERSION: u16 = 1;
+pub const CLIENT_PROTOCOL_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ContractVersions {
+    pub kdbx_format_version: u16,
+    pub arca_semantics_version: u16,
+    pub client_protocol_version: u16,
+}
+
+impl ContractVersions {
+    /// Returns the currently supported public contract version tuple.
+    pub fn current() -> Self {
+        Self {
+            kdbx_format_version: KDBX_FORMAT_VERSION,
+            arca_semantics_version: ARCA_SEMANTICS_VERSION,
+            client_protocol_version: CLIENT_PROTOCOL_VERSION,
+        }
+    }
+
+    /// Rejects writer paths that would rewrite newer Arca semantics.
+    pub fn ensure_writer_supported(&self) -> Result<(), ApiError> {
+        if self.arca_semantics_version > ARCA_SEMANTICS_VERSION {
+            return Err(ApiError::new(
+                ErrorCode::InvalidInput,
+                "unsupported future Arca semantics version",
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct VaultSummary {
     pub name: String,
@@ -85,7 +120,7 @@ impl VaultSummary {
     }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct EntryView {
     pub id: String,
@@ -100,7 +135,7 @@ pub struct EntryView {
     pub revision_count: usize,
 }
 
-#[derive(Clone, Serialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct RevisionView {
     pub captured_at: String,
@@ -165,7 +200,7 @@ where
     Option::<T>::deserialize(deserializer).map(Some)
 }
 
-#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct GeneratorParams {
     pub length: Option<usize>,
@@ -206,7 +241,7 @@ impl fmt::Debug for RevealedSecret {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum GeneratorMode {
     Random,

--- a/packages/vault-api/tests/contract_fixtures.rs
+++ b/packages/vault-api/tests/contract_fixtures.rs
@@ -1,0 +1,269 @@
+use std::fs;
+use std::path::PathBuf;
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use vault_api::{
+    ApiError, AuditFinding, AuditFindingKind, AuditSeverity, Capability, ClientKind,
+    ContractVersions, EntryMutation, EntryView, ErrorCode, GeneratorMode, GeneratorParams,
+    RevisionView, VaultSummary,
+};
+
+#[test]
+fn contract_versions_match_golden_fixture() {
+    assert_fixture("contract_versions.json", &ContractVersions::current());
+}
+
+#[test]
+fn vault_summary_matches_golden_fixture() {
+    let summary = VaultSummary::new(
+        "vault.local",
+        "/tmp/arca/vault.local.kdbx",
+        3,
+        "2026-09-02T00:00:00+00:00",
+    );
+
+    assert_fixture("vault_summary.json", &summary);
+    assert_round_trip("vault_summary.json", summary);
+}
+
+#[test]
+fn entry_view_matches_golden_fixture_without_secret_fields() {
+    let view = EntryView {
+        id: "entry-0001".to_string(),
+        title: "GitHub".to_string(),
+        username: "arca-admin".to_string(),
+        collection: Some("work".to_string()),
+        url: Some("https://github.com".to_string()),
+        notes: Some("Non-secret fixture notes".to_string()),
+        tags: vec!["work".to_string(), "ssh".to_string()],
+        created_at: "2026-09-01T00:00:00+00:00".to_string(),
+        updated_at: "2026-09-02T00:00:00+00:00".to_string(),
+        revision_count: 2,
+    };
+
+    assert_fixture("entry_view.json", &view);
+    assert_round_trip("entry_view.json", view);
+    assert_fixture_has_no_secret_fields("entry_view.json");
+}
+
+#[test]
+fn archived_entry_view_matches_golden_fixture_without_secret_fields() {
+    let view = EntryView {
+        id: "entry-archived-0001".to_string(),
+        title: "Archived Entry".to_string(),
+        username: "archived-user".to_string(),
+        collection: Some("archive".to_string()),
+        url: None,
+        notes: None,
+        tags: Vec::new(),
+        created_at: "2026-09-01T00:00:00+00:00".to_string(),
+        updated_at: "2026-09-02T00:00:00+00:00".to_string(),
+        revision_count: 0,
+    };
+
+    assert_fixture("archived_entry_view.json", &view);
+    assert_round_trip("archived_entry_view.json", view);
+    assert_fixture_has_no_secret_fields("archived_entry_view.json");
+}
+
+#[test]
+fn revision_view_matches_golden_fixture_without_secret_fields() {
+    let view = RevisionView {
+        captured_at: "2026-09-03T00:00:00+00:00".to_string(),
+        updated_at: "2026-09-02T00:00:00+00:00".to_string(),
+        title: "GitHub".to_string(),
+        username: "arca-admin".to_string(),
+        collection: Some("work".to_string()),
+        url: Some("https://github.com".to_string()),
+        notes: Some("Previous non-secret fixture notes".to_string()),
+        tags: vec!["work".to_string(), "ssh".to_string()],
+        password_changed: true,
+    };
+
+    assert_fixture("revision_view.json", &view);
+    assert_round_trip("revision_view.json", view);
+    assert_fixture_has_no_secret_fields("revision_view.json");
+}
+
+#[test]
+fn generator_params_match_golden_fixture() {
+    let params = GeneratorParams {
+        length: Some(24),
+        uppercase: Some(true),
+        lowercase: Some(true),
+        digits: Some(true),
+        symbols: Some(true),
+        exclude_ambiguous: Some(false),
+        mode: Some(GeneratorMode::Random),
+    };
+
+    assert_fixture("generator_params.json", &params);
+    assert_round_trip("generator_params.json", params);
+}
+
+#[test]
+fn audit_finding_matches_golden_fixture() {
+    let finding = AuditFinding {
+        key: "duplicate-url:entry-0001".to_string(),
+        severity: AuditSeverity::Medium,
+        kind: AuditFindingKind::DuplicateUrl,
+        entry_id: "entry-0001".to_string(),
+        meta: "https://example.test".to_string(),
+    };
+
+    assert_fixture("audit_finding.json", &finding);
+    assert_round_trip("audit_finding.json", finding);
+}
+
+#[test]
+fn api_error_matches_golden_fixture() {
+    let error = ApiError::new(ErrorCode::CapabilityDenied, "client cannot reveal secrets");
+
+    assert_fixture("api_error.json", &error);
+    assert_round_trip("api_error.json", error);
+}
+
+#[test]
+fn capability_fixture_round_trips() {
+    let fixture = ClientCapabilityFixture {
+        client_kind: ClientKind::BrowserExtension,
+        capabilities: vec![
+            Capability::Unlock,
+            Capability::ReadMeta,
+            Capability::CopySecret,
+        ],
+    };
+
+    assert_fixture("client_capabilities.json", &fixture);
+    assert_round_trip("client_capabilities.json", fixture);
+}
+
+#[test]
+fn entry_mutation_fixture_preserves_omitted_nullable_fields() {
+    let mutation: EntryMutation = read_fixture_json("entry_mutation_omitted_nullable.json");
+
+    assert_eq!(mutation.title.as_deref(), Some("GitHub"));
+    assert_eq!(mutation.username.as_deref(), Some("arca-admin"));
+    assert_eq!(mutation.collection, None);
+    assert_eq!(mutation.url, None);
+    assert_eq!(mutation.notes, None);
+    assert_eq!(
+        mutation.tags,
+        Some(vec!["work".to_string(), "ssh".to_string()])
+    );
+}
+
+#[test]
+fn entry_mutation_fixture_preserves_explicit_nullable_clears() {
+    let mutation: EntryMutation = read_fixture_json("entry_mutation_clear_nullable.json");
+
+    assert_eq!(mutation.collection, Some(None));
+    assert_eq!(mutation.url, Some(None));
+    assert_eq!(mutation.notes, Some(None));
+    assert_eq!(mutation.tags, Some(Vec::new()));
+}
+
+#[test]
+fn non_secret_response_dtos_ignore_unknown_fields() {
+    let json = r#"{
+      "id": "entry-0001",
+      "title": "GitHub",
+      "username": "arca-admin",
+      "collection": "work",
+      "url": "https://github.com",
+      "notes": "Non-secret fixture notes",
+      "tags": ["work", "ssh"],
+      "createdAt": "2026-09-01T00:00:00+00:00",
+      "updatedAt": "2026-09-02T00:00:00+00:00",
+      "revisionCount": 2,
+      "futureClientField": "ignored"
+    }"#;
+
+    let view = serde_json::from_str::<EntryView>(json)
+        .expect("entry response should ignore unknown future fields");
+
+    assert_eq!(view.title, "GitHub");
+    assert_eq!(view.revision_count, 2);
+}
+
+#[test]
+fn unknown_future_enum_values_fail_closed() {
+    let error = serde_json::from_str::<ClientKind>(r#""watchApp""#)
+        .expect_err("unknown client kind should not deserialize silently");
+
+    assert!(error.to_string().contains("unknown variant"));
+}
+
+#[test]
+fn newer_arca_semantics_versions_fail_closed_for_writers() {
+    let versions: ContractVersions = read_fixture_json("unsupported_future_versions.json");
+    let error = versions
+        .ensure_writer_supported()
+        .expect_err("future Arca semantics version should fail closed for writer paths");
+
+    assert_eq!(error.code, ErrorCode::InvalidInput);
+    assert!(error.message.contains("unsupported future Arca semantics"));
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct ClientCapabilityFixture {
+    client_kind: ClientKind,
+    capabilities: Vec<Capability>,
+}
+
+fn assert_fixture<T>(name: &str, value: &T)
+where
+    T: Serialize,
+{
+    let expected = read_fixture(name);
+    let actual =
+        serde_json::to_string_pretty(value).expect("contract fixture should serialize") + "\n";
+
+    assert_eq!(
+        actual, expected,
+        "{name} drifted from the checked-in fixture"
+    );
+}
+
+fn assert_round_trip<T>(name: &str, value: T)
+where
+    T: DeserializeOwned + PartialEq + std::fmt::Debug,
+{
+    let decoded: T = read_fixture_json(name);
+
+    assert_eq!(decoded, value, "{name} did not round-trip");
+}
+
+fn assert_fixture_has_no_secret_fields(name: &str) {
+    let value: serde_json::Value = read_fixture_json(name);
+    let object = value.as_object().expect("fixture should be a JSON object");
+
+    assert!(
+        !object.contains_key("password") && !object.contains_key("secret"),
+        "{name} must not expose secret-bearing fields"
+    );
+}
+
+fn read_fixture_json<T>(name: &str) -> T
+where
+    T: DeserializeOwned,
+{
+    let json = read_fixture(name);
+
+    serde_json::from_str(&json).expect("fixture should deserialize")
+}
+
+fn read_fixture(name: &str) -> String {
+    let contents = fs::read_to_string(fixture_path(name)).expect("fixture should be readable");
+
+    contents.trim_end().to_string() + "\n"
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}

--- a/packages/vault-api/tests/fixtures/README.md
+++ b/packages/vault-api/tests/fixtures/README.md
@@ -1,0 +1,14 @@
+# vault-api contract fixtures
+
+These JSON files are deterministic public-contract fixtures. They are used by
+`cargo test --workspace` to detect accidental DTO drift.
+
+Rules:
+
+- Do not store real vault data, real credentials, recovery material, or copied
+  secrets in fixtures.
+- Non-secret DTO fixtures must not contain secret-bearing fields.
+- Secret-bearing request and response types are tested separately with runtime
+  values so static analysis does not confuse fixture text with production
+  credentials.
+

--- a/packages/vault-api/tests/fixtures/api_error.json
+++ b/packages/vault-api/tests/fixtures/api_error.json
@@ -1,0 +1,5 @@
+{
+  "code": "capability_denied",
+  "message": "client cannot reveal secrets"
+}
+

--- a/packages/vault-api/tests/fixtures/archived_entry_view.json
+++ b/packages/vault-api/tests/fixtures/archived_entry_view.json
@@ -1,0 +1,13 @@
+{
+  "id": "entry-archived-0001",
+  "title": "Archived Entry",
+  "username": "archived-user",
+  "collection": "archive",
+  "url": null,
+  "notes": null,
+  "tags": [],
+  "createdAt": "2026-09-01T00:00:00+00:00",
+  "updatedAt": "2026-09-02T00:00:00+00:00",
+  "revisionCount": 0
+}
+

--- a/packages/vault-api/tests/fixtures/audit_finding.json
+++ b/packages/vault-api/tests/fixtures/audit_finding.json
@@ -1,0 +1,8 @@
+{
+  "key": "duplicate-url:entry-0001",
+  "severity": "medium",
+  "kind": "duplicateUrl",
+  "entryId": "entry-0001",
+  "meta": "https://example.test"
+}
+

--- a/packages/vault-api/tests/fixtures/client_capabilities.json
+++ b/packages/vault-api/tests/fixtures/client_capabilities.json
@@ -1,0 +1,9 @@
+{
+  "clientKind": "browserExtension",
+  "capabilities": [
+    "unlock",
+    "readMeta",
+    "copySecret"
+  ]
+}
+

--- a/packages/vault-api/tests/fixtures/contract_versions.json
+++ b/packages/vault-api/tests/fixtures/contract_versions.json
@@ -1,0 +1,6 @@
+{
+  "kdbxFormatVersion": 4,
+  "arcaSemanticsVersion": 1,
+  "clientProtocolVersion": 1
+}
+

--- a/packages/vault-api/tests/fixtures/entry_mutation_clear_nullable.json
+++ b/packages/vault-api/tests/fixtures/entry_mutation_clear_nullable.json
@@ -1,0 +1,7 @@
+{
+  "collection": null,
+  "url": null,
+  "notes": null,
+  "tags": []
+}
+

--- a/packages/vault-api/tests/fixtures/entry_mutation_omitted_nullable.json
+++ b/packages/vault-api/tests/fixtures/entry_mutation_omitted_nullable.json
@@ -1,0 +1,9 @@
+{
+  "title": "GitHub",
+  "username": "arca-admin",
+  "tags": [
+    "work",
+    "ssh"
+  ]
+}
+

--- a/packages/vault-api/tests/fixtures/entry_view.json
+++ b/packages/vault-api/tests/fixtures/entry_view.json
@@ -1,0 +1,16 @@
+{
+  "id": "entry-0001",
+  "title": "GitHub",
+  "username": "arca-admin",
+  "collection": "work",
+  "url": "https://github.com",
+  "notes": "Non-secret fixture notes",
+  "tags": [
+    "work",
+    "ssh"
+  ],
+  "createdAt": "2026-09-01T00:00:00+00:00",
+  "updatedAt": "2026-09-02T00:00:00+00:00",
+  "revisionCount": 2
+}
+

--- a/packages/vault-api/tests/fixtures/generator_params.json
+++ b/packages/vault-api/tests/fixtures/generator_params.json
@@ -1,0 +1,10 @@
+{
+  "length": 24,
+  "uppercase": true,
+  "lowercase": true,
+  "digits": true,
+  "symbols": true,
+  "excludeAmbiguous": false,
+  "mode": "random"
+}
+

--- a/packages/vault-api/tests/fixtures/revision_view.json
+++ b/packages/vault-api/tests/fixtures/revision_view.json
@@ -1,0 +1,15 @@
+{
+  "capturedAt": "2026-09-03T00:00:00+00:00",
+  "updatedAt": "2026-09-02T00:00:00+00:00",
+  "title": "GitHub",
+  "username": "arca-admin",
+  "collection": "work",
+  "url": "https://github.com",
+  "notes": "Previous non-secret fixture notes",
+  "tags": [
+    "work",
+    "ssh"
+  ],
+  "passwordChanged": true
+}
+

--- a/packages/vault-api/tests/fixtures/unsupported_future_versions.json
+++ b/packages/vault-api/tests/fixtures/unsupported_future_versions.json
@@ -1,0 +1,6 @@
+{
+  "kdbxFormatVersion": 4,
+  "arcaSemanticsVersion": 2,
+  "clientProtocolVersion": 1
+}
+

--- a/packages/vault-api/tests/fixtures/vault_summary.json
+++ b/packages/vault-api/tests/fixtures/vault_summary.json
@@ -1,0 +1,7 @@
+{
+  "name": "vault.local",
+  "path": "/tmp/arca/vault.local.kdbx",
+  "entryCount": 3,
+  "modifiedAt": "2026-09-02T00:00:00+00:00"
+}
+


### PR DESCRIPTION
# Description

Adds the first compatibility gate for the public `vault-api` machine contract.

This PR:

- adds golden JSON fixtures for public `vault-api` DTOs
- adds cargo test coverage that fails when fixture serialization drifts
- adds public contract version constants plus a writer guard for future Arca semantics versions
- makes non-secret response DTOs deserialize so clients and fixtures can verify both directions

Closes #225

## Linked Issue Coverage

- **Public DTO fixtures:** covered by `packages/vault-api/tests/fixtures/*` and `packages/vault-api/tests/contract_fixtures.rs`.
- **Contract drift gate:** covered by `cargo test --workspace`, which runs in `.github/workflows/ci.yml`; the fixture tests compare current serialization against checked-in JSON snapshots.
- **Secret exclusion:** `EntryView`, archived `EntryView`, and `RevisionView` fixtures assert that non-secret DTOs do not expose `password` or `secret` fields.
- **Nullable mutation semantics:** fixture tests preserve omitted-vs-null behavior for `EntryMutation`.
- **Unknown future data:** tests cover unknown response fields, unknown enum values, and unsupported future Arca semantics versions for writer paths.
- **Malformed metadata/KDBX compatibility:** existing `vault-core` tests already cover KDBX fixture reads, protected revision storage, malformed revision metadata, and invalid metadata timestamp refusal. This PR intentionally adds the public API fixture layer on top of those tests rather than duplicating KDBX binary fixtures inside `vault-api`.

Secret-bearing request/response types continue to avoid checked-in secret fixture values. Their explicit serialization and debug redaction behavior remains covered with runtime-generated test values.

## Security Checklist

- [x] No secrets, keys, passwords, vault contents, or generated credentials are hardcoded or logged
- [x] No new `unsafe` blocks without justification and human review
- [x] Cryptographic changes reviewed against the threat model - N/A, no cryptographic behavior changes
- [x] OSV/RustSec scan passes with no new vulnerabilities introduced
- [x] Changes touching `packages/vault-core`, Tauri IPC, or secret display/copy flows are marked for human review - N/A, this touches `vault-api` contract only and is still labeled `needs-human-review`

## Testing

- [x] Unit tests added/updated
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `pnpm build` - covered by CI Node Checks; no frontend changes in this PR
- [x] Tested locally on target platform when UI or Tauri behavior changed - N/A, no UI or Tauri behavior changed

## Agent-Assisted Changes

- [ ] AI-generated or AI-edited code was reviewed line by line by a human - pending maintainer review before merge
- [x] `AGENTS.md` files remain accurate after this change

## Validation

Local:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

GitHub checks:

- Rust Checks
- Node Checks
- CodeQL
- Semgrep
- TruffleHog
- OSV
- CodeRabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version information for vault formats and client protocols.
  * Added compatibility checks to reject unsupported future vault semantics.
  * Enabled deserialization for vault summaries, entries, revisions, and password-generator settings.

* **Tests**
  * Added comprehensive contract tests covering serialization, round trips, nullable fields, unknown fields, enum validation, secret-field handling, and version compatibility.
  * Added deterministic fixtures for vault data, mutations, capabilities, errors, generator settings, revisions, and audit findings.
  * Documented fixture safety and maintenance guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

