### PR TITLE
docs: plan extension and mobile bootstraps

### DIFF
--- a/docs/adr/0011-browser-extension-repo-bootstrap.md
+++ b/docs/adr/0011-browser-extension-repo-bootstrap.md
@@ -1,0 +1,220 @@
+---
+status: proposed
+date: 2026-09-08
+decision-makers: ["akei9"]
+related: ["#138", "#207", "#208", "#209", "#210", "#211", "#213"]
+---
+
+# ADR-0011: Browser extension repository bootstrap
+
+## Status History
+
+- 2026-09-08 - proposed by Codex for maintainer review.
+
+## Context
+
+ADR-0007 accepts the first browser extension boundary: the extension is a thin
+UI and autofill client, while unlock, KDF work, KDBX parsing, vault persistence,
+and long-lived unlocked material stay outside the browser. ADR-0009 keeps the
+first extension local-first through native messaging to the desktop app or a
+small native host. ADR-0010 defers creating `arca-extension` until browser
+extension implementation starts.
+
+This ADR turns that accepted boundary into the implementation and repository
+bootstrap plan needed before generating TypeScript bindings or creating the
+extension repository.
+
+## Decision Drivers
+
+- Preserve the Arca client constitution and `vault-api` capability policy.
+- Avoid KDBX, KDF, vault persistence, and unlocked vault sessions in browser
+  extension contexts.
+- Support useful autofill without broad browser permissions or hidden secret
+  movement.
+- Make the native messaging surface explicit before implementation.
+- Keep browser-specific release, signing, and store workflows outside
+  `akei9/arca` once implementation starts.
+
+## Considered Options
+
+- Bootstrap `arca-extension` immediately with planning docs only.
+- Keep extension implementation in `akei9/arca`.
+- Bootstrap `arca-extension` when implementation starts, after this ADR and the
+  native messaging contract are reviewed.
+- Use a standalone WASM vault engine in the extension.
+- Use native messaging to the desktop app or a small native host.
+
+## Proposed Decision
+
+Keep all #211 planning work in `akei9/arca`. Create `arca-extension` only when
+implementation starts and the bootstrap checklist in this ADR is satisfied.
+
+The first implementation target is Chromium-family browsers using a
+Manifest-V3-compatible architecture and native messaging. Chrome is the first
+store/package target. Microsoft Edge may reuse the Chromium package after Chrome
+support is stable and store metadata is ready.
+
+Firefox is an MVP compatibility target, but not the first implementation target.
+Before claiming Firefox support, the native messaging host registration,
+permissions, background lifecycle behavior, and automated compatibility checks
+must pass against Firefox. Safari is out of scope for the first extension MVP
+because its packaging and native app extension model need a separate spike.
+
+The extension is a `BrowserExtension` client in the `vault-api` capability
+matrix. It may request only `Unlock`, `ReadMeta`, and `CopySecret` operations
+through the bridge. It must not receive `RevealSecret`, `MutateEntry`,
+`CreateVault`, `ChangeKdf`, `ExportPlaintext`, `ExportKdbx`, `ReadHistory`, or
+`DeletePermanent` unless a later ADR expands the capability matrix with tests.
+
+Unlock stays native-owned. The extension may ask the native side to start or
+focus an unlock flow, but it must not collect or transmit the master password.
+The native side owns KDF execution, vault file access, session lifetime, and any
+OS clipboard integration used for copy operations.
+
+## Native Messaging Protocol Surface
+
+Define the first native messaging contract in `akei9/arca` before
+implementation. The source of truth is Rust `vault-api`; generated TypeScript
+bindings in `arca-extension` consume the contract and must be checked for drift.
+
+The first protocol version should expose only these message families:
+
+- `hello`: negotiate client protocol version, extension build metadata, native
+  host version, and granted `ClientKind::BrowserExtension` capabilities.
+- `status`: report whether a vault is available, locked, or unlocked without
+  returning plaintext secrets or a full vault snapshot.
+- `requestUnlock`: ask the native side to show or focus its unlock UI. The
+  response is status-only.
+- `searchEntries`: return redacted entry metadata needed to choose a fill
+  candidate.
+- `getEntryMeta`: return redacted metadata for one entry, excluding password
+  and revision passwords.
+- `copySecret`: copy one selected secret through the native side after explicit
+  user action and capability enforcement. Prefer host-owned clipboard writes.
+- `fillSecret`: request a one-time fill payload for one selected entry and
+  origin after explicit user approval. This maps to `CopySecret`, not
+  `RevealSecret`, and the extension must drop the payload immediately after the
+  content script fills the selected fields.
+- `fillApproved`: record that the user approved filling one selected origin and
+  entry, without widening the extension's capability set or returning a secret.
+- `lock`: ask the native side to lock the session.
+- `error`: return typed `vault-api` errors, including capability denial.
+
+Every request must identify the protocol version, client kind, browser
+extension instance, active tab URL or origin when relevant, and a correlation ID
+that is safe to log. The bridge must treat all browser-provided fields as
+untrusted input and must never log plaintext secrets.
+
+The bridge must fail closed on unknown protocol versions, unknown message
+types, missing client kind, capability mismatch, malformed URLs, or host/extension
+origin mismatch.
+
+## Extension Surface
+
+The extension repository should start with these user-visible surfaces only:
+
+- browser action popup for connection, locked/unlocked state, search, and copy
+  or fill actions;
+- content script that detects login fields and requests user approval before
+  filling;
+- background service worker that brokers messages between popup, content
+  scripts, and the native messaging port;
+- options page for host connection diagnostics and permissions explanation.
+
+The extension must not keep decrypted vault snapshots in `chrome.storage`,
+`browser.storage`, IndexedDB, localStorage, sessionStorage, or cache storage. It
+may cache non-secret metadata for a bounded session only when invalidated on
+lock, host disconnect, tab origin change, or protocol version change.
+
+Autofill requires explicit user action for the MVP. Fill payloads are scoped to
+one selected origin and entry, are not cached, and must not be reused for later
+page events. Silent page-driven fill, automatic submit, broad credential
+scraping, and injected password generation are out of scope.
+
+## WASM Boundary
+
+WASM is not the primary unlock path and must not parse KDBX, run KDFs, persist
+vaults, hold the unlocked vault session, or implement independent vault
+semantics in the extension.
+
+A later ADR may allow WASM for constrained already-unlocked working-set helpers
+such as local filtering of redacted metadata, URL matching, or non-secret
+validation. Any WASM helper must consume `vault-api` DTOs, avoid plaintext
+secrets unless a capability-specific ADR allows it, and pass the same fixture
+drift checks as native bindings.
+
+## Repository Bootstrap Checklist
+
+Create `arca-extension` when implementation starts and all of the following are
+true:
+
+- [ ] ADR-0007, ADR-0009, ADR-0010, and this ADR are accepted.
+- [ ] `vault-api` exposes the browser extension operations or adapter contract
+  needed by the MVP.
+- [ ] Native messaging message schemas or generated bindings are committed in
+  `akei9/arca` with fixture drift tests.
+- [ ] Capability denial tests prove `BrowserExtension` cannot reveal, mutate,
+  export, read history, change KDF settings, or delete permanently.
+- [ ] Permission rationale is documented for `nativeMessaging`, active tab or
+  host permissions, content scripts, storage, and clipboard behavior.
+- [ ] Chrome package and store submission flow are documented.
+- [ ] Firefox compatibility requirements are documented before support is
+  advertised.
+- [ ] CI covers TypeScript linting, tests, build, dependency scanning, secret
+  scanning, browser compatibility checks, and generated contract drift.
+- [ ] Security issue routing points shared contract, vault, native messaging,
+  and secret-lifetime issues back to `akei9/arca`.
+
+## Consequences
+
+### Positive
+
+- Keeps browser code out of the vault engine and KDF path.
+- Gives extension implementation a narrow, testable protocol surface.
+- Lets browser packaging and store review move independently once
+  implementation begins.
+- Aligns extension MVP work with the already enforced capability matrix.
+
+### Negative
+
+- Extension usefulness depends on installing or running the desktop app or
+  native host.
+- Chrome ships before complete browser coverage.
+- Native messaging adds OS-specific install and diagnostics work.
+
+### Neutral
+
+- Edge and Firefox support can follow without changing Arca's vault contract if
+  their platform behavior satisfies the same bridge requirements.
+
+## Compliance
+
+- [ ] Add the native messaging protocol contract in `akei9/arca`.
+- [ ] Add browser extension generated binding drift tests.
+- [ ] Add bridge-level capability denial tests for `BrowserExtension`.
+- [ ] Add permission and store-review documentation to `arca-extension` before
+  first release.
+- [ ] Create `arca-extension` only when implementation starts.
+
+## Revisit / Out Of Scope
+
+- Creating `arca-extension` in this PR.
+- Safari extension support.
+- Browser-side standalone unlock.
+- Direct browser vault-file access.
+- Sync, pairing, remote unlock, accounts, or shared vaults.
+- Silent autofill or submit automation.
+
+## References
+
+- #138
+- #207
+- #208
+- #209
+- #210
+- #211
+- #213
+- Chrome Extensions native messaging documentation:
+  https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
+- MDN WebExtensions native messaging documentation:
+  https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging

--- a/docs/adr/0011-browser-extension-repo-bootstrap.md
+++ b/docs/adr/0011-browser-extension-repo-bootstrap.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-09-08
 decision-makers: ["akei9"]
 related: ["#138", "#207", "#208", "#209", "#210", "#211", "#213"]
@@ -10,6 +10,7 @@ related: ["#138", "#207", "#208", "#209", "#210", "#211", "#213"]
 ## Status History
 
 - 2026-09-08 - proposed by Codex for maintainer review.
+- 2026-09-08 - accepted by maintainer approval.
 
 ## Context
 

--- a/docs/adr/0012-mobile-uniffi-repo-bootstrap.md
+++ b/docs/adr/0012-mobile-uniffi-repo-bootstrap.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-09-08
 decision-makers: ["akei9"]
 related: ["#138", "#207", "#208", "#209", "#210", "#214", "#215", "#216"]
@@ -10,6 +10,7 @@ related: ["#138", "#207", "#208", "#209", "#210", "#214", "#215", "#216"]
 ## Status History
 
 - 2026-09-08 - proposed by Codex for maintainer review.
+- 2026-09-08 - accepted by maintainer approval.
 
 ## Context
 

--- a/docs/adr/0012-mobile-uniffi-repo-bootstrap.md
+++ b/docs/adr/0012-mobile-uniffi-repo-bootstrap.md
@@ -1,0 +1,212 @@
+---
+status: proposed
+date: 2026-09-08
+decision-makers: ["akei9"]
+related: ["#138", "#207", "#208", "#209", "#210", "#214", "#215", "#216"]
+---
+
+# ADR-0012: Mobile UniFFI repository bootstrap
+
+## Status History
+
+- 2026-09-08 - proposed by Codex for maintainer review.
+
+## Context
+
+ADR-0008 accepts `vault-api` plus UniFFI, native iOS SwiftUI first, and Android
+Jetpack Compose after that. ADR-0009 keeps the first mobile clients local-first
+through OS file surfaces, app-scoped storage, secure storage, and restricted
+autofill extensions. ADR-0010 defers creating `arca-mobile` until mobile
+implementation starts, unless a later accepted ADR chooses separate native
+repositories.
+
+This ADR turns that accepted direction into the mobile implementation and
+repository bootstrap plan needed before creating `arca-mobile`.
+
+## Decision Drivers
+
+- Reuse Rust vault semantics without rewriting crypto, KDBX parsing, password
+  generation, audit rules, or secret lifetime behavior.
+- Keep full mobile apps more capable than autofill extensions, but still
+  narrower than desktop for plaintext export.
+- Fit platform-native secure storage, biometrics, app backgrounding,
+  screenshots, clipboard, and autofill lifecycles.
+- Confirm whether one `arca-mobile` repository is sufficient before bootstrap.
+- Make mobile binding and fixture compatibility testable from the first commit.
+
+## Considered Options
+
+- Bootstrap one `arca-mobile` repository for iOS and Android.
+- Split immediately into `arca-ios` and `arca-android`.
+- Keep mobile implementation in `akei9/arca`.
+- Use React Native, Flutter, or Tauri mobile as the primary UI layer.
+- Use native SwiftUI and Jetpack Compose with Rust `vault-api` bindings.
+
+## Proposed Decision
+
+Keep all #216 planning work in `akei9/arca`. Create one `arca-mobile`
+repository when mobile implementation starts. That repository should contain the
+native iOS app, native Android app, mobile binding integration, mobile-specific
+fixtures, platform CI, app-store documentation, and mobile release workflow.
+
+Do not split into `arca-ios` and `arca-android` for the first mobile MVP. A
+separate native-repo split requires a later accepted ADR showing that one
+`arca-mobile` repository blocks release, security review, ownership, CI, or
+store operations.
+
+The implementation order is:
+
+1. UniFFI feasibility spike against `vault-api`.
+2. iOS SwiftUI app with local vault open, unlock, search, view, copy, edit, and
+   KDBX export support, but no plaintext export.
+3. iOS autofill extension as a restricted `IosAutofillExtension` client.
+4. Android Jetpack Compose app with equivalent full-app behavior.
+5. Android Autofill Service as a restricted `AndroidAutofillService` client.
+
+React Native, Flutter, or Tauri mobile remain out of scope for the primary
+strategy unless a later ADR explains the security, memory, binding, autofill,
+and store-review tradeoffs.
+
+## Binding Architecture
+
+`vault-api` remains the public machine contract. Mobile bindings should expose a
+small FFI facade around `vault-api` operations and DTOs rather than exposing
+`vault-core` internals directly.
+
+The UniFFI layer should:
+
+- identify every call as `IosApp`, `AndroidApp`, `IosAutofillExtension`, or
+  `AndroidAutofillService`;
+- enforce `ClientKind` and `Capability` before dispatching operations;
+- preserve typed errors and contract versions across Swift and Kotlin;
+- keep secret-bearing methods explicit and easy to audit;
+- avoid implementing mobile-only vault semantics outside Rust;
+- regenerate bindings from checked-in source definitions or generated artifacts
+  whose drift is verified by CI.
+
+The full iOS and Android apps use the mobile app capability set: all initial
+capabilities except `ExportPlaintext`. Mobile autofill extensions use only
+`Unlock`, `ReadMeta`, and `CopySecret`.
+
+## Platform Boundaries
+
+Mobile apps may use OS document pickers, security-scoped or app-scoped local
+file access, and cloud file providers only as OS-presented local files. Direct
+cloud-provider SDKs, account-backed Arca services, remote sync, pairing, push
+unlock, and conflict resolution are out of scope for the first MVP.
+
+Secure storage is for platform-bound auxiliary material such as recent local
+vault handles, user preferences, biometric policy state, and non-secret
+metadata. It must not become a replacement vault store and must not persist the
+master password or unlocked vault contents.
+
+Biometric unlock can be used only as a platform gate around locally protected
+auxiliary material or session re-entry. The master password flow, key material
+lifetime, fallback behavior, and biometric reset behavior need tests before any
+biometric unlock feature ships.
+
+The app must protect plaintext during mobile lifecycle transitions. On
+backgrounding, screen recording, screenshot surfaces, app switcher previews,
+lock events, and OS memory pressure, the UI should obscure secret views and drop
+short-lived plaintext where platform APIs allow it.
+
+Clipboard writes must be explicit, bounded, and clearable where the platform
+allows. Clipboard behavior belongs to the mobile security model and must be
+covered by tests or manual release checks before release.
+
+## Autofill Constraints
+
+Mobile autofill extensions are separate restricted clients. They must request
+only the smallest candidate set needed for an explicit autofill interaction and
+must not retain decrypted vault contents beyond the platform extension
+lifecycle.
+
+Autofill extensions should prefer host-app-mediated unlock or a tested
+platform-approved extension unlock path. They must not add independent KDBX
+parsing, KDF execution, vault persistence, plaintext export, entry mutation, or
+history access.
+
+The mobile app may maintain user preferences that influence autofill behavior,
+but the extension must still pass `vault-api` capability checks as its own
+client kind.
+
+## Repository Bootstrap Checklist
+
+Create `arca-mobile` when implementation starts and all of the following are
+true:
+
+- [ ] ADR-0008, ADR-0009, ADR-0010, and this ADR are accepted.
+- [ ] A UniFFI feasibility spike proves Swift and Kotlin can call the selected
+  `vault-api` facade and receive typed DTOs/errors.
+- [ ] Binding generation and fixture drift checks are defined in `akei9/arca`.
+- [ ] Capability denial tests prove mobile apps deny plaintext export and
+  autofill clients deny reveal, mutate, export, history, KDF, create-vault, and
+  permanent-delete operations.
+- [ ] iOS local file access, secure storage, biometric, clipboard,
+  screenshot/backgrounding, and autofill requirements are documented.
+- [ ] Android local file access, secure storage, biometric, clipboard,
+  screenshot/backgrounding, and autofill requirements are documented.
+- [ ] The first repository layout is documented, including ownership of shared
+  mobile bindings, `ios/`, `android/`, test fixtures, and release notes.
+- [ ] CI covers iOS build/test, Android build/test, Rust binding tests,
+  dependency scanning, secret scanning, and contract fixture drift.
+- [ ] Security issue routing points shared contract, vault, binding,
+  secret-lifetime, and capability issues back to `akei9/arca`.
+
+## Consequences
+
+### Positive
+
+- Keeps mobile vault behavior aligned with the canonical Rust contract.
+- Avoids committing to a repo split before there is implementation pressure.
+- Gives iOS and Android a shared mobile release and security-review home.
+- Treats autofill extensions as restricted clients from the beginning.
+
+### Negative
+
+- Native UI work cannot reuse the desktop Svelte implementation directly.
+- Android follows iOS unless the roadmap changes.
+- UniFFI setup and mobile CI must be solved before feature work accelerates.
+
+### Neutral
+
+- A later ADR may still split iOS and Android repositories if one mobile repo
+  becomes operationally harmful.
+
+## Compliance
+
+- [ ] Complete the UniFFI feasibility spike before creating `arca-mobile`.
+- [ ] Add mobile generated binding drift tests.
+- [ ] Add capability denial tests for iOS, Android, and autofill clients.
+- [ ] Add secure storage, biometric, clipboard, screenshot/backgrounding, and
+  autofill lifecycle requirements to the mobile MVP checklist.
+- [ ] Create `arca-mobile` only when implementation starts.
+
+## Revisit / Out Of Scope
+
+- Creating `arca-mobile` in this PR.
+- Splitting into `arca-ios` and `arca-android`.
+- React Native, Flutter, or Tauri mobile as the primary strategy.
+- Sync, accounts, pairing, push unlock, or shared vaults.
+- Plaintext export from mobile apps.
+
+## References
+
+- #138
+- #207
+- #208
+- #209
+- #210
+- #214
+- #215
+- #216
+- UniFFI user guide:
+  https://mozilla.github.io/uniffi-rs/latest/
+- Apple AuthenticationServices credential provider extension documentation:
+  https://developer.apple.com/documentation/authenticationservices/ascredentialproviderextension
+- Apple LocalAuthentication documentation:
+  https://developer.apple.com/documentation/localauthentication
+- Android Autofill framework documentation:
+  https://developer.android.com/identity/autofill
+- Android biometric authentication documentation:
+  https://developer.android.com/identity/sign-in/biometric-auth

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,5 +21,5 @@ new ADR instead of editing the accepted record in place.
 | [0008](0008-mobile-uniffi-native-ui.md) | accepted | Mobile UniFFI and native UI |
 | [0009](0009-local-first-access-constraints.md) | accepted | Local-first access constraints before sync or new clients |
 | [0010](0010-client-repository-governance.md) | accepted | Client repository governance |
-| [0011](0011-browser-extension-repo-bootstrap.md) | proposed | Browser extension repository bootstrap |
-| [0012](0012-mobile-uniffi-repo-bootstrap.md) | proposed | Mobile UniFFI repository bootstrap |
+| [0011](0011-browser-extension-repo-bootstrap.md) | accepted | Browser extension repository bootstrap |
+| [0012](0012-mobile-uniffi-repo-bootstrap.md) | accepted | Mobile UniFFI repository bootstrap |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,3 +21,5 @@ new ADR instead of editing the accepted record in place.
 | [0008](0008-mobile-uniffi-native-ui.md) | accepted | Mobile UniFFI and native UI |
 | [0009](0009-local-first-access-constraints.md) | accepted | Local-first access constraints before sync or new clients |
 | [0010](0010-client-repository-governance.md) | accepted | Client repository governance |
+| [0011](0011-browser-extension-repo-bootstrap.md) | proposed | Browser extension repository bootstrap |
+| [0012](0012-mobile-uniffi-repo-bootstrap.md) | proposed | Mobile UniFFI repository bootstrap |


### PR DESCRIPTION
## Summary

- Add ADR-0011 for the browser extension boundary, native messaging protocol surface, target browser sequence, WASM limits, and `arca-extension` bootstrap checklist.
- Add ADR-0012 for the mobile UniFFI architecture, native iOS/Android rollout order, platform security boundaries, autofill constraints, and `arca-mobile` bootstrap checklist.
- Update the ADR index with both proposed ADRs.

Closes #211.
Closes #216.

## Testing

- `git diff --check`
- `git diff --cached --check`
- `cargo fmt --all --check`
- `pnpm lint`

## Notes

This PR keeps planning in `akei9/arca`. It does not create `arca-extension` or `arca-mobile`; those repositories remain gated on accepted ADRs and implementation start.
