### PR TITLE
docs: define local-first access constraints

### DIFF
--- a/docs/adr/0009-local-first-access-constraints.md
+++ b/docs/adr/0009-local-first-access-constraints.md
@@ -1,0 +1,143 @@
+---
+status: proposed
+date: 2026-09-07
+decision-makers: ["akei9"]
+related: ["#88", "#138", "#210", "#211", "#216"]
+---
+
+# ADR-0009: Local-first access constraints before sync or new clients
+
+## Status History
+
+- 2026-09-07 - proposed by Codex for maintainer review.
+
+## Context
+
+Browser extension and mobile clients need access to vault data without turning
+Arca into an account-backed or network-first system. The first cross-client
+contract should preserve local vault ownership, keep `vault-core` offline, and
+avoid designing sync before the local boundaries are stable.
+
+This ADR defines access constraints for early browser and mobile work. It does
+not approve a sync service, sharing protocol, account system, or remote storage
+provider integration.
+
+## Decision Drivers
+
+- Preserve local-first vault ownership.
+- Keep KDFs, KDBX parsing, and decrypted vault material inside Rust boundaries.
+- Keep `vault-core` free of network access.
+- Make browser and autofill clients depend on narrow, explicit bridges.
+- Let mobile apps use OS-native file and credential surfaces without adding an
+  Arca account model.
+- Leave sync metadata and conflict resolution for a later ADR.
+
+## Considered Options
+
+- Desktop-bridge or native-host-backed access for browser extension clients.
+- File-based local access for full mobile apps.
+- Cloud-file-provider-backed local files on mobile.
+- Direct browser extension vault-file access.
+- Account-backed sync as the first multi-client access model.
+- Network sync embedded in `vault-core`.
+
+## Proposed Decision
+
+Arca remains local-first for the first extension and mobile clients.
+
+`vault-core` must not perform network I/O. It owns local KDBX parsing,
+cryptography, password generation, audit primitives, and vault mutation. Any
+future network sync or sharing component requires a separate ADR, a threat model,
+and human review before implementation.
+
+The desktop app continues to access local vault files directly through the Tauri
+shell and Rust vault/session boundary.
+
+The first browser extension should access vault data through native messaging to
+the desktop app or a small native host. The extension must not parse KDBX, run
+the full unlock path in a content script or service worker, directly read vault
+files, persist unlocked vault material, or rely on cloud storage APIs as its
+primary access path. Browser access is a bridge to an already installed local
+component, not a standalone vault engine.
+
+The first full mobile apps may use local file access through OS document
+pickers, app-scoped storage, secure storage for platform-bound auxiliary
+material, and cloud file providers only as local file providers exposed by the
+operating system. The mobile app must still route vault semantics through
+`vault-api` and `vault-core`; cloud provider SDKs, account-backed remote APIs,
+and Arca-hosted sync are out of scope.
+
+Mobile autofill extensions are separate restricted clients. They should request
+only the smallest working set needed for an explicit autofill interaction and
+must not retain decrypted vault contents beyond the platform extension
+lifecycle.
+
+All early clients are offline-first. A client must remain useful with a local
+vault file and no network. If a vault file changes externally while a client has
+it open, the first implementation may fail closed, prompt the user to close and
+reopen, or use a tested single-writer handoff. Automatic merge, multi-device
+conflict resolution, per-record sync clocks, and remote tombstones are out of
+scope until a sync ADR exists.
+
+Native messaging and device handoff boundaries must identify the calling client
+kind, enforce `vault-api` capabilities, avoid logging plaintext secrets, and
+treat message payloads as untrusted input. Pairing protocols, long-lived device
+trust, push notifications, and background remote unlock are out of scope for the
+first extension and mobile MVPs.
+
+Sync metadata must not be added to persisted vault semantics unless a later ADR
+defines it. `FutureSyncServer` remains ciphertext-only and must not receive
+plaintext secret capabilities.
+
+## Consequences
+
+### Positive
+
+- Keeps future clients aligned with Arca's local-first promise.
+- Prevents sync assumptions from leaking into the first public API and client
+  bootstraps.
+- Gives extension and mobile work concrete access boundaries before
+  implementation begins.
+- Keeps network dependencies out of `vault-core`.
+
+### Negative
+
+- Browser extension usefulness depends on a native host or desktop app being
+  installed.
+- Mobile cross-device use relies on user-managed files or OS file providers
+  until sync is designed.
+- Conflict handling remains intentionally limited for the first client phase.
+
+### Neutral
+
+- A future sync service may still be designed later, but it starts from a
+  ciphertext-only and threat-modeled boundary.
+
+## Compliance
+
+- [ ] Verify `vault-core` remains free of network dependencies and network I/O.
+- [ ] Add a native messaging protocol contract before browser extension
+  implementation.
+- [ ] Add extension tests that identify the client kind and enforce restricted
+  capabilities at the bridge.
+- [ ] Add mobile bootstrap notes for OS file access, secure storage, and
+  autofill lifecycle boundaries.
+- [ ] Require a separate sync ADR before adding sync metadata, remote conflict
+  resolution, account-backed access, device pairing, or Arca-hosted services.
+
+## Revisit / Out Of Scope
+
+- Account management.
+- Shared vaults and secure sharing.
+- Remote sync transport and conflict resolution.
+- Device pairing or long-lived device trust.
+- Browser extension direct KDBX parsing or standalone unlock.
+- Cloud provider SDK integrations.
+
+## References
+
+- #88
+- #138
+- #210
+- #211
+- #216

--- a/docs/adr/0009-local-first-access-constraints.md
+++ b/docs/adr/0009-local-first-access-constraints.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-09-07
 decision-makers: ["akei9"]
 related: ["#88", "#138", "#210", "#211", "#216"]
@@ -10,6 +10,7 @@ related: ["#88", "#138", "#210", "#211", "#216"]
 ## Status History
 
 - 2026-09-07 - proposed by Codex for maintainer review.
+- 2026-09-07 - accepted by maintainer approval.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,4 @@ new ADR instead of editing the accepted record in place.
 | [0006](0006-repo-layout.md) | accepted | Repository layout |
 | [0007](0007-extension-boundary.md) | accepted | Browser extension boundary |
 | [0008](0008-mobile-uniffi-native-ui.md) | accepted | Mobile UniFFI and native UI |
+| [0009](0009-local-first-access-constraints.md) | proposed | Local-first access constraints before sync or new clients |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,4 +19,4 @@ new ADR instead of editing the accepted record in place.
 | [0006](0006-repo-layout.md) | accepted | Repository layout |
 | [0007](0007-extension-boundary.md) | accepted | Browser extension boundary |
 | [0008](0008-mobile-uniffi-native-ui.md) | accepted | Mobile UniFFI and native UI |
-| [0009](0009-local-first-access-constraints.md) | proposed | Local-first access constraints before sync or new clients |
+| [0009](0009-local-first-access-constraints.md) | accepted | Local-first access constraints before sync or new clients |


### PR DESCRIPTION
# Description

Closes #210.

Adds ADR-0009 as a proposed local-first access constraints decision record for browser extension and mobile client work before sync or new clients are implemented.

## Summary

- State that `vault-core` must remain free of network I/O and network-backed sync behavior.
- Define desktop, browser extension, mobile app, and mobile autofill access boundaries.
- Keep browser access native-messaging/native-host-backed for the first extension path.
- Keep mobile access local-file and OS-file-provider based, without cloud provider SDKs or Arca-hosted sync.
- Define offline-first expectations, limited conflict assumptions, native messaging trust boundaries, and explicit sync/account out-of-scope items.
- Add ADR-0009 to the ADR index.

## Security Checklist

- [x] No secrets, keys, passwords, vault contents, or generated credentials are hardcoded or logged
- [x] No new `unsafe` blocks without justification and human review
- [x] No cryptographic changes reviewed against the threat model; this is a docs-only ADR proposal
- [x] OSV/RustSec scan passes with no new vulnerabilities introduced; no dependencies changed
- [x] Changes are marked for human review with `security`, `needs-human-review`, and `agent-assisted` labels

## Testing

- [x] `git diff --check`
- [x] `cargo fmt --all --check`
- [x] `pnpm lint`
- [ ] Unit tests added/updated; not applicable for docs-only ADR
- [ ] `cargo test --workspace`; not run because no Rust code changed
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`; not run because no Rust code changed
- [ ] `pnpm build`; not run because no frontend implementation changed
- [x] Tested locally on target platform when UI or Tauri behavior changed; not applicable for docs-only ADR

## Agent-Assisted Changes

- [ ] AI-generated or AI-edited code was reviewed line by line by a human
- [x] `AGENTS.md` files remain accurate after this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record defining local-first access constraints for browser, mobile, and autofill clients.
  * Documented offline-first behavior and boundaries for native messaging, local files, and secure storage.
  * Clarified that sync, accounts, remote storage, pairing, and related metadata require separate review.
  * Added the new decision record to the architecture documentation index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->