### PR TITLE
fix: update yanked chacha20 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,9 +426,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/packages/vault-core/fuzz/Cargo.lock
+++ b/packages/vault-core/fuzz/Cargo.lock
@@ -139,9 +139,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher",


### PR DESCRIPTION
# Description

Closes #218.

Updates the locked `chacha20` crate away from yanked versions:

- root workspace lockfile: `chacha20 0.10.0` -> `0.10.2`
- vault-core fuzz lockfile: `chacha20 0.10.1` -> `0.10.2`

No `Cargo.toml` dependency ranges changed; Cargo resolved the compatible patch update through the existing transitive requirements from `keepass` and `rand`.

## Security Checklist

- [x] No secrets, keys, passwords, vault contents, or generated credentials are hardcoded or logged
- [x] No new `unsafe` blocks without justification and human review
- [x] Cryptographic behavior was not changed intentionally; this is a patch-level transitive crate update to replace yanked lockfile entries
- [x] OSV/RustSec scan passes with no new vulnerabilities introduced
- [x] Changes are marked for human review with `security`, `needs-human-review`, and `agent-assisted` labels

## Testing

- [x] `cargo tree -i chacha20`
- [x] `cargo tree --manifest-path packages/vault-core/fuzz/Cargo.toml -i chacha20`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test --manifest-path packages/vault-core/fuzz/Cargo.toml --no-run`
- [x] `cargo deny check`
- [ ] `pnpm build`; not run because no frontend code changed
- [x] Tested locally on target platform when UI or Tauri behavior changed; not applicable for lockfile-only update

## Agent-Assisted Changes

- [ ] AI-generated or AI-edited code was reviewed line by line by a human
- [x] `AGENTS.md` files remain accurate after this change