### PR TITLE
feat: enforce client capability policy

### DIFF
--- a/docs/adr/0003-client-capability-matrix.md
+++ b/docs/adr/0003-client-capability-matrix.md
@@ -76,9 +76,9 @@ Initial capabilities:
 
 ## Compliance
 
-- [ ] Add capability denial tests.
-- [ ] Add tests proving restricted clients cannot call privileged operations.
-- [ ] Document the capability matrix in the public API docs.
+- [x] Add capability denial tests.
+- [x] Add tests proving restricted clients cannot call privileged operations.
+- [x] Document the capability matrix in the public API docs.
 
 ## Revisit / Out Of Scope
 

--- a/packages/vault-api/src/lib.rs
+++ b/packages/vault-api/src/lib.rs
@@ -413,7 +413,9 @@ pub enum ApiOperation {
     ListEntries,
     GetEntry,
     RevealSecret,
+    RevealRevisionSecret,
     CopySecret,
+    GenerateSecret,
     CreateEntry,
     UpdateEntry,
     CreateVault,
@@ -430,7 +432,9 @@ impl ApiOperation {
         match self {
             Self::UnlockVault => Capability::Unlock,
             Self::ReadVaultSummary | Self::ListEntries | Self::GetEntry => Capability::ReadMeta,
-            Self::RevealSecret => Capability::RevealSecret,
+            Self::RevealSecret | Self::RevealRevisionSecret | Self::GenerateSecret => {
+                Capability::RevealSecret
+            }
             Self::CopySecret => Capability::CopySecret,
             Self::CreateEntry | Self::UpdateEntry => Capability::MutateEntry,
             Self::CreateVault => Capability::CreateVault,

--- a/packages/vault-api/src/lib.rs
+++ b/packages/vault-api/src/lib.rs
@@ -1,3 +1,20 @@
+//! Public machine contract for Arca clients.
+//!
+//! Client privileges are enforced through [`ClientKind`] and [`Capability`].
+//! Adapters should call [`ClientKind::require_operation`] before servicing a
+//! public operation, or [`ClientKind::require_capability`] when an adapter has
+//! already resolved the operation to a capability. The initial capability matrix is:
+//!
+//! | Client kind | Capabilities |
+//! | --- | --- |
+//! | `DesktopApp` | all initial capabilities |
+//! | `BrowserExtension` | `Unlock`, `ReadMeta`, `CopySecret` |
+//! | `IosApp` | all initial capabilities except `ExportPlaintext` |
+//! | `AndroidApp` | all initial capabilities except `ExportPlaintext` |
+//! | `IosAutofillExtension` | `Unlock`, `ReadMeta`, `CopySecret` |
+//! | `AndroidAutofillService` | `Unlock`, `ReadMeta`, `CopySecret` |
+//! | `FutureSyncServer` | none; sync is ciphertext-only and outside this plaintext API surface |
+
 use core::fmt;
 
 use serde::de::DeserializeOwned;
@@ -274,7 +291,48 @@ impl fmt::Debug for GeneratedSecret {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+const ALL_CAPABILITIES: &[Capability] = &[
+    Capability::Unlock,
+    Capability::ReadMeta,
+    Capability::RevealSecret,
+    Capability::CopySecret,
+    Capability::MutateEntry,
+    Capability::CreateVault,
+    Capability::ChangeKdf,
+    Capability::ExportPlaintext,
+    Capability::ExportKdbx,
+    Capability::ReadHistory,
+    Capability::DeletePermanent,
+];
+
+const BROWSER_EXTENSION_CAPABILITIES: &[Capability] = &[
+    Capability::Unlock,
+    Capability::ReadMeta,
+    Capability::CopySecret,
+];
+
+const MOBILE_APP_CAPABILITIES: &[Capability] = &[
+    Capability::Unlock,
+    Capability::ReadMeta,
+    Capability::RevealSecret,
+    Capability::CopySecret,
+    Capability::MutateEntry,
+    Capability::CreateVault,
+    Capability::ChangeKdf,
+    Capability::ExportKdbx,
+    Capability::ReadHistory,
+    Capability::DeletePermanent,
+];
+
+const AUTOFILL_CAPABILITIES: &[Capability] = &[
+    Capability::Unlock,
+    Capability::ReadMeta,
+    Capability::CopySecret,
+];
+
+const FUTURE_SYNC_SERVER_CAPABILITIES: &[Capability] = &[];
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum ClientKind {
     DesktopApp,
@@ -286,7 +344,106 @@ pub enum ClientKind {
     FutureSyncServer,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+impl ClientKind {
+    /// Returns the capabilities granted to this client by the public API policy.
+    pub fn capabilities(self) -> &'static [Capability] {
+        match self {
+            Self::DesktopApp => ALL_CAPABILITIES,
+            Self::BrowserExtension => BROWSER_EXTENSION_CAPABILITIES,
+            Self::IosApp | Self::AndroidApp => MOBILE_APP_CAPABILITIES,
+            Self::IosAutofillExtension | Self::AndroidAutofillService => AUTOFILL_CAPABILITIES,
+            Self::FutureSyncServer => FUTURE_SYNC_SERVER_CAPABILITIES,
+        }
+    }
+
+    /// Builds the serializable DTO describing the granted capabilities.
+    pub fn granted_capabilities(self) -> ClientCapabilities {
+        ClientCapabilities {
+            client_kind: self,
+            capabilities: self.capabilities().to_vec(),
+        }
+    }
+
+    /// Returns true when this client is allowed to use a public API capability.
+    pub fn allows(self, capability: Capability) -> bool {
+        self.capabilities().contains(&capability)
+    }
+
+    /// Fails closed when this client attempts to use a capability it lacks.
+    pub fn require_capability(self, capability: Capability) -> Result<(), ApiError> {
+        if self.allows(capability) {
+            return Ok(());
+        }
+
+        Err(ApiError::new(
+            ErrorCode::CapabilityDenied,
+            format!(
+                "{} cannot use the {} capability",
+                self.as_str(),
+                capability.as_str()
+            ),
+        ))
+    }
+
+    /// Fails closed when this client attempts to call a public API operation
+    /// that maps to a capability it lacks.
+    pub fn require_operation(self, operation: ApiOperation) -> Result<(), ApiError> {
+        self.require_capability(operation.required_capability())
+    }
+
+    /// Returns the stable lower-camel-case wire name for this client kind.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::DesktopApp => "desktopApp",
+            Self::BrowserExtension => "browserExtension",
+            Self::IosApp => "iosApp",
+            Self::AndroidApp => "androidApp",
+            Self::IosAutofillExtension => "iosAutofillExtension",
+            Self::AndroidAutofillService => "androidAutofillService",
+            Self::FutureSyncServer => "futureSyncServer",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ApiOperation {
+    UnlockVault,
+    ReadVaultSummary,
+    ListEntries,
+    GetEntry,
+    RevealSecret,
+    CopySecret,
+    CreateEntry,
+    UpdateEntry,
+    CreateVault,
+    ChangeKdf,
+    ExportPlaintext,
+    ExportKdbx,
+    ReadHistory,
+    DeletePermanent,
+}
+
+impl ApiOperation {
+    /// Returns the capability required before servicing this public operation.
+    pub fn required_capability(self) -> Capability {
+        match self {
+            Self::UnlockVault => Capability::Unlock,
+            Self::ReadVaultSummary | Self::ListEntries | Self::GetEntry => Capability::ReadMeta,
+            Self::RevealSecret => Capability::RevealSecret,
+            Self::CopySecret => Capability::CopySecret,
+            Self::CreateEntry | Self::UpdateEntry => Capability::MutateEntry,
+            Self::CreateVault => Capability::CreateVault,
+            Self::ChangeKdf => Capability::ChangeKdf,
+            Self::ExportPlaintext => Capability::ExportPlaintext,
+            Self::ExportKdbx => Capability::ExportKdbx,
+            Self::ReadHistory => Capability::ReadHistory,
+            Self::DeletePermanent => Capability::DeletePermanent,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum Capability {
     Unlock,
@@ -300,6 +457,52 @@ pub enum Capability {
     ExportKdbx,
     ReadHistory,
     DeletePermanent,
+}
+
+impl Capability {
+    /// Returns every capability in the public API policy.
+    pub fn all() -> &'static [Self] {
+        ALL_CAPABILITIES
+    }
+
+    /// Returns true for capabilities that receive or emit plaintext secrets at
+    /// the public API boundary.
+    pub fn carries_plaintext_secret(self) -> bool {
+        matches!(
+            self,
+            Self::Unlock
+                | Self::RevealSecret
+                | Self::CopySecret
+                | Self::MutateEntry
+                | Self::CreateVault
+                | Self::ChangeKdf
+                | Self::ExportPlaintext
+        )
+    }
+
+    /// Returns the stable lower-camel-case wire name for this capability.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unlock => "unlock",
+            Self::ReadMeta => "readMeta",
+            Self::RevealSecret => "revealSecret",
+            Self::CopySecret => "copySecret",
+            Self::MutateEntry => "mutateEntry",
+            Self::CreateVault => "createVault",
+            Self::ChangeKdf => "changeKdf",
+            Self::ExportPlaintext => "exportPlaintext",
+            Self::ExportKdbx => "exportKdbx",
+            Self::ReadHistory => "readHistory",
+            Self::DeletePermanent => "deletePermanent",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientCapabilities {
+    pub client_kind: ClientKind,
+    pub capabilities: Vec<Capability>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/packages/vault-api/tests/contract_fixtures.rs
+++ b/packages/vault-api/tests/contract_fixtures.rs
@@ -2,11 +2,12 @@ use std::fs;
 use std::path::PathBuf;
 
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use vault_api::{
-    ApiError, AuditFinding, AuditFindingKind, AuditSeverity, Capability, ClientKind,
-    ContractVersions, EntryMutation, EntryView, ErrorCode, GeneratedSecret, GeneratorMode,
-    GeneratorParams, RevealedSecret, RevisionView, VaultSummary,
+    ApiError, ApiOperation, AuditFinding, AuditFindingKind, AuditSeverity, Capability,
+    ClientCapabilities, ClientKind, ContractVersions, CreateEntryRequest, EntryMutation, EntryView,
+    ErrorCode, GeneratedSecret, GeneratorMode, GeneratorParams, RevealedSecret, RevisionView,
+    SecretString, VaultSummary,
 };
 
 #[test]
@@ -140,17 +141,212 @@ fn generated_secret_matches_redacted_golden_fixture() {
 
 #[test]
 fn capability_fixture_round_trips() {
-    let fixture = ClientCapabilityFixture {
-        client_kind: ClientKind::BrowserExtension,
-        capabilities: vec![
-            Capability::Unlock,
-            Capability::ReadMeta,
-            Capability::CopySecret,
-        ],
-    };
+    let fixture: ClientCapabilities = ClientKind::BrowserExtension.granted_capabilities();
 
     assert_fixture("client_capabilities.json", &fixture);
     assert_round_trip("client_capabilities.json", fixture);
+}
+
+#[test]
+fn desktop_app_has_the_full_initial_capability_surface() {
+    assert_eq!(ClientKind::DesktopApp.capabilities(), Capability::all());
+
+    for capability in Capability::all() {
+        assert!(ClientKind::DesktopApp.allows(*capability));
+        ClientKind::DesktopApp
+            .require_capability(*capability)
+            .expect("desktop app should receive every initial capability");
+    }
+}
+
+#[test]
+fn restricted_clients_deny_privileged_capabilities() {
+    let restricted_clients = [
+        ClientKind::BrowserExtension,
+        ClientKind::IosAutofillExtension,
+        ClientKind::AndroidAutofillService,
+    ];
+    let denied_capabilities = [
+        Capability::RevealSecret,
+        Capability::MutateEntry,
+        Capability::CreateVault,
+        Capability::ChangeKdf,
+        Capability::ExportPlaintext,
+        Capability::ExportKdbx,
+        Capability::ReadHistory,
+        Capability::DeletePermanent,
+    ];
+
+    for client_kind in restricted_clients {
+        for capability in denied_capabilities {
+            let error = client_kind
+                .require_capability(capability)
+                .expect_err("restricted clients should fail closed");
+
+            assert_eq!(error.code, ErrorCode::CapabilityDenied);
+            assert!(
+                error.message.contains(client_kind.as_str())
+                    && error.message.contains(capability.as_str()),
+                "denial should name the client kind and denied capability"
+            );
+        }
+    }
+}
+
+#[test]
+fn restricted_clients_deny_privileged_operations() {
+    let restricted_clients = [
+        ClientKind::BrowserExtension,
+        ClientKind::IosAutofillExtension,
+        ClientKind::AndroidAutofillService,
+    ];
+    let denied_operations = [
+        ApiOperation::RevealSecret,
+        ApiOperation::CreateEntry,
+        ApiOperation::UpdateEntry,
+        ApiOperation::CreateVault,
+        ApiOperation::ChangeKdf,
+        ApiOperation::ExportPlaintext,
+        ApiOperation::ExportKdbx,
+        ApiOperation::ReadHistory,
+        ApiOperation::DeletePermanent,
+    ];
+
+    for client_kind in restricted_clients {
+        for operation in denied_operations {
+            let error = client_kind
+                .require_operation(operation)
+                .expect_err("restricted clients should fail closed by operation");
+
+            assert_eq!(error.code, ErrorCode::CapabilityDenied);
+            assert!(error
+                .message
+                .contains(operation.required_capability().as_str()));
+        }
+    }
+}
+
+#[test]
+fn secret_bearing_entry_dtos_do_not_bypass_mutation_capability() {
+    let _create_request = CreateEntryRequest {
+        title: "GitHub".to_string(),
+        username: "arca".to_string(),
+        password: SecretString::new(redacted_fixture_secret()),
+        collection: None,
+        url: None,
+        notes: None,
+        tags: Vec::new(),
+    };
+    let _update_request = EntryMutation {
+        password: Some(SecretString::new(redacted_fixture_secret())),
+        ..EntryMutation::default()
+    };
+
+    assert_eq!(
+        ApiOperation::CreateEntry.required_capability(),
+        Capability::MutateEntry
+    );
+    assert_eq!(
+        ApiOperation::UpdateEntry.required_capability(),
+        Capability::MutateEntry
+    );
+
+    for client_kind in [
+        ClientKind::BrowserExtension,
+        ClientKind::IosAutofillExtension,
+        ClientKind::AndroidAutofillService,
+        ClientKind::FutureSyncServer,
+    ] {
+        ClientKind::DesktopApp
+            .require_operation(ApiOperation::CreateEntry)
+            .expect("desktop app should be allowed to create entries");
+        client_kind
+            .require_operation(ApiOperation::CreateEntry)
+            .expect_err("restricted clients should not create entries with shared DTOs");
+        client_kind
+            .require_operation(ApiOperation::UpdateEntry)
+            .expect_err("restricted clients should not update entries with shared DTOs");
+    }
+}
+
+#[test]
+fn browser_and_autofill_surfaces_are_strict_subsets_of_desktop_app() {
+    let desktop_capabilities = ClientKind::DesktopApp.capabilities();
+    let restricted_clients = [
+        ClientKind::BrowserExtension,
+        ClientKind::IosAutofillExtension,
+        ClientKind::AndroidAutofillService,
+    ];
+
+    for client_kind in restricted_clients {
+        let capabilities = client_kind.capabilities();
+
+        assert!(capabilities.len() < desktop_capabilities.len());
+        assert!(
+            capabilities
+                .iter()
+                .all(|capability| desktop_capabilities.contains(capability)),
+            "{client_kind:?} should not receive any capability outside DesktopApp"
+        );
+    }
+}
+
+#[test]
+fn mobile_apps_deny_plaintext_export_but_keep_app_management_surface() {
+    let allowed_capabilities = [
+        Capability::Unlock,
+        Capability::ReadMeta,
+        Capability::RevealSecret,
+        Capability::CopySecret,
+        Capability::MutateEntry,
+        Capability::CreateVault,
+        Capability::ChangeKdf,
+        Capability::ExportKdbx,
+        Capability::ReadHistory,
+        Capability::DeletePermanent,
+    ];
+
+    for client_kind in [ClientKind::IosApp, ClientKind::AndroidApp] {
+        for capability in allowed_capabilities {
+            client_kind
+                .require_capability(capability)
+                .expect("mobile app should keep normal app management capability");
+        }
+
+        let error = client_kind
+            .require_capability(Capability::ExportPlaintext)
+            .expect_err("mobile app should not receive plaintext export by default");
+
+        assert_eq!(error.code, ErrorCode::CapabilityDenied);
+    }
+}
+
+#[test]
+fn future_sync_server_remains_ciphertext_only() {
+    assert!(ClientKind::FutureSyncServer.capabilities().is_empty());
+
+    for capability in Capability::all() {
+        let error = ClientKind::FutureSyncServer
+            .require_capability(*capability)
+            .expect_err("future sync should not receive public plaintext API capabilities");
+
+        assert_eq!(error.code, ErrorCode::CapabilityDenied);
+    }
+}
+
+#[test]
+fn future_sync_server_has_no_plaintext_secret_capabilities() {
+    let plaintext_capabilities: Vec<_> = ClientKind::FutureSyncServer
+        .capabilities()
+        .iter()
+        .copied()
+        .filter(|capability| capability.carries_plaintext_secret())
+        .collect();
+
+    assert!(
+        plaintext_capabilities.is_empty(),
+        "FutureSyncServer must stay ciphertext-only"
+    );
 }
 
 #[test]
@@ -218,13 +414,6 @@ fn newer_arca_semantics_versions_fail_closed_for_writers() {
 
     assert_eq!(error.code, ErrorCode::InvalidInput);
     assert!(error.message.contains("unsupported future Arca semantics"));
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-struct ClientCapabilityFixture {
-    client_kind: ClientKind,
-    capabilities: Vec<Capability>,
 }
 
 fn assert_fixture<T>(name: &str, value: &T)

--- a/packages/vault-api/tests/contract_fixtures.rs
+++ b/packages/vault-api/tests/contract_fixtures.rs
@@ -270,6 +270,32 @@ fn secret_bearing_entry_dtos_do_not_bypass_mutation_capability() {
 }
 
 #[test]
+fn plaintext_secret_response_operations_require_reveal_secret_capability() {
+    let plaintext_response_operations = [
+        ApiOperation::RevealSecret,
+        ApiOperation::RevealRevisionSecret,
+        ApiOperation::GenerateSecret,
+    ];
+
+    for operation in plaintext_response_operations {
+        assert_eq!(operation.required_capability(), Capability::RevealSecret);
+
+        ClientKind::DesktopApp
+            .require_operation(operation)
+            .expect("desktop app should receive plaintext secret responses");
+        ClientKind::BrowserExtension
+            .require_operation(operation)
+            .expect_err("browser extension should not receive plaintext secret responses");
+        ClientKind::IosAutofillExtension
+            .require_operation(operation)
+            .expect_err("autofill extension should not receive plaintext secret responses");
+        ClientKind::FutureSyncServer
+            .require_operation(operation)
+            .expect_err("sync server should never receive plaintext secret responses");
+    }
+}
+
+#[test]
 fn browser_and_autofill_surfaces_are_strict_subsets_of_desktop_app() {
     let desktop_capabilities = ClientKind::DesktopApp.capabilities();
     let restricted_clients = [


### PR DESCRIPTION
# Description

Closes #226.

## Summary

- Encode the initial client capability matrix in vault-api with ClientKind policy helpers.
- Add ApiOperation-to-Capability enforcement so adapters can deny by operation before using shared DTOs.
- Document the public API capability matrix and mark ADR-0003 compliance complete.

## Security Checklist

- [x] No secrets, keys, passwords, vault contents, or generated credentials are hardcoded or logged
- [x] No new `unsafe` blocks without justification and human review
- [x] No cryptographic algorithms, KDF parameters, vault formats, or key-management behavior changed
- [x] OSV/RustSec scan passes with no new vulnerabilities introduced
- [x] Changes are marked for human review with `security`, `needs-human-review`, and `agent-assisted` labels

## Testing

- [x] Unit tests added/updated
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p vault-api --no-deps`
- [x] `pnpm --filter @arca/desktop contract:check`
- [x] `pnpm lint`
- [ ] `pnpm build` not run; no frontend implementation changed, and `pnpm lint` plus contract drift checks passed
- [x] Local UI/Tauri target testing not applicable; no UI or Tauri behavior changed

## Agent-Assisted Changes

- [ ] AI-generated or AI-edited code was reviewed line by line by a human
- [x] `AGENTS.md` files remain accurate after this change