### PR TITLE
docs: define semantic branch naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,7 @@ All cryptography, vault parsing, password generation, and secret-handling logic 
 - Use semantic branch prefixes that match the work: `feat/`, `bug/`, `docs/`,
   `chore/`, `test/`, `security/`, or `refactor/`, followed by a short
   kebab-case description.
-- Reserve `codex/` for exceptional agent-only work when a semantic prefix is
-  not appropriate; it is not the default branch prefix.
+- Never use the `codex/` prefix; every branch must use a semantic prefix.
 - Mark AI-assisted PRs with the `agent-assisted` label when available.
 - Any change touching crypto, auth, vault persistence, IPC secret transport, or secret display/copy behavior needs human review before merge.
 - Keep `AGENTS.md` files updated when project commands, constraints, or recurring agent mistakes change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,11 @@ All cryptography, vault parsing, password generation, and secret-handling logic 
 ## Pull Requests
 
 - Use Conventional Commits such as `feat:`, `fix:`, `security:`, `test:`, and `chore:`.
+- Use semantic branch prefixes that match the work: `feat/`, `bug/`, `docs/`,
+  `chore/`, `test/`, `security/`, or `refactor/`, followed by a short
+  kebab-case description.
+- Reserve `codex/` for exceptional agent-only work when a semantic prefix is
+  not appropriate; it is not the default branch prefix.
 - Mark AI-assisted PRs with the `agent-assisted` label when available.
 - Any change touching crypto, auth, vault persistence, IPC secret transport, or secret display/copy behavior needs human review before merge.
 - Keep `AGENTS.md` files updated when project commands, constraints, or recurring agent mistakes change.


### PR DESCRIPTION
## Summary

- establish semantic branch prefixes for repository work
- use `feat/`, `bug/`, `docs/`, `chore/`, `test/`, `security/`, and `refactor/` as appropriate
- reserve `codex/` for exceptional agent-only branches rather than using it by default

This keeps branch names aligned with the change type and applies the same convention used by the mobile repository.